### PR TITLE
feat(ssh): add ProxyJump (jump-host) support — Phase 1 of #14

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -11,7 +11,7 @@ use crate::facts::Facts;
 use crate::notification::Notification;
 use crate::session::Session;
 use crate::transport::Transport;
-use crate::transport::ssh::{HostKeyVerification, SshAuth, SshConfig, SshTransport};
+use crate::transport::ssh::{HostKeyVerification, JumpHostConfig, SshAuth, SshConfig, SshTransport};
 #[cfg(feature = "tls")]
 use crate::transport::tls::{TlsConfig, TlsTransport};
 use crate::rpc::RpcErrorInfo;
@@ -53,6 +53,7 @@ pub struct ClientBuilder {
     gather_facts: bool,
     keepalive_interval: Option<Duration>,
     host_key_verification: HostKeyVerification,
+    jump_hosts: Vec<JumpHostConfig>,
 }
 
 impl ClientBuilder {
@@ -152,6 +153,22 @@ impl ClientBuilder {
         self
     }
 
+    /// Set the ordered list of SSH jump hosts (`ProxyJump` chain) to tunnel
+    /// through before reaching the target.
+    ///
+    /// Each hop carries its own credentials and host-key-verification policy
+    /// because in the real world the bastion frequently has different access
+    /// rules than the device behind it (different user, key, fingerprint).
+    /// The hops are dialed in order: hop 0 directly, hop 1 through hop 0's
+    /// `direct-tcpip`, etc., and the final target through the last hop.
+    ///
+    /// Equivalent to OpenSSH's `ProxyJump h1,h2,...,target`. When empty (the
+    /// default), a direct TCP connection is made to the target.
+    pub fn jump_hosts(mut self, hops: Vec<JumpHostConfig>) -> Self {
+        self.jump_hosts = hops;
+        self
+    }
+
     /// Establish the SSH connection and perform the NETCONF hello exchange.
     pub async fn connect(self) -> Result<Client, NetconfError> {
         let username = self
@@ -182,6 +199,7 @@ impl ClientBuilder {
             username,
             auth,
             host_key_verification: self.host_key_verification,
+            jump_hosts: self.jump_hosts,
         };
 
         let transport = SshTransport::connect(config.clone()).await?;
@@ -243,6 +261,7 @@ impl Client {
             gather_facts: true,
             keepalive_interval: None,
             host_key_verification: HostKeyVerification::default(),
+            jump_hosts: Vec::new(),
         }
     }
 

--- a/src/transport/ssh.rs
+++ b/src/transport/ssh.rs
@@ -19,6 +19,11 @@ use crate::transport::Transport;
 pub struct SshTransport {
     channel: Arc<Mutex<ChannelStream>>,
     handle: Arc<Mutex<client::Handle<SshHandler>>>,
+    /// SSH handles for each jump-host hop, kept alive for the lifetime of
+    /// the target session. Dropping a jump handle would tear down the
+    /// `direct-tcpip` channel that carries the next hop's transport, so
+    /// these must outlive `handle`.
+    _jump_handles: Vec<client::Handle<SshHandler>>,
 }
 
 /// SSH authentication method.
@@ -68,6 +73,29 @@ pub struct SshConfig {
     pub username: String,
     pub auth: SshAuth,
     /// Host key verification policy.
+    pub host_key_verification: HostKeyVerification,
+    /// Optional ordered list of jump-host hops to tunnel through.
+    ///
+    /// Each hop has its own host, credentials, and host-key-verification
+    /// policy (independent of the target). When empty (the default), a
+    /// direct TCP connection is made to `host:port`. When set, an SSH
+    /// session is established to each hop in turn, and a `direct-tcpip`
+    /// channel is used to carry the next leg — equivalent to OpenSSH's
+    /// `ProxyJump h1,h2,h3,...,target`.
+    pub jump_hosts: Vec<JumpHostConfig>,
+}
+
+/// Configuration for one jump-host hop in a `ProxyJump` chain.
+///
+/// Each hop carries its own credentials and host-key policy because in
+/// the real world the bastion frequently has different access rules than
+/// the device behind it (different user, key, fingerprint).
+#[derive(Clone)]
+pub struct JumpHostConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub auth: SshAuth,
     pub host_key_verification: HostKeyVerification,
 }
 
@@ -127,121 +155,232 @@ struct ChannelStream {
     read_buffer: Vec<u8>,
 }
 
+/// Build the russh client config used for every hop and the target.
+///
+/// Network devices (Juniper, Cisco) often only support ECDH NIST or DH
+/// group key exchange — not Curve25519 which is russh's default
+/// preference, so we extend the preferred list.
+fn build_russh_config() -> client::Config {
+    let preferred = Preferred {
+        kex: Cow::Borrowed(&[
+            kex::CURVE25519,
+            kex::CURVE25519_PRE_RFC_8731,
+            kex::ECDH_SHA2_NISTP256,
+            kex::ECDH_SHA2_NISTP384,
+            kex::ECDH_SHA2_NISTP521,
+            kex::DH_G16_SHA512,
+            kex::DH_G14_SHA256,
+            kex::EXTENSION_SUPPORT_AS_CLIENT,
+            kex::EXTENSION_OPENSSH_STRICT_KEX_AS_CLIENT,
+        ]),
+        ..Preferred::default()
+    };
+    client::Config {
+        preferred,
+        ..Default::default()
+    }
+}
+
+/// Authenticate an open SSH session against the given username/auth method.
+///
+/// Used uniformly for jump hosts and the final target.
+async fn authenticate(
+    handle: &mut client::Handle<SshHandler>,
+    username: &str,
+    auth: &SshAuth,
+) -> Result<(), TransportError> {
+    let auth_result = match auth {
+        SshAuth::Password(password) => handle
+            .authenticate_password(username, password)
+            .await
+            .map_err(|e| TransportError::Auth(format!("password auth failed: {e}")))?,
+        SshAuth::KeyFile { path, passphrase } => {
+            let key_path = Path::new(path);
+            let key_contents = std::fs::read_to_string(key_path).map_err(|e| {
+                tracing::debug!(path, %e, "failed to read key file");
+                TransportError::Auth("failed to read SSH key file".to_string())
+            })?;
+            let key_pair = keys::decode_secret_key(&key_contents, passphrase.as_deref())
+                .map_err(|e| {
+                    tracing::debug!(%e, "failed to decode key");
+                    TransportError::Auth("failed to decode SSH key".to_string())
+                })?;
+            let hash_alg = handle
+                .best_supported_rsa_hash()
+                .await
+                .unwrap_or(None)
+                .flatten();
+            let key_with_hash = PrivateKeyWithHashAlg::new(Arc::new(key_pair), hash_alg);
+            handle
+                .authenticate_publickey(username, key_with_hash)
+                .await
+                .map_err(|e| TransportError::Auth(format!("key auth failed: {e}")))?
+        }
+        SshAuth::Agent => {
+            let mut agent = keys::agent::client::AgentClient::connect_env()
+                .await
+                .map_err(|e| TransportError::Auth(format!("SSH agent connect failed: {e}")))?;
+            let identities = agent.request_identities().await.map_err(|e| {
+                TransportError::Auth(format!("SSH agent identities failed: {e}"))
+            })?;
+
+            let mut auth_success = false;
+            for identity in identities {
+                match handle
+                    .authenticate_publickey_with(
+                        username,
+                        identity.public_key().into_owned(),
+                        None,
+                        &mut agent,
+                    )
+                    .await
+                {
+                    Ok(AuthResult::Success) => {
+                        auth_success = true;
+                        break;
+                    }
+                    _ => continue,
+                }
+            }
+            if auth_success {
+                AuthResult::Success
+            } else {
+                AuthResult::Failure {
+                    remaining_methods: russh::MethodSet::empty(),
+                    partial_success: false,
+                }
+            }
+        }
+    };
+
+    if !matches!(auth_result, AuthResult::Success) {
+        return Err(TransportError::Auth(format!(
+            "authentication failed for user '{username}'"
+        )));
+    }
+    Ok(())
+}
+
 impl SshTransport {
     /// Connect to a NETCONF device over SSH and open the `netconf` subsystem.
+    ///
+    /// If `config.jump_hosts` is non-empty, an SSH session is established to
+    /// each hop in turn and a `direct-tcpip` channel is used to carry the
+    /// next leg, equivalent to OpenSSH's `ProxyJump h1,h2,...,target`.
     pub async fn connect(config: SshConfig) -> Result<Self, TransportError> {
-        // Build SSH config with broad algorithm support for network devices.
-        // Many devices (Juniper, Cisco) only support ECDH NIST or DH group
-        // key exchange — not Curve25519 which is russh's default preference.
-        let preferred = Preferred {
-            kex: Cow::Borrowed(&[
-                kex::CURVE25519,
-                kex::CURVE25519_PRE_RFC_8731,
-                kex::ECDH_SHA2_NISTP256,
-                kex::ECDH_SHA2_NISTP384,
-                kex::ECDH_SHA2_NISTP521,
-                kex::DH_G16_SHA512,
-                kex::DH_G14_SHA256,
-                kex::EXTENSION_SUPPORT_AS_CLIENT,
-                kex::EXTENSION_OPENSSH_STRICT_KEX_AS_CLIENT,
-            ]),
-            ..Preferred::default()
-        };
+        let russh_config = Arc::new(build_russh_config());
 
-        let russh_config = client::Config {
-            preferred,
-            ..Default::default()
-        };
+        // Establish each jump-host hop in sequence. After the loop, `prev`
+        // holds the Handle of the last hop (or None for direct connection).
+        // We must keep all jump handles alive for the lifetime of the
+        // target session — dropping them would tear down the tunneled
+        // channels that carry the target session's transport.
+        let mut jump_handles: Vec<client::Handle<SshHandler>> = Vec::new();
+        let mut prev: Option<&client::Handle<SshHandler>> = None;
 
-        let handler = SshHandler {
-            host_key_verification: config.host_key_verification.clone(),
-        };
-        let mut handle = client::connect(Arc::new(russh_config), (&*config.host, config.port), handler)
-            .await
-            .map_err(|e| TransportError::Connect(format!("SSH connect to {}:{} failed: {e}", config.host, config.port)))?;
-
-        // Authenticate
-        let auth_result = match &config.auth {
-            SshAuth::Password(password) => {
-                handle
-                    .authenticate_password(&config.username, password)
-                    .await
-                    .map_err(|e| TransportError::Auth(format!("password auth failed: {e}")))?
-            }
-            SshAuth::KeyFile { path, passphrase } => {
-                let key_path = Path::new(path);
-                let key_pair = if let Some(pass) = passphrase {
-                    keys::decode_secret_key(&std::fs::read_to_string(key_path)
-                        .map_err(|e| {
-                            tracing::debug!(path, %e, "failed to read key file");
-                            TransportError::Auth("failed to read SSH key file".to_string())
-                        })?, Some(pass))
-                        .map_err(|e| {
-                            tracing::debug!(%e, "failed to decode key");
-                            TransportError::Auth("failed to decode SSH key".to_string())
-                        })?
-                } else {
-                    keys::decode_secret_key(&std::fs::read_to_string(key_path)
-                        .map_err(|e| {
-                            tracing::debug!(path, %e, "failed to read key file");
-                            TransportError::Auth("failed to read SSH key file".to_string())
-                        })?, None)
-                        .map_err(|e| {
-                            tracing::debug!(%e, "failed to decode key");
-                            TransportError::Auth("failed to decode SSH key".to_string())
-                        })?
-                };
-                let hash_alg = handle.best_supported_rsa_hash().await
-                    .unwrap_or(None)
-                    .flatten();
-                let key_with_hash = PrivateKeyWithHashAlg::new(
-                    Arc::new(key_pair),
-                    hash_alg,
-                );
-                handle
-                    .authenticate_publickey(&config.username, key_with_hash)
-                    .await
-                    .map_err(|e| TransportError::Auth(format!("key auth failed: {e}")))?
-            }
-            SshAuth::Agent => {
-                let mut agent = keys::agent::client::AgentClient::connect_env()
-                    .await
-                    .map_err(|e| TransportError::Auth(format!("SSH agent connect failed: {e}")))?;
-                let identities = agent
-                    .request_identities()
-                    .await
-                    .map_err(|e| TransportError::Auth(format!("SSH agent identities failed: {e}")))?;
-
-                let mut auth_success = false;
-                for identity in identities {
-                    match handle
-                        .authenticate_publickey_with(&config.username, identity.public_key().into_owned(), None, &mut agent)
+        for (idx, hop) in config.jump_hosts.iter().enumerate() {
+            let label = format!("jump-host {} ({}:{})", idx, hop.host, hop.port);
+            let handle = match prev {
+                None => {
+                    // First hop: direct TCP connection.
+                    let handler = SshHandler {
+                        host_key_verification: hop.host_key_verification.clone(),
+                    };
+                    client::connect(russh_config.clone(), (&*hop.host, hop.port), handler)
                         .await
-                    {
-                        Ok(AuthResult::Success) => {
-                            auth_success = true;
-                            break;
-                        }
-                        _ => continue,
-                    }
+                        .map_err(|e| {
+                            TransportError::Connect(format!("SSH connect to {label} failed: {e}"))
+                        })?
                 }
-                if auth_success {
-                    AuthResult::Success
-                } else {
-                    AuthResult::Failure {
-                        remaining_methods: russh::MethodSet::empty(),
-                        partial_success: false,
-                    }
+                Some(parent) => {
+                    // Subsequent hop: tunneled via the previous hop's session.
+                    let channel = parent
+                        .channel_open_direct_tcpip(&*hop.host, hop.port as u32, "0.0.0.0", 0)
+                        .await
+                        .map_err(|e| {
+                            TransportError::Connect(format!(
+                                "direct-tcpip to {label} failed: {e}"
+                            ))
+                        })?;
+                    let stream = channel.into_stream();
+                    let handler = SshHandler {
+                        host_key_verification: hop.host_key_verification.clone(),
+                    };
+                    client::connect_stream(russh_config.clone(), stream, handler)
+                        .await
+                        .map_err(|e| {
+                            TransportError::Connect(format!(
+                                "SSH handshake with {label} failed: {e}"
+                            ))
+                        })?
                 }
+            };
+
+            jump_handles.push(handle);
+            prev = Some(jump_handles.last().expect("just pushed"));
+        }
+
+        // Authenticate to each jump host in order. Done after the loop above
+        // so the borrow of `prev` is released.
+        for (idx, hop) in config.jump_hosts.iter().enumerate() {
+            let handle = &mut jump_handles[idx];
+            authenticate(handle, &hop.username, &hop.auth)
+                .await
+                .map_err(|e| match e {
+                    TransportError::Auth(msg) => TransportError::Auth(format!(
+                        "jump-host {} ({}:{}): {msg}",
+                        idx, hop.host, hop.port
+                    )),
+                    other => other,
+                })?;
+        }
+
+        // Open the final hop to the target — either direct or through the
+        // last jump host.
+        let target_label = format!("{}:{}", config.host, config.port);
+        let mut handle = match jump_handles.last() {
+            None => {
+                let handler = SshHandler {
+                    host_key_verification: config.host_key_verification.clone(),
+                };
+                client::connect(russh_config.clone(), (&*config.host, config.port), handler)
+                    .await
+                    .map_err(|e| {
+                        TransportError::Connect(format!(
+                            "SSH connect to {target_label} failed: {e}"
+                        ))
+                    })?
+            }
+            Some(parent) => {
+                let channel = parent
+                    .channel_open_direct_tcpip(
+                        &*config.host,
+                        config.port as u32,
+                        "0.0.0.0",
+                        0,
+                    )
+                    .await
+                    .map_err(|e| {
+                        TransportError::Connect(format!(
+                            "direct-tcpip to target {target_label} failed: {e}"
+                        ))
+                    })?;
+                let stream = channel.into_stream();
+                let handler = SshHandler {
+                    host_key_verification: config.host_key_verification.clone(),
+                };
+                client::connect_stream(russh_config.clone(), stream, handler)
+                    .await
+                    .map_err(|e| {
+                        TransportError::Connect(format!(
+                            "SSH handshake with target {target_label} failed: {e}"
+                        ))
+                    })?
             }
         };
 
-        if !matches!(auth_result, AuthResult::Success) {
-            return Err(TransportError::Auth(format!(
-                "authentication failed for user '{}'",
-                config.username
-            )));
-        }
+        // Authenticate to the target.
+        authenticate(&mut handle, &config.username, &config.auth).await?;
 
         // Open a session channel and request the netconf subsystem
         let mut channel = handle
@@ -291,6 +430,7 @@ impl SshTransport {
         Ok(Self {
             channel: Arc::new(Mutex::new(channel_stream)),
             handle: Arc::new(Mutex::new(handle)),
+            _jump_handles: jump_handles,
         })
     }
 }
@@ -356,5 +496,98 @@ impl Transport for SshTransport {
             .await
             .map_err(|e| TransportError::Io(std::io::Error::other(e.to_string())))?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ssh_config_default_jump_hosts_is_empty() {
+        // Direct connection (no jump hosts) is the default; verify the field
+        // exists and constructs cleanly.
+        let cfg = SshConfig {
+            host: "10.0.0.1".to_string(),
+            port: 830,
+            username: "u".to_string(),
+            auth: SshAuth::Password("p".to_string()),
+            host_key_verification: HostKeyVerification::AcceptAll,
+            jump_hosts: Vec::new(),
+        };
+        assert!(cfg.jump_hosts.is_empty());
+    }
+
+    #[test]
+    fn jump_host_config_constructs_with_independent_creds() {
+        // Bastion frequently has different access rules than the device.
+        // Verify each hop carries its own credentials and host-key policy.
+        let hop = JumpHostConfig {
+            host: "bastion.example.com".to_string(),
+            port: 22,
+            username: "jump-user".to_string(),
+            auth: SshAuth::KeyFile {
+                path: "/home/me/.ssh/jump_key".to_string(),
+                passphrase: None,
+            },
+            host_key_verification: HostKeyVerification::Fingerprint(
+                "SHA256:abc123".to_string(),
+            ),
+        };
+        assert_eq!(hop.host, "bastion.example.com");
+        assert_eq!(hop.port, 22);
+        assert_eq!(hop.username, "jump-user");
+        assert!(matches!(hop.auth, SshAuth::KeyFile { .. }));
+        assert!(matches!(
+            hop.host_key_verification,
+            HostKeyVerification::Fingerprint(_)
+        ));
+    }
+
+    #[test]
+    fn jump_host_config_is_clone() {
+        // SshConfig derives Clone (used by ClientBuilder for reconnect),
+        // so JumpHostConfig must also be Clone.
+        let hop = JumpHostConfig {
+            host: "h".to_string(),
+            port: 22,
+            username: "u".to_string(),
+            auth: SshAuth::Agent,
+            host_key_verification: HostKeyVerification::AcceptAll,
+        };
+        let _cloned = hop.clone();
+    }
+
+    #[test]
+    fn ssh_config_with_multi_hop_chain_clones() {
+        // Reconnect support requires SshConfig: Clone, including a chain.
+        let hops = vec![
+            JumpHostConfig {
+                host: "h1".to_string(),
+                port: 22,
+                username: "u1".to_string(),
+                auth: SshAuth::Agent,
+                host_key_verification: HostKeyVerification::AcceptAll,
+            },
+            JumpHostConfig {
+                host: "h2".to_string(),
+                port: 22,
+                username: "u2".to_string(),
+                auth: SshAuth::Agent,
+                host_key_verification: HostKeyVerification::AcceptAll,
+            },
+        ];
+        let cfg = SshConfig {
+            host: "target".to_string(),
+            port: 830,
+            username: "u".to_string(),
+            auth: SshAuth::Agent,
+            host_key_verification: HostKeyVerification::AcceptAll,
+            jump_hosts: hops,
+        };
+        let cloned = cfg.clone();
+        assert_eq!(cloned.jump_hosts.len(), 2);
+        assert_eq!(cloned.jump_hosts[0].host, "h1");
+        assert_eq!(cloned.jump_hosts[1].host, "h2");
     }
 }


### PR DESCRIPTION
## Summary

Adds support for tunneling NETCONF/SSH through one or more jump hosts, equivalent to OpenSSH's `ProxyJump h1,h2,...,target`. This is **Phase 1** of #14; Phases 2 (ProxyCommand) and 3 (OpenSSH config parser) remain open.

- New `JumpHostConfig` struct — each hop carries its own host, port, credentials, and host-key-verification policy (bastions frequently have different access rules than the devices behind them).
- New `SshConfig.jump_hosts: Vec<JumpHostConfig>` field. Empty = direct connection (existing behavior, fully backwards compatible).
- New `ClientBuilder::jump_hosts(...)` builder method.
- `SshTransport::connect` walks the hop chain: hop 0 via direct TCP, subsequent hops via the previous hop's `direct-tcpip` channel + `client::connect_stream`. Final target is opened through the last hop's `direct-tcpip` channel.
- `SshTransport` retains the `Vec<client::Handle<SshHandler>>` of jump handles for the lifetime of the target session — dropping a jump handle would tear down the channel carrying the next hop.
- Internal refactor: extracted `build_russh_config()` and `authenticate()` so hops and target share the same kex preferences and the same auth-method handling.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test --lib` — 137 passed (4 new unit tests for `JumpHostConfig` / `SshConfig.jump_hosts`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Live test against a 2-hop chain (bastion → vSRX) — deferred to integration tests once we have a lab bastion configured
- [ ] Live test against a 3-hop chain — deferred (same)

## Notes

- Backwards compatible: existing direct connections take the `None` branch in the connect loop and behave identically.
- The `_jump_handles` field is prefixed with `_` because it's a lifetime anchor, not read after construction.
- Auth is run **after** the connection chain is fully built, to avoid borrow conflicts on the previous-hop handle inside the loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)