### PR TITLE
feat: SSH known_hosts host-key verification (closes #28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,10 @@ jobs:
         run: cargo build --workspace --all-features --verbose
 
       - name: Test
+        # Live-device integration tests (`integration_vsrx`,
+        # `integration_vendor_pool`) opt in via `RUSTNETCONF_TEST_VSRX_HOST`
+        # and are no-ops here in hosted CI without lab access.
         run: cargo test --workspace --all-features --verbose
-        env:
-          SKIP_INTEGRATION: "1"
 
   clippy:
     name: Clippy (workspace, all features)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /.serena/
 .claude/worktrees/
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2048,6 +2048,8 @@ name = "rustnetconf"
 version = "0.11.0"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
+ "base64ct",
  "quick-xml",
  "russh",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ tls = ["rustls", "tokio-rustls", "webpki-roots"]
 [dependencies]
 tokio = { version = "1", features = ["full"] }
 russh = { version = "0.60", default-features = false, features = ["flate2", "aws-lc-rs"] }
+aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"] }
+base64ct = { version = "1", features = ["std"] }
 quick-xml = "0.37"
 thiserror = "2"
 tracing = "0.1"

--- a/README.md
+++ b/README.md
@@ -491,7 +491,7 @@ SKIP_INTEGRATION=1 cargo test             # Skip tests requiring a device
 
 - Use Ed25519 SSH keys (not RSA) for device authentication (also mitigates
   RUSTSEC-2023-0071 above)
-- Set `host_key_verification(HostKeyVerification::Fingerprint(...))` in production — the default is `RejectAll` (fail closed), so the connection will refuse to complete until you choose a policy. For the CLI, set `host_key_fingerprint = "SHA256:..."` per device in `inventory.toml`.
+- Set `host_key_verification(HostKeyVerification::Fingerprint(...))` or `HostKeyVerification::KnownHosts(path)` in production — the default is `RejectAll` (fail closed), so the connection will refuse to complete until you choose a policy. For the CLI, set either `host_key_fingerprint = "SHA256:..."` or `known_hosts_path = "/path/to/known_hosts"` per device in `inventory.toml` (or `known_hosts_path` under `[defaults]` for fleet-wide pinning). See `examples/known_hosts.rs` for the `ssh-keyscan` workflow.
 - Set `.rpc_timeout(Duration::from_secs(30))` to prevent hanging on unresponsive devices
 - Prefer SSH agent auth over inline passwords
 - Store credentials in inventory.toml with restricted file permissions (`chmod 600`)

--- a/examples/known_hosts.rs
+++ b/examples/known_hosts.rs
@@ -1,0 +1,137 @@
+//! Verify a device's SSH host key against an OpenSSH `known_hosts` file.
+//!
+//! This is the recommended host-key policy for managing a fleet of network
+//! devices — you can ship a single `known_hosts` file (e.g. baked into a
+//! container image or a config-management bundle) and the library will fail
+//! closed on any host whose key is missing, mismatched, or `@revoked`.
+//!
+//! ## Workflow
+//!
+//! 1. Pre-populate a `known_hosts` file using `ssh-keyscan`:
+//!
+//!    ```sh
+//!    # Default port 22
+//!    ssh-keyscan -t ed25519,rsa,ecdsa router-01.example.com >> ./known_hosts
+//!
+//!    # Custom NETCONF port — ssh-keyscan emits the [host]:port form
+//!    ssh-keyscan -t ed25519,rsa,ecdsa -p 830 router-01.example.com \
+//!        >> ./known_hosts
+//!    ```
+//!
+//!    Always inspect the file before trusting it — `ssh-keyscan` does NOT
+//!    verify host identity itself (TOFU). Confirm the fingerprints out of
+//!    band (e.g. via console, MOTD, or your provisioning system) before
+//!    promoting the file to production.
+//!
+//! 2. Run this example:
+//!
+//!    ```sh
+//!    cargo run --example known_hosts -- \
+//!        router-01.example.com:830 admin ./known_hosts \
+//!        --key ~/.ssh/id_ed25519
+//!    ```
+//!
+//! ## Failure modes
+//!
+//! - `TransportError::HostKeyMismatch` — file has a different fingerprint
+//!   for this host. Possible MITM or rotated host key. Investigate before
+//!   updating the file.
+//! - `TransportError::HostKeyNotInKnownHosts` — host has no entry. Run
+//!   `ssh-keyscan` to add one, after verifying the key out of band.
+//! - `TransportError::HostKeyRevoked` — the file has an `@revoked` marker
+//!   for the key the server presented. Do not connect; the operator has
+//!   explicitly blocklisted this key.
+
+use rustnetconf::transport::ssh::HostKeyVerification;
+use rustnetconf::{Client, Datastore};
+use std::env;
+use std::path::PathBuf;
+use std::process;
+
+#[tokio::main]
+async fn main() {
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() < 4 {
+        eprintln!(
+            "Usage: {} <host[:port]> <username> <known_hosts_path> [--password <pass>] [--key <path>]",
+            args[0]
+        );
+        process::exit(1);
+    }
+
+    let host = &args[1];
+    let username = &args[2];
+    let known_hosts_path = PathBuf::from(&args[3]);
+
+    let mut password: Option<String> = None;
+    let mut key_file: Option<String> = None;
+    let mut idx = 4;
+    while idx < args.len() {
+        match args[idx].as_str() {
+            "--password" => {
+                idx += 1;
+                password = Some(args.get(idx).expect("--password requires a value").clone());
+            }
+            "--key" => {
+                idx += 1;
+                key_file = Some(args.get(idx).expect("--key requires a value").clone());
+            }
+            other => {
+                eprintln!("Unknown option: {other}");
+                process::exit(1);
+            }
+        }
+        idx += 1;
+    }
+
+    let mut builder = Client::connect(host)
+        .username(username)
+        .host_key_verification(HostKeyVerification::KnownHosts(known_hosts_path.clone()));
+
+    if let Some(ref key) = key_file {
+        builder = builder.key_file(key);
+    } else if let Some(ref pass) = password {
+        builder = builder.password(pass);
+    } else {
+        eprintln!("Error: specify --password or --key for authentication");
+        process::exit(1);
+    }
+
+    eprintln!(
+        "Connecting to {host} (host key verified against {})",
+        known_hosts_path.display()
+    );
+
+    let mut client = match builder.connect().await {
+        Ok(c) => c,
+        Err(e) => {
+            // The structured TransportError variants (HostKeyMismatch,
+            // HostKeyNotInKnownHosts, HostKeyRevoked) flow through here as
+            // part of the rendered error chain.
+            eprintln!("Connection failed: {e}");
+            process::exit(1);
+        }
+    };
+
+    eprintln!("Host key verified.");
+
+    // Fetch a small piece of running config to prove the session works.
+    match client.get_config(Datastore::Running).await {
+        Ok(data) => {
+            // Print only the first 500 chars to keep example output short.
+            let preview: String = data.chars().take(500).collect();
+            println!("{preview}");
+            if data.len() > 500 {
+                println!("... ({} more chars)", data.len() - 500);
+            }
+        }
+        Err(e) => {
+            eprintln!("get-config failed: {e}");
+            client.close_session().await.ok();
+            process::exit(1);
+        }
+    }
+
+    client.close_session().await.ok();
+}

--- a/rustnetconf-cli/src/connect.rs
+++ b/rustnetconf-cli/src/connect.rs
@@ -3,17 +3,52 @@
 use crate::inventory::ResolvedDevice;
 use rustnetconf::transport::ssh::HostKeyVerification;
 use rustnetconf::Client;
+use std::path::PathBuf;
+
+/// Pure policy-selection helper — decides which `HostKeyVerification` to use
+/// based on inventory state and the `--insecure-accept-host-key` flag.
+///
+/// Precedence (most to least secure):
+/// 1. `--insecure-accept-host-key` → `AcceptAll` (with a logged warning,
+///    handled by the caller).
+/// 2. `device.known_hosts_path` set → `KnownHosts(path)`.
+/// 3. `device.host_key_fingerprint` set → `Fingerprint(fp)`.
+/// 4. Nothing pinned → `Err` (fail closed; user must pin or pass the
+///    insecure flag).
+///
+/// The inventory resolver already errors when both `known_hosts_path` and
+/// `host_key_fingerprint` are set on the same device entry, so this function
+/// trusts that `device.known_hosts_path` and `device.host_key_fingerprint`
+/// will not both be `Some`.
+pub(crate) fn select_host_key_policy(
+    device: &ResolvedDevice,
+    accept_insecure_host_key: bool,
+) -> Result<HostKeyVerification, String> {
+    if accept_insecure_host_key {
+        return Ok(HostKeyVerification::AcceptAll);
+    }
+    if let Some(ref path) = device.known_hosts_path {
+        return Ok(HostKeyVerification::KnownHosts(PathBuf::from(path)));
+    }
+    if let Some(ref fingerprint) = device.host_key_fingerprint {
+        return Ok(HostKeyVerification::Fingerprint(fingerprint.clone()));
+    }
+    Err(format!(
+        "device '{}': no host_key_fingerprint or known_hosts_path in inventory \
+         and --insecure-accept-host-key not set. Pin the device's host key in \
+         inventory.toml (host_key_fingerprint = \"SHA256:...\" or \
+         known_hosts_path = \"/path/to/known_hosts\") or rerun with \
+         --insecure-accept-host-key for lab use.",
+        device.name
+    ))
+}
 
 /// Connect to a device using resolved inventory details.
 ///
 /// `accept_insecure_host_key` is true when the user passed
 /// `--insecure-accept-host-key` on the CLI. In that case the SSH host key
-/// is accepted without verification. Otherwise the policy is:
-///
-/// 1. If the inventory entry has `host_key_fingerprint`, pin it.
-/// 2. Else, fall back to the library default (`RejectAll`), which fails
-///    closed — the user must add a fingerprint to the inventory or pass
-///    `--insecure-accept-host-key` to proceed.
+/// is accepted without verification. Otherwise [`select_host_key_policy`]
+/// decides the policy from inventory state.
 pub async fn connect_device(
     device: &ResolvedDevice,
     accept_insecure_host_key: bool,
@@ -31,23 +66,13 @@ pub async fn connect_device(
         ));
     }
 
-    let host_key_policy = if accept_insecure_host_key {
+    if accept_insecure_host_key {
         eprintln!(
             "WARNING: --insecure-accept-host-key set — accepting SSH host key for '{}' without verification",
             device.name
         );
-        HostKeyVerification::AcceptAll
-    } else if let Some(ref fingerprint) = device.host_key_fingerprint {
-        HostKeyVerification::Fingerprint(fingerprint.clone())
-    } else {
-        return Err(format!(
-            "device '{}': no host_key_fingerprint in inventory and \
-             --insecure-accept-host-key not set. Pin the device's host key in \
-             inventory.toml (host_key_fingerprint = \"SHA256:...\") or rerun \
-             with --insecure-accept-host-key for lab use.",
-            device.name
-        ));
-    };
+    }
+    let host_key_policy = select_host_key_policy(device, accept_insecure_host_key)?;
     builder = builder.host_key_verification(host_key_policy);
 
     builder.connect().await.map_err(|e| {
@@ -56,4 +81,89 @@ pub async fn connect_device(
             device.name, device.host
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::inventory::ResolvedDevice;
+
+    fn dev() -> ResolvedDevice {
+        ResolvedDevice {
+            name: "router-01".to_string(),
+            host: "10.0.0.1".to_string(),
+            username: "admin".to_string(),
+            password: None,
+            key_file: Some("~/.ssh/id_ed25519".to_string()),
+            vendor: None,
+            confirm_timeout: 60,
+            host_key_fingerprint: None,
+            known_hosts_path: None,
+        }
+    }
+
+    #[test]
+    fn insecure_flag_yields_accept_all() {
+        let policy = select_host_key_policy(&dev(), true).unwrap();
+        assert!(matches!(policy, HostKeyVerification::AcceptAll));
+    }
+
+    #[test]
+    fn known_hosts_path_yields_known_hosts_policy() {
+        let mut d = dev();
+        d.known_hosts_path = Some("/etc/jmcp/known_hosts".to_string());
+        let policy = select_host_key_policy(&d, false).unwrap();
+        match policy {
+            HostKeyVerification::KnownHosts(path) => {
+                assert_eq!(path, PathBuf::from("/etc/jmcp/known_hosts"));
+            }
+            other => panic!("expected KnownHosts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fingerprint_yields_fingerprint_policy() {
+        let mut d = dev();
+        d.host_key_fingerprint = Some("SHA256:aaa".to_string());
+        let policy = select_host_key_policy(&d, false).unwrap();
+        match policy {
+            HostKeyVerification::Fingerprint(fp) => assert_eq!(fp, "SHA256:aaa"),
+            other => panic!("expected Fingerprint, got {other:?}"),
+        }
+    }
+
+    /// known_hosts_path wins over a (hypothetical) fingerprint — but the
+    /// inventory resolver already prevents this combination, so this just
+    /// documents precedence in case it slips past validation in some future
+    /// refactor.
+    #[test]
+    fn known_hosts_path_wins_over_fingerprint() {
+        let mut d = dev();
+        d.known_hosts_path = Some("/etc/jmcp/known_hosts".to_string());
+        d.host_key_fingerprint = Some("SHA256:aaa".to_string());
+        let policy = select_host_key_policy(&d, false).unwrap();
+        assert!(matches!(policy, HostKeyVerification::KnownHosts(_)));
+    }
+
+    #[test]
+    fn insecure_wins_even_when_fingerprint_set() {
+        let mut d = dev();
+        d.host_key_fingerprint = Some("SHA256:aaa".to_string());
+        let policy = select_host_key_policy(&d, true).unwrap();
+        assert!(matches!(policy, HostKeyVerification::AcceptAll));
+    }
+
+    #[test]
+    fn no_pin_and_no_insecure_errors_with_actionable_message() {
+        let err = select_host_key_policy(&dev(), false).unwrap_err();
+        assert!(err.contains("router-01"), "error names device: {err}");
+        assert!(
+            err.contains("host_key_fingerprint") || err.contains("known_hosts_path"),
+            "error mentions options: {err}"
+        );
+        assert!(
+            err.contains("--insecure-accept-host-key"),
+            "error mentions escape hatch: {err}"
+        );
+    }
 }

--- a/rustnetconf-cli/src/inventory.rs
+++ b/rustnetconf-cli/src/inventory.rs
@@ -65,6 +65,9 @@ pub struct InventoryDefaults {
     pub confirm_timeout: Option<u32>,
     pub username: Option<String>,
     pub vendor: Option<String>,
+    /// Default known_hosts file path applied to every device that doesn't
+    /// override it. Tilde (`~`) is expanded to `$HOME`.
+    pub known_hosts_path: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -82,7 +85,17 @@ pub struct DeviceEntry {
     /// Obtain with `ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub` on the
     /// device. When set, the SSH host key must match exactly or the
     /// connection is rejected.
+    ///
+    /// Mutually exclusive with `known_hosts_path` — setting both is a hard
+    /// error to avoid ambiguity about which policy is in effect.
     pub host_key_fingerprint: Option<String>,
+    /// Path to an OpenSSH-format `known_hosts` file. When set, the device's
+    /// host key is verified against entries in this file on every connect.
+    /// Tilde (`~`) is expanded to `$HOME`.
+    ///
+    /// Overrides `defaults.known_hosts_path` for this device only.
+    /// Mutually exclusive with `host_key_fingerprint`.
+    pub known_hosts_path: Option<String>,
 }
 
 impl Inventory {
@@ -115,6 +128,28 @@ impl Inventory {
 
         let key_file = entry.key_file.as_ref().map(|p| resolve_home(p));
 
+        if entry.host_key_fingerprint.is_some() && entry.known_hosts_path.is_some() {
+            return Err(format!(
+                "device '{name}': host_key_fingerprint and known_hosts_path are mutually exclusive — choose one"
+            ));
+        }
+
+        // Per-device explicit setting overrides defaults entirely:
+        //   - if device sets known_hosts_path → that wins
+        //   - else if device sets host_key_fingerprint → no known_hosts inherited
+        //     (fingerprint is the policy for this device)
+        //   - else → inherit defaults.known_hosts_path
+        let known_hosts_path = if let Some(p) = entry.known_hosts_path.as_ref() {
+            Some(resolve_home(p))
+        } else if entry.host_key_fingerprint.is_some() {
+            None
+        } else {
+            self.defaults
+                .known_hosts_path
+                .as_ref()
+                .map(|p| resolve_home(p))
+        };
+
         Ok(ResolvedDevice {
             name: name.to_string(),
             host: entry.host.clone(),
@@ -127,6 +162,7 @@ impl Inventory {
                 .or_else(|| self.defaults.vendor.clone()),
             confirm_timeout: self.defaults.confirm_timeout.unwrap_or(60),
             host_key_fingerprint: entry.host_key_fingerprint.clone(),
+            known_hosts_path,
         })
     }
 }
@@ -145,6 +181,9 @@ pub struct ResolvedDevice {
     pub confirm_timeout: u32,
     /// Optional SHA-256 host key fingerprint to pin for this device.
     pub host_key_fingerprint: Option<String>,
+    /// Optional `known_hosts` file (already tilde-expanded). When set, host
+    /// key is verified against this file at connect time.
+    pub known_hosts_path: Option<String>,
 }
 
 /// Resolve ~ to home directory in a path.
@@ -267,5 +306,120 @@ host = "10.0.0.1"
         let resolved = resolve_home("~/.ssh/id_ed25519");
         assert!(!resolved.starts_with("~"));
         assert!(resolved.contains(".ssh/id_ed25519"));
+    }
+
+    #[test]
+    fn known_hosts_path_set_on_device_resolves_directly() {
+        let toml = r#"
+[devices.router-01]
+host = "10.0.0.1"
+username = "admin"
+known_hosts_path = "/etc/jmcp/known_hosts"
+"#;
+        let inv: Inventory = toml::from_str(toml).unwrap();
+        let dev = inv.device("router-01").unwrap();
+        assert_eq!(
+            dev.known_hosts_path.as_deref(),
+            Some("/etc/jmcp/known_hosts")
+        );
+    }
+
+    #[test]
+    fn known_hosts_path_falls_back_to_defaults() {
+        let toml = r#"
+[defaults]
+known_hosts_path = "/etc/jmcp/known_hosts"
+
+[devices.router-01]
+host = "10.0.0.1"
+username = "admin"
+"#;
+        let inv: Inventory = toml::from_str(toml).unwrap();
+        let dev = inv.device("router-01").unwrap();
+        assert_eq!(
+            dev.known_hosts_path.as_deref(),
+            Some("/etc/jmcp/known_hosts")
+        );
+    }
+
+    #[test]
+    fn device_known_hosts_path_overrides_defaults() {
+        let toml = r#"
+[defaults]
+known_hosts_path = "/etc/jmcp/known_hosts"
+
+[devices.router-01]
+host = "10.0.0.1"
+username = "admin"
+known_hosts_path = "/var/lib/jmcp/router-01_known_hosts"
+"#;
+        let inv: Inventory = toml::from_str(toml).unwrap();
+        let dev = inv.device("router-01").unwrap();
+        assert_eq!(
+            dev.known_hosts_path.as_deref(),
+            Some("/var/lib/jmcp/router-01_known_hosts")
+        );
+    }
+
+    #[test]
+    fn known_hosts_path_expands_tilde() {
+        std::env::set_var("HOME", "/home/test-user");
+        let toml = r#"
+[devices.router-01]
+host = "10.0.0.1"
+username = "admin"
+known_hosts_path = "~/.ssh/known_hosts"
+"#;
+        let inv: Inventory = toml::from_str(toml).unwrap();
+        let dev = inv.device("router-01").unwrap();
+        assert_eq!(
+            dev.known_hosts_path.as_deref(),
+            Some("/home/test-user/.ssh/known_hosts")
+        );
+    }
+
+    /// Setting both `host_key_fingerprint` and `known_hosts_path` on the same
+    /// device is ambiguous — fail loudly at inventory-resolution time rather
+    /// than silently preferring one.
+    #[test]
+    fn fingerprint_and_known_hosts_path_conflict_errors() {
+        let toml = r#"
+[devices.router-01]
+host = "10.0.0.1"
+username = "admin"
+host_key_fingerprint = "SHA256:aaa"
+known_hosts_path = "/etc/jmcp/known_hosts"
+"#;
+        let inv: Inventory = toml::from_str(toml).unwrap();
+        let err = inv.device("router-01").unwrap_err();
+        assert!(
+            err.contains("mutually exclusive"),
+            "expected conflict error, got: {err}"
+        );
+        assert!(err.contains("router-01"), "error should name device: {err}");
+    }
+
+    /// A device-level `host_key_fingerprint` opts the device out of the
+    /// defaults-level `known_hosts_path`. The two are NOT both set on the
+    /// resolved device — the device's explicit choice wins cleanly so
+    /// policy selection in `connect.rs` has no ambiguity to resolve.
+    #[test]
+    fn device_fingerprint_suppresses_defaults_known_hosts() {
+        let toml = r#"
+[defaults]
+known_hosts_path = "/etc/jmcp/known_hosts"
+
+[devices.router-01]
+host = "10.0.0.1"
+username = "admin"
+host_key_fingerprint = "SHA256:aaa"
+"#;
+        let inv: Inventory = toml::from_str(toml).unwrap();
+        let dev = inv.device("router-01").expect("should resolve");
+        assert_eq!(dev.host_key_fingerprint.as_deref(), Some("SHA256:aaa"));
+        assert!(
+            dev.known_hosts_path.is_none(),
+            "defaults known_hosts must not be inherited when device pins fingerprint"
+        );
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -78,9 +78,7 @@ pub enum TransportError {
     /// Server presented a host key whose fingerprint does not match the one
     /// recorded in the known_hosts file for this host. Possible MITM attack
     /// or the device's host key was rotated — investigate before reconnecting.
-    #[error(
-        "host key mismatch for {host}: known_hosts has {expected}, server presented {actual}"
-    )]
+    #[error("host key mismatch for {host}: known_hosts has {expected}, server presented {actual}")]
     HostKeyMismatch {
         host: String,
         expected: String,

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,32 @@ pub enum TransportError {
     #[cfg(feature = "tls")]
     #[error("TLS error: {0}")]
     Tls(String),
+
+    /// Server presented a host key whose fingerprint does not match the one
+    /// recorded in the known_hosts file for this host. Possible MITM attack
+    /// or the device's host key was rotated — investigate before reconnecting.
+    #[error(
+        "host key mismatch for {host}: known_hosts has {expected}, server presented {actual}"
+    )]
+    HostKeyMismatch {
+        host: String,
+        expected: String,
+        actual: String,
+    },
+
+    /// No entry for this host exists in the known_hosts file. Fail closed —
+    /// pre-populate the file with `ssh-keyscan` before connecting.
+    #[error("host {host}:{port} not found in known_hosts file {path}")]
+    HostKeyNotInKnownHosts {
+        host: String,
+        port: u16,
+        path: String,
+    },
+
+    /// The known_hosts file contains an `@revoked` entry for the host key
+    /// presented by the server. Fail closed.
+    #[error("host key for {host} is marked @revoked in known_hosts")]
+    HostKeyRevoked { host: String },
 }
 
 /// Framing layer errors (EOM or chunked framing).
@@ -159,4 +185,44 @@ pub enum ProtocolError {
     /// XML parsing error during protocol message handling.
     #[error("XML error: {0}")]
     Xml(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_key_mismatch_display_includes_all_fields() {
+        let err = TransportError::HostKeyMismatch {
+            host: "device-a.lab".into(),
+            expected: "SHA256:aaa".into(),
+            actual: "SHA256:bbb".into(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("device-a.lab"), "got {s:?}");
+        assert!(s.contains("SHA256:aaa"), "got {s:?}");
+        assert!(s.contains("SHA256:bbb"), "got {s:?}");
+    }
+
+    #[test]
+    fn host_key_not_in_known_hosts_display_includes_port_and_path() {
+        let err = TransportError::HostKeyNotInKnownHosts {
+            host: "device-a.lab".into(),
+            port: 830,
+            path: "/etc/jmcp/known_hosts".into(),
+        };
+        let s = err.to_string();
+        assert!(s.contains("device-a.lab"), "got {s:?}");
+        assert!(s.contains("830"), "got {s:?}");
+        assert!(s.contains("/etc/jmcp/known_hosts"), "got {s:?}");
+    }
+
+    #[test]
+    fn host_key_revoked_display_includes_host() {
+        let err = TransportError::HostKeyRevoked {
+            host: "device-a.lab".into(),
+        };
+        assert!(err.to_string().contains("device-a.lab"));
+        assert!(err.to_string().contains("revoked"));
+    }
 }

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! ```rust,no_run
 //! use rustnetconf::pool::{DevicePool, DeviceConfig};
-//! use rustnetconf::transport::ssh::SshAuth;
+//! use rustnetconf::transport::ssh::{HostKeyVerification, SshAuth};
 //! use rustnetconf::Datastore;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
@@ -23,6 +23,9 @@
 //!         host: "10.0.0.1:830".into(),
 //!         username: "admin".into(),
 //!         auth: SshAuth::Password(zeroize::Zeroizing::new("secret".into())),
+//!         host_key_verification: Some(HostKeyVerification::Fingerprint(
+//!             "SHA256:AAAA...".into(),
+//!         )),
 //!         vendor: None,
 //!     })
 //!     .build();

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -42,7 +42,7 @@ use tokio::sync::{Mutex, Semaphore, SemaphorePermit};
 
 use crate::client::Client;
 use crate::error::NetconfError;
-use crate::transport::ssh::SshAuth;
+use crate::transport::ssh::{HostKeyVerification, SshAuth};
 use crate::vendor::VendorProfile;
 
 /// Configuration for a single device in the pool.
@@ -53,6 +53,13 @@ pub struct DeviceConfig {
     pub username: String,
     /// SSH authentication method.
     pub auth: SshAuth,
+    /// SSH host-key verification policy for this device.
+    ///
+    /// `None` means "use the library default" (`HostKeyVerification::RejectAll`),
+    /// which fails closed — connections will refuse to complete. Pool users
+    /// must set this to one of `Fingerprint(...)`, `KnownHosts(path)`, or
+    /// (for labs only) `AcceptAll`.
+    pub host_key_verification: Option<HostKeyVerification>,
     /// Optional explicit vendor profile. `None` = auto-detect.
     ///
     /// TODO: This field is not yet wired into connection setup. `connect_device()`
@@ -284,6 +291,10 @@ async fn connect_device(config: &DeviceConfig) -> Result<Client, NetconfError> {
         SshAuth::Agent => {
             builder = builder.ssh_agent();
         }
+    }
+
+    if let Some(policy) = &config.host_key_verification {
+        builder = builder.host_key_verification(policy.clone());
     }
 
     builder.connect().await

--- a/src/transport/known_hosts.rs
+++ b/src/transport/known_hosts.rs
@@ -1,0 +1,701 @@
+//! OpenSSH `known_hosts(5)` parser + host-key lookup.
+//!
+//! Used by [`crate::transport::ssh::HostKeyVerification::KnownHosts`] to pin
+//! host keys for a fleet of devices via an OpenSSH-format file. See `man 5
+//! known_hosts` for the file format.
+//!
+//! Supported features:
+//! - Plain hostnames, comma-separated host lists
+//! - `[host]:port` form (per OpenSSH convention when port != 22)
+//! - Wildcard patterns (`*`, `?`)
+//! - CIDR patterns (`10.0.0.0/8`, `2001:db8::/32`)
+//! - Hashed entries (`|1|<salt>|<hmac>` — HMAC-SHA1)
+//! - Multiple key types per host (rsa/ed25519/ecdsa) — match any
+//! - `@revoked` markers (fail closed if matched)
+//!
+//! Deferred: `@cert-authority` (SSH host certificates).
+
+use std::path::Path;
+
+/// A parsed `known_hosts` entry (one non-blank, non-comment line).
+#[derive(Debug, Clone)]
+pub(crate) struct Entry {
+    pub host_spec: HostSpec,
+    pub key_type: String,
+    pub key_blob_b64: String,
+    pub marker: Option<Marker>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum HostSpec {
+    /// One or more comma-separated patterns (literal/wildcard/CIDR/`[host]:port`).
+    Plain(Vec<Pattern>),
+    /// OpenSSH hashed-hostname entry: `|1|<salt>|<HMAC-SHA1(salt, hostname)>`.
+    /// The hostname is the literal lookup string OpenSSH would feed in — plain
+    /// `host` if port is default 22, else `[host]:port`.
+    Hashed { salt: Vec<u8>, mac: Vec<u8> },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum Pattern {
+    /// Literal hostname (no wildcards), port-agnostic — matches the host
+    /// regardless of port (compat with OpenSSH which treats plain entries
+    /// as matching the default port but not strictly).
+    Literal(String),
+    /// `[host]:port` form — host AND port must match.
+    HostPort { host: String, port: u16 },
+    /// Glob pattern containing `*` (zero-or-more) and/or `?` (exactly one).
+    Wildcard(String),
+    /// CIDR network — match host IPs that fall inside the prefix.
+    Cidr(CidrNet),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum CidrNet {
+    V4 { network: u32, prefix_len: u8 },
+    V6 { network: u128, prefix_len: u8 },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Marker {
+    Revoked,
+    /// Recognized but not validated — see module docs. Lines with this marker
+    /// are skipped by [`parse_line`], never reaching this variant in practice;
+    /// retained for completeness in case we later honor SSH certs.
+    #[allow(dead_code)]
+    CertAuthority,
+}
+
+impl Entry {
+    pub fn host_matches(&self, host: &str, port: u16) -> bool {
+        match &self.host_spec {
+            HostSpec::Plain(patterns) => patterns.iter().any(|p| p.matches(host, port)),
+            HostSpec::Hashed { salt, mac } => {
+                // OpenSSH feeds plain `host` for default port, `[host]:port` otherwise.
+                let key = if port == 22 {
+                    host.to_string()
+                } else {
+                    format!("[{host}]:{port}")
+                };
+                hashed_host_matches(salt, mac, key.as_bytes())
+            }
+        }
+    }
+}
+
+/// Compute the OpenSSH-style SHA-256 fingerprint (`"SHA256:<base64-unpadded>"`)
+/// of a base64-encoded SSH wire-format public key blob.
+///
+/// Matches the format produced by `russh::keys::PublicKey::fingerprint(Sha256)`
+/// and by `ssh-keygen -lf`.
+fn fingerprint_from_key_blob_b64(blob_b64: &str) -> Result<String, base64ct::Error> {
+    use aws_lc_rs::digest;
+    use base64ct::{Base64, Base64Unpadded, Encoding};
+    let raw = Base64::decode_vec(blob_b64)?;
+    let digest = digest::digest(&digest::SHA256, &raw);
+    Ok(format!(
+        "SHA256:{}",
+        Base64Unpadded::encode_string(digest.as_ref())
+    ))
+}
+
+/// Constant-time compare of `HMAC-SHA1(salt, key)` against `expected_mac`.
+fn hashed_host_matches(salt: &[u8], expected_mac: &[u8], key: &[u8]) -> bool {
+    use aws_lc_rs::hmac;
+    let hmac_key = hmac::Key::new(hmac::HMAC_SHA1_FOR_LEGACY_USE_ONLY, salt);
+    let computed = hmac::sign(&hmac_key, key);
+    // Length-then-bytewise compare; aws-lc-rs Tag impls AsRef<[u8]>.
+    let computed_bytes = computed.as_ref();
+    if computed_bytes.len() != expected_mac.len() {
+        return false;
+    }
+    // Constant-time compare to avoid timing leaks of the file's contents.
+    let mut diff: u8 = 0;
+    for (a, b) in computed_bytes.iter().zip(expected_mac.iter()) {
+        diff |= a ^ b;
+    }
+    diff == 0
+}
+
+impl Pattern {
+    fn matches(&self, host: &str, port: u16) -> bool {
+        match self {
+            Pattern::Literal(s) => s == host,
+            Pattern::HostPort { host: h, port: p } => h == host && *p == port,
+            Pattern::Wildcard(glob) => glob_matches(glob, host),
+            Pattern::Cidr(net) => net.contains(host),
+        }
+    }
+}
+
+impl CidrNet {
+    fn contains(&self, host: &str) -> bool {
+        use std::net::IpAddr;
+        let Ok(addr) = host.parse::<IpAddr>() else {
+            return false;
+        };
+        match (self, addr) {
+            (CidrNet::V4 { network, prefix_len }, IpAddr::V4(v4)) => {
+                let bits = u32::from(v4);
+                let mask = if *prefix_len == 0 {
+                    0
+                } else {
+                    u32::MAX << (32 - *prefix_len)
+                };
+                (bits & mask) == (*network & mask)
+            }
+            (CidrNet::V6 { network, prefix_len }, IpAddr::V6(v6)) => {
+                let bits = u128::from(v6);
+                let mask = if *prefix_len == 0 {
+                    0
+                } else {
+                    u128::MAX << (128 - *prefix_len)
+                };
+                (bits & mask) == (*network & mask)
+            }
+            _ => false,
+        }
+    }
+}
+
+fn parse_cidr(token: &str) -> Option<CidrNet> {
+    use std::net::IpAddr;
+    let (addr_str, prefix_str) = token.split_once('/')?;
+    let prefix_len: u8 = prefix_str.parse().ok()?;
+    match addr_str.parse::<IpAddr>().ok()? {
+        IpAddr::V4(v4) => {
+            if prefix_len > 32 {
+                return None;
+            }
+            Some(CidrNet::V4 {
+                network: u32::from(v4),
+                prefix_len,
+            })
+        }
+        IpAddr::V6(v6) => {
+            if prefix_len > 128 {
+                return None;
+            }
+            Some(CidrNet::V6 {
+                network: u128::from(v6),
+                prefix_len,
+            })
+        }
+    }
+}
+
+/// Match a glob pattern (`*` = zero-or-more, `?` = exactly-one) against `text`.
+///
+/// Iterative implementation with backtracking on `*`. O(n*m) worst case, but
+/// inputs are short hostnames so it's negligible. Matches the *entire* text.
+fn glob_matches(pattern: &str, text: &str) -> bool {
+    let pattern: Vec<char> = pattern.chars().collect();
+    let text: Vec<char> = text.chars().collect();
+    let (mut pi, mut ti) = (0usize, 0usize);
+    let (mut star_pi, mut star_ti): (Option<usize>, usize) = (None, 0);
+    while ti < text.len() {
+        if pi < pattern.len() && (pattern[pi] == '?' || pattern[pi] == text[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if pi < pattern.len() && pattern[pi] == '*' {
+            star_pi = Some(pi);
+            star_ti = ti;
+            pi += 1;
+        } else if let Some(sp) = star_pi {
+            pi = sp + 1;
+            star_ti += 1;
+            ti = star_ti;
+        } else {
+            return false;
+        }
+    }
+    // Consume trailing `*`s in the pattern.
+    while pi < pattern.len() && pattern[pi] == '*' {
+        pi += 1;
+    }
+    pi == pattern.len()
+}
+
+/// Parse a single host pattern token (one comma-separated piece of the
+/// host field). Recognizes `[host]:port` form.
+fn parse_pattern(token: &str) -> Result<Pattern, String> {
+    if let Some(rest) = token.strip_prefix('[') {
+        let close = rest
+            .find(']')
+            .ok_or_else(|| format!("unterminated '[' in pattern {token:?}"))?;
+        let host = &rest[..close];
+        let after = &rest[close + 1..];
+        let port_str = after
+            .strip_prefix(':')
+            .ok_or_else(|| format!("missing ':port' after ']' in pattern {token:?}"))?;
+        let port: u16 = port_str
+            .parse()
+            .map_err(|_| format!("invalid port in pattern {token:?}"))?;
+        return Ok(Pattern::HostPort {
+            host: host.to_string(),
+            port,
+        });
+    }
+    if token.contains('/') {
+        if let Some(net) = parse_cidr(token) {
+            return Ok(Pattern::Cidr(net));
+        }
+        // Falls through to literal/wildcard — '/' isn't otherwise meaningful.
+    }
+    if token.contains('*') || token.contains('?') {
+        return Ok(Pattern::Wildcard(token.to_string()));
+    }
+    Ok(Pattern::Literal(token.to_string()))
+}
+
+/// Parse one line of a `known_hosts` file.
+///
+/// Returns `Ok(None)` for blank lines and comments. Returns `Ok(Some(Entry))`
+/// for a valid entry. Returns `Err` for malformed lines.
+pub(crate) fn parse_line(line: &str, line_no: usize) -> Result<Option<Entry>, KnownHostsError> {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return Ok(None);
+    }
+    let mut parts = trimmed.split_whitespace();
+    let first = parts.next().ok_or_else(|| KnownHostsError::Parse {
+        line: line_no,
+        reason: "missing host field".into(),
+    })?;
+    let (marker, host_field) = match first {
+        "@revoked" => {
+            let host = parts.next().ok_or_else(|| KnownHostsError::Parse {
+                line: line_no,
+                reason: "@revoked: missing host field".into(),
+            })?;
+            (Some(Marker::Revoked), host)
+        }
+        "@cert-authority" => {
+            // SSH host certificates — not yet supported. Skip silently.
+            tracing::debug!(
+                line = line_no,
+                "skipping unsupported @cert-authority known_hosts line"
+            );
+            return Ok(None);
+        }
+        s if s.starts_with('@') => {
+            return Err(KnownHostsError::Parse {
+                line: line_no,
+                reason: format!("unknown marker {s:?}"),
+            });
+        }
+        host => (None, host),
+    };
+    let key_type = parts.next().ok_or_else(|| KnownHostsError::Parse {
+        line: line_no,
+        reason: "missing key type".into(),
+    })?;
+    let key_blob = parts.next().ok_or_else(|| KnownHostsError::Parse {
+        line: line_no,
+        reason: "missing key blob".into(),
+    })?;
+
+    let host_spec = parse_host_spec(host_field, line_no)?;
+    Ok(Some(Entry {
+        host_spec,
+        key_type: key_type.to_string(),
+        key_blob_b64: key_blob.to_string(),
+        marker,
+    }))
+}
+
+fn parse_host_spec(host_field: &str, line_no: usize) -> Result<HostSpec, KnownHostsError> {
+    use base64ct::{Base64, Encoding};
+    if let Some(rest) = host_field.strip_prefix("|1|") {
+        let (salt_b64, mac_b64) = rest.split_once('|').ok_or_else(|| KnownHostsError::Parse {
+            line: line_no,
+            reason: "hashed entry missing second '|' separator".into(),
+        })?;
+        let salt = Base64::decode_vec(salt_b64).map_err(|e| KnownHostsError::Parse {
+            line: line_no,
+            reason: format!("hashed entry: bad base64 salt: {e}"),
+        })?;
+        let mac = Base64::decode_vec(mac_b64).map_err(|e| KnownHostsError::Parse {
+            line: line_no,
+            reason: format!("hashed entry: bad base64 hmac: {e}"),
+        })?;
+        return Ok(HostSpec::Hashed { salt, mac });
+    }
+    let mut patterns: Vec<Pattern> = Vec::new();
+    for token in host_field.split(',').filter(|s| !s.is_empty()) {
+        let pat = parse_pattern(token).map_err(|reason| KnownHostsError::Parse {
+            line: line_no,
+            reason,
+        })?;
+        patterns.push(pat);
+    }
+    if patterns.is_empty() {
+        return Err(KnownHostsError::Parse {
+            line: line_no,
+            reason: "empty host field".into(),
+        });
+    }
+    Ok(HostSpec::Plain(patterns))
+}
+
+/// Outcome of looking up `host:port` against a `known_hosts` file.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LookupOutcome {
+    /// At least one entry matched the host and the fingerprint.
+    Match,
+    /// Host matched but no entry's fingerprint matched the actual key.
+    /// Includes one example file fingerprint for diagnostics.
+    Mismatch { file_fp: String },
+    /// No entry in the file matched the host.
+    NotFound,
+    /// An `@revoked` marker matched the host + key. Fail closed.
+    Revoked,
+}
+
+/// Errors raised while reading or parsing a `known_hosts` file.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum KnownHostsError {
+    #[error("known_hosts I/O: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("known_hosts parse error at line {line}: {reason}")]
+    Parse { line: usize, reason: String },
+}
+
+/// Look up `host:port` in `path` and compare against `actual_fp`.
+///
+/// `actual_fp` is expected in the format produced by
+/// `russh::keys::PublicKey::fingerprint(HashAlg::Sha256).to_string()` —
+/// typically `"SHA256:<base64>"`.
+pub(crate) fn lookup(
+    path: &Path,
+    host: &str,
+    port: u16,
+    actual_fp: &str,
+) -> Result<LookupOutcome, KnownHostsError> {
+    use std::io::{BufRead, BufReader};
+    let file = std::fs::File::open(path)?;
+    let reader = BufReader::new(file);
+
+    let mut matched_host = false;
+    let mut fp_match_found = false;
+    let mut first_mismatch_fp: Option<String> = None;
+
+    for (i, line_res) in reader.lines().enumerate() {
+        let line = line_res?;
+        let line_no = i + 1;
+        let entry = match parse_line(&line, line_no) {
+            Ok(Some(e)) => e,
+            Ok(None) => continue,
+            Err(e) => {
+                tracing::warn!(error = %e, "skipping malformed known_hosts line");
+                continue;
+            }
+        };
+        if !entry.host_matches(host, port) {
+            continue;
+        }
+        matched_host = true;
+
+        let entry_fp = match fingerprint_from_key_blob_b64(&entry.key_blob_b64) {
+            Ok(fp) => fp,
+            Err(e) => {
+                tracing::warn!(
+                    line = line_no,
+                    error = %e,
+                    "skipping known_hosts entry with invalid base64 key blob"
+                );
+                continue;
+            }
+        };
+
+        let fp_matches = entry_fp == actual_fp;
+
+        // @revoked is short-circuit: if ANY revoked line matches the host AND
+        // the server's key, fail closed immediately.
+        if entry.marker == Some(Marker::Revoked) && fp_matches {
+            return Ok(LookupOutcome::Revoked);
+        }
+        if entry.marker.is_some() {
+            // Non-revoked markers we don't honor (cert-authority is skipped
+            // earlier in parse_line; this is defense-in-depth).
+            continue;
+        }
+
+        if fp_matches {
+            fp_match_found = true;
+            // Keep scanning — a later @revoked for the same key must win.
+        } else if first_mismatch_fp.is_none() {
+            first_mismatch_fp = Some(entry_fp);
+        }
+    }
+
+    if !matched_host {
+        return Ok(LookupOutcome::NotFound);
+    }
+    if fp_match_found {
+        return Ok(LookupOutcome::Match);
+    }
+    Ok(LookupOutcome::Mismatch {
+        file_fp: first_mismatch_fp.unwrap_or_default(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn parse_line_plain_host_match() {
+        // A single plain-hostname entry; the line should parse and the host
+        // pattern should match exactly.
+        let line = "device-a.lab ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBlobForTesting";
+        let entry = super::parse_line(line, 1).expect("parses").expect("not blank");
+        assert!(entry.host_matches("device-a.lab", 22));
+        assert!(!entry.host_matches("device-b.lab", 22));
+    }
+
+    // ---------- helpers ----------
+
+    /// Build a known_hosts file with `lines`, return the path + tempdir guard.
+    fn write_known_hosts(lines: &[&str]) -> (tempfile::TempDir, std::path::PathBuf) {
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("known_hosts");
+        let mut f = std::fs::File::create(&path).unwrap();
+        for line in lines {
+            writeln!(f, "{line}").unwrap();
+        }
+        (dir, path)
+    }
+
+    /// Compute a real SHA256 fingerprint over `blob` for use as `actual_fp`,
+    /// and return both the base64 blob (for embedding in a known_hosts line)
+    /// and the fingerprint string.
+    fn blob_and_fp(blob: &[u8]) -> (String, String) {
+        use base64ct::{Base64, Encoding};
+        let blob_b64 = Base64::encode_string(blob);
+        let fp = super::fingerprint_from_key_blob_b64(&blob_b64).unwrap();
+        (blob_b64, fp)
+    }
+
+    // ---------- lookup() integration tests ----------
+
+    #[test]
+    fn lookup_match_plain_host() {
+        let (blob_b64, fp) = blob_and_fp(b"device-a-key");
+        let (_dir, path) = write_known_hosts(&[&format!("device-a.lab ssh-ed25519 {blob_b64}")]);
+        let out = super::lookup(&path, "device-a.lab", 22, &fp).unwrap();
+        assert_eq!(out, super::LookupOutcome::Match);
+    }
+
+    #[test]
+    fn lookup_mismatch_returns_file_fp() {
+        let (blob_b64, file_fp) = blob_and_fp(b"on-file-key");
+        let (_, server_fp) = blob_and_fp(b"different-key-from-server");
+        let (_dir, path) = write_known_hosts(&[&format!("device-a.lab ssh-ed25519 {blob_b64}")]);
+        let out = super::lookup(&path, "device-a.lab", 22, &server_fp).unwrap();
+        assert_eq!(out, super::LookupOutcome::Mismatch { file_fp });
+    }
+
+    #[test]
+    fn lookup_not_found_when_host_absent() {
+        let (blob_b64, _fp) = blob_and_fp(b"someone-elses-key");
+        let (_dir, path) = write_known_hosts(&[&format!("device-a.lab ssh-ed25519 {blob_b64}")]);
+        let out = super::lookup(&path, "device-b.lab", 22, "SHA256:anything").unwrap();
+        assert_eq!(out, super::LookupOutcome::NotFound);
+    }
+
+    #[test]
+    fn lookup_revoked_takes_precedence_over_match() {
+        // Even if a non-revoked match exists, an @revoked entry for the same
+        // host must fail closed.
+        let (blob_b64, fp) = blob_and_fp(b"compromised-key");
+        let (_dir, path) = write_known_hosts(&[
+            &format!("device-a.lab ssh-ed25519 {blob_b64}"),
+            &format!("@revoked device-a.lab ssh-ed25519 {blob_b64}"),
+        ]);
+        let out = super::lookup(&path, "device-a.lab", 22, &fp).unwrap();
+        assert_eq!(out, super::LookupOutcome::Revoked);
+    }
+
+    #[test]
+    fn lookup_multiple_key_types_accepts_if_any_matches() {
+        // Device advertises ssh-rsa OR ssh-ed25519 keys; whichever the
+        // server presents, we should accept.
+        let (rsa_blob, _rsa_fp) = blob_and_fp(b"the-rsa-key");
+        let (ed_blob, ed_fp) = blob_and_fp(b"the-ed25519-key");
+        let (_dir, path) = write_known_hosts(&[
+            &format!("device-a.lab ssh-rsa {rsa_blob}"),
+            &format!("device-a.lab ssh-ed25519 {ed_blob}"),
+        ]);
+        let out = super::lookup(&path, "device-a.lab", 22, &ed_fp).unwrap();
+        assert_eq!(out, super::LookupOutcome::Match);
+    }
+
+    #[test]
+    fn lookup_io_error_on_missing_file() {
+        let path = std::path::PathBuf::from("/nonexistent/path/to/known_hosts");
+        let err = super::lookup(&path, "h", 22, "SHA256:x").unwrap_err();
+        assert!(
+            matches!(err, super::KnownHostsError::Io(_)),
+            "expected Io error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn lookup_skips_blank_and_comment_lines() {
+        let (blob_b64, fp) = blob_and_fp(b"key");
+        let (_dir, path) = write_known_hosts(&[
+            "",
+            "# comment",
+            "   ",
+            &format!("device-a.lab ssh-ed25519 {blob_b64}"),
+        ]);
+        let out = super::lookup(&path, "device-a.lab", 22, &fp).unwrap();
+        assert_eq!(out, super::LookupOutcome::Match);
+    }
+
+    // ---------- parse-line tests ----------
+
+    #[test]
+    fn parse_line_blank_and_comment_yield_none() {
+        assert!(super::parse_line("", 1).unwrap().is_none());
+        assert!(super::parse_line("   ", 1).unwrap().is_none());
+        assert!(super::parse_line("# this is a comment", 1).unwrap().is_none());
+        assert!(super::parse_line("   # indented comment", 1).unwrap().is_none());
+    }
+
+    #[test]
+    fn parse_line_malformed_returns_error() {
+        // Missing key type and blob.
+        let err = super::parse_line("just-a-hostname", 7).unwrap_err();
+        match err {
+            super::KnownHostsError::Parse { line, reason } => {
+                assert_eq!(line, 7);
+                assert!(reason.contains("key type"), "reason was {reason:?}");
+            }
+            other => panic!("expected Parse error, got {other:?}"),
+        }
+        // Missing key blob.
+        let err = super::parse_line("host ssh-rsa", 3).unwrap_err();
+        assert!(matches!(err, super::KnownHostsError::Parse { line: 3, .. }));
+    }
+
+    #[test]
+    fn parse_line_host_port_form() {
+        // OpenSSH convention: [host]:port for any non-default port.
+        let line = "[192.168.1.10]:830 ssh-ed25519 AAAAblob";
+        let entry = super::parse_line(line, 1).unwrap().unwrap();
+        assert!(entry.host_matches("192.168.1.10", 830));
+        // Same host, different port — must not match.
+        assert!(!entry.host_matches("192.168.1.10", 22));
+        // Different host — must not match.
+        assert!(!entry.host_matches("192.168.1.11", 830));
+    }
+
+    #[test]
+    fn parse_line_wildcard_star_and_question() {
+        // `*` matches any run of characters, `?` matches exactly one.
+        let line = "*.lab.example.org ssh-ed25519 AAAAblob";
+        let entry = super::parse_line(line, 1).unwrap().unwrap();
+        assert!(entry.host_matches("a.lab.example.org", 22));
+        assert!(entry.host_matches("longer.lab.example.org", 22));
+        assert!(!entry.host_matches("lab.example.org", 22), "literal '.' in pattern must match");
+        assert!(!entry.host_matches("a.other.example.org", 22));
+
+        let line = "device?.lab ssh-ed25519 AAAAblob";
+        let entry = super::parse_line(line, 1).unwrap().unwrap();
+        assert!(entry.host_matches("device1.lab", 22));
+        assert!(entry.host_matches("deviceX.lab", 22));
+        assert!(!entry.host_matches("device.lab", 22));
+        assert!(!entry.host_matches("device12.lab", 22));
+    }
+
+    #[test]
+    fn entry_fingerprint_matches_russh_format() {
+        // The fingerprint we compute for an entry must match what russh produces
+        // for the server's public key: SHA-256 over the wire-format blob,
+        // base64-encoded (no padding), prefixed with "SHA256:".
+        //
+        // Verifiable cross-tool: ssh-keygen -lf prints the same hash for the
+        // same blob. Test with a fixed 32-byte blob to keep the expectation
+        // deterministic.
+        let blob = b"hello world for fingerprint test";
+        // sha256("hello world for fingerprint test"), unpadded base64:
+        let expected = "SHA256:Y8DAbifEb7qz0xN/BjIW76kakks+3wR5SjMdPrQhNpE";
+        use base64ct::{Base64, Encoding};
+        let blob_b64 = Base64::encode_string(blob);
+        let fp = super::fingerprint_from_key_blob_b64(&blob_b64).expect("computes");
+        assert_eq!(fp, expected);
+    }
+
+    #[test]
+    fn parse_line_revoked_marker() {
+        let line = "@revoked device-a.lab ssh-ed25519 AAAAblob";
+        let entry = super::parse_line(line, 1).unwrap().unwrap();
+        assert_eq!(entry.marker, Some(super::Marker::Revoked));
+        assert!(entry.host_matches("device-a.lab", 22));
+    }
+
+    #[test]
+    fn parse_line_cert_authority_marker_is_skipped() {
+        // We don't implement @cert-authority (SSH certs) — but a line with
+        // that marker must not crash the parser; we treat it as skipped.
+        let line = "@cert-authority *.example.com ssh-rsa AAAAblob";
+        // For now, accept the line by reporting None (skip semantics) OR a
+        // parse error. We pick "skip with a debug log" — return Ok(None).
+        let res = super::parse_line(line, 1).unwrap();
+        assert!(res.is_none(), "cert-authority lines must be skipped");
+    }
+
+    #[test]
+    fn parse_line_hashed_entry_matches_host() {
+        // OpenSSH `HashKnownHosts yes` format: |1|<base64-salt>|<base64-hmac-sha1>
+        // Computed offline: salt = b"aaaabbbbccccddddeeee", host = "device-a.lab".
+        let line = "|1|YWFhYWJiYmJjY2NjZGRkZGVlZWU=|rxu231q7p1LEiU6fuhmWDfkVu9I= \
+                    ssh-ed25519 AAAAblob";
+        let entry = super::parse_line(line, 1).unwrap().unwrap();
+        assert!(entry.host_matches("device-a.lab", 22));
+        assert!(!entry.host_matches("device-b.lab", 22));
+    }
+
+    #[test]
+    fn parse_line_cidr_ipv4() {
+        let line = "10.0.0.0/8 ssh-ed25519 AAAAblob";
+        let entry = super::parse_line(line, 1).unwrap().unwrap();
+        assert!(entry.host_matches("10.0.0.1", 22));
+        assert!(entry.host_matches("10.255.255.255", 22));
+        assert!(!entry.host_matches("11.0.0.1", 22));
+        assert!(!entry.host_matches("192.168.1.1", 22));
+        // Non-IP hosts must not match a CIDR pattern.
+        assert!(!entry.host_matches("device.lab", 22));
+    }
+
+    #[test]
+    fn parse_line_cidr_ipv6() {
+        let line = "2001:db8::/32 ssh-ed25519 AAAAblob";
+        let entry = super::parse_line(line, 1).unwrap().unwrap();
+        assert!(entry.host_matches("2001:db8::1", 22));
+        assert!(entry.host_matches("2001:db8:cafe::1", 22));
+        assert!(!entry.host_matches("2001:db9::1", 22));
+    }
+
+    #[test]
+    fn parse_line_default_port_form_matches_port_22() {
+        // Plain hostname (no [host]:port) implicitly means default SSH port 22.
+        let line = "device.lab ssh-ed25519 AAAAblob";
+        let entry = super::parse_line(line, 1).unwrap().unwrap();
+        assert!(entry.host_matches("device.lab", 22));
+        // The pattern is hostname-only, so other ports also match it for
+        // backward compat with how OpenSSH treats plain entries (port-agnostic).
+        assert!(entry.host_matches("device.lab", 830));
+    }
+
+    #[test]
+    fn parse_line_comma_separated_hosts() {
+        let line = "a.lab,b.lab,c.lab ssh-ed25519 AAAAblob";
+        let entry = super::parse_line(line, 1).unwrap().unwrap();
+        assert!(entry.host_matches("a.lab", 22));
+        assert!(entry.host_matches("b.lab", 22));
+        assert!(entry.host_matches("c.lab", 22));
+        assert!(!entry.host_matches("d.lab", 22));
+    }
+}

--- a/src/transport/known_hosts.rs
+++ b/src/transport/known_hosts.rs
@@ -139,7 +139,13 @@ impl CidrNet {
             return false;
         };
         match (self, addr) {
-            (CidrNet::V4 { network, prefix_len }, IpAddr::V4(v4)) => {
+            (
+                CidrNet::V4 {
+                    network,
+                    prefix_len,
+                },
+                IpAddr::V4(v4),
+            ) => {
                 let bits = u32::from(v4);
                 let mask = if *prefix_len == 0 {
                     0
@@ -148,7 +154,13 @@ impl CidrNet {
                 };
                 (bits & mask) == (*network & mask)
             }
-            (CidrNet::V6 { network, prefix_len }, IpAddr::V6(v6)) => {
+            (
+                CidrNet::V6 {
+                    network,
+                    prefix_len,
+                },
+                IpAddr::V6(v6),
+            ) => {
                 let bits = u128::from(v6);
                 let mask = if *prefix_len == 0 {
                     0
@@ -451,7 +463,9 @@ mod tests {
         // A single plain-hostname entry; the line should parse and the host
         // pattern should match exactly.
         let line = "device-a.lab ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExampleKeyBlobForTesting";
-        let entry = super::parse_line(line, 1).expect("parses").expect("not blank");
+        let entry = super::parse_line(line, 1)
+            .expect("parses")
+            .expect("not blank");
         assert!(entry.host_matches("device-a.lab", 22));
         assert!(!entry.host_matches("device-b.lab", 22));
     }
@@ -563,8 +577,12 @@ mod tests {
     fn parse_line_blank_and_comment_yield_none() {
         assert!(super::parse_line("", 1).unwrap().is_none());
         assert!(super::parse_line("   ", 1).unwrap().is_none());
-        assert!(super::parse_line("# this is a comment", 1).unwrap().is_none());
-        assert!(super::parse_line("   # indented comment", 1).unwrap().is_none());
+        assert!(super::parse_line("# this is a comment", 1)
+            .unwrap()
+            .is_none());
+        assert!(super::parse_line("   # indented comment", 1)
+            .unwrap()
+            .is_none());
     }
 
     #[test]
@@ -602,7 +620,10 @@ mod tests {
         let entry = super::parse_line(line, 1).unwrap().unwrap();
         assert!(entry.host_matches("a.lab.example.org", 22));
         assert!(entry.host_matches("longer.lab.example.org", 22));
-        assert!(!entry.host_matches("lab.example.org", 22), "literal '.' in pattern must match");
+        assert!(
+            !entry.host_matches("lab.example.org", 22),
+            "literal '.' in pattern must match"
+        );
         assert!(!entry.host_matches("a.other.example.org", 22));
 
         let line = "device?.lab ssh-ed25519 AAAAblob";

--- a/src/transport/known_hosts.rs
+++ b/src/transport/known_hosts.rs
@@ -21,6 +21,10 @@ use std::path::Path;
 #[derive(Debug, Clone)]
 pub(crate) struct Entry {
     pub host_spec: HostSpec,
+    /// SSH key type label (e.g. `ssh-ed25519`, `ssh-rsa`). Parsed and validated
+    /// during line parsing but not currently used at lookup time — the
+    /// fingerprint comparison subsumes it.
+    #[allow(dead_code)]
     pub key_type: String,
     pub key_blob_b64: String,
     pub marker: Option<Marker>,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -6,6 +6,7 @@
 //! - Transports are independently testable
 //! - Future transports (TLS, RESTCONF) plug in without reimplementing framing
 
+pub mod known_hosts;
 pub mod ssh;
 #[cfg(feature = "tls")]
 pub mod tls;

--- a/src/transport/ssh.rs
+++ b/src/transport/ssh.rs
@@ -87,6 +87,27 @@ pub enum HostKeyVerification {
     ///
     /// Also useful in tests to exercise error paths.
     RejectAll,
+
+    /// Validate the device's host key against entries in an OpenSSH-format
+    /// `known_hosts` file.
+    ///
+    /// On connect, the host (and port if non-default) is looked up in the
+    /// file. A SHA-256 fingerprint match accepts the key; mismatch, missing
+    /// entry, or `@revoked` marker fails closed with a structured
+    /// [`crate::error::TransportError`] variant
+    /// ([`HostKeyMismatch`](crate::error::TransportError::HostKeyMismatch),
+    /// [`HostKeyNotInKnownHosts`](crate::error::TransportError::HostKeyNotInKnownHosts),
+    /// or [`HostKeyRevoked`](crate::error::TransportError::HostKeyRevoked)).
+    ///
+    /// Supported file features: plain hostnames, comma-separated host lists,
+    /// `[host]:port` form, wildcards (`*`, `?`), CIDR networks, hashed
+    /// entries (`|1|salt|hmac`), and `@revoked` markers. Pre-populate with
+    /// `ssh-keyscan -t ed25519,rsa,ecdsa <host>` (add `-H` for hashed,
+    /// `-p <port>` for non-default ports).
+    ///
+    /// `@cert-authority` lines are silently skipped (SSH host certs not yet
+    /// supported).
+    KnownHosts(std::path::PathBuf),
 }
 
 /// Configuration for establishing an SSH transport.
@@ -138,9 +159,39 @@ pub struct JumpHostConfig {
     pub host_key_verification: HostKeyVerification,
 }
 
+/// Slot for surfacing structured host-key errors from inside the russh
+/// callback to the outer `connect()` call.
+///
+/// `check_server_key` can only return `Result<bool, russh::Error>` — there's
+/// no way to thread our own error type through. When `KnownHosts` policy
+/// rejects, we record the structured error here; after `client::connect`
+/// fails with a generic auth/key error, the caller swaps in this error.
+#[derive(Clone, Default)]
+struct HostKeyErrorSlot(Arc<std::sync::Mutex<Option<TransportError>>>);
+
+impl HostKeyErrorSlot {
+    fn set(&self, err: TransportError) {
+        if let Ok(mut guard) = self.0.lock() {
+            *guard = Some(err);
+        }
+    }
+
+    fn take(&self) -> Option<TransportError> {
+        self.0.lock().ok().and_then(|mut g| g.take())
+    }
+}
+
 /// Internal SSH client handler for russh callbacks.
 struct SshHandler {
     host_key_verification: HostKeyVerification,
+    /// Host this handler is verifying — used for known_hosts lookup and
+    /// for structured error messages.
+    host: String,
+    port: u16,
+    /// Shared slot to surface structured rejection errors back to the
+    /// outer connect call. Cloned `Arc` so it's visible after the handler
+    /// is moved into `client::connect`.
+    error_slot: HostKeyErrorSlot,
 }
 
 impl client::Handler for SshHandler {
@@ -153,24 +204,25 @@ impl client::Handler for SshHandler {
         let fingerprint = server_public_key
             .fingerprint(keys::HashAlg::Sha256)
             .to_string();
-        let allowed = evaluate_host_key_policy(&self.host_key_verification, &fingerprint);
-        match &self.host_key_verification {
+        let allowed = match &self.host_key_verification {
             HostKeyVerification::AcceptAll => {
                 tracing::warn!(
                     "accepting SSH host key without verification — \
                      set host_key_verification() for production use"
                 );
+                true
             }
-            HostKeyVerification::Fingerprint(expected) if allowed => {
-                tracing::debug!("SSH host key fingerprint verified");
-                let _ = expected;
-            }
-            HostKeyVerification::Fingerprint(expected) => {
-                tracing::error!(
-                    expected = %expected,
-                    actual = %fingerprint,
-                    "SSH host key fingerprint mismatch — possible MITM attack"
-                );
+            HostKeyVerification::Fingerprint(_) => {
+                let ok = evaluate_host_key_policy(&self.host_key_verification, &fingerprint);
+                if ok {
+                    tracing::debug!("SSH host key fingerprint verified");
+                } else {
+                    tracing::error!(
+                        actual = %fingerprint,
+                        "SSH host key fingerprint mismatch — possible MITM attack"
+                    );
+                }
+                ok
             }
             HostKeyVerification::RejectAll => {
                 tracing::error!(
@@ -179,9 +231,90 @@ impl client::Handler for SshHandler {
                      Pin the device's fingerprint with HostKeyVerification::Fingerprint \
                      or explicitly opt in to HostKeyVerification::AcceptAll for lab use."
                 );
+                false
             }
-        }
+            HostKeyVerification::KnownHosts(path) => {
+                match crate::transport::known_hosts::lookup(
+                    path,
+                    &self.host,
+                    self.port,
+                    &fingerprint,
+                ) {
+                    Ok(outcome) => {
+                        let res = known_hosts_outcome_to_result(
+                            outcome,
+                            &self.host,
+                            self.port,
+                            path,
+                            &fingerprint,
+                        );
+                        match res {
+                            Ok(()) => {
+                                tracing::debug!(
+                                    file = %path.display(),
+                                    "SSH host key verified via known_hosts"
+                                );
+                                true
+                            }
+                            Err(err) => {
+                                tracing::error!(
+                                    file = %path.display(),
+                                    host = %self.host,
+                                    error = %err,
+                                    "SSH host key rejected by known_hosts policy"
+                                );
+                                self.error_slot.set(err);
+                                false
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        // I/O or unrecoverable error reading the file.
+                        let transport_err = TransportError::Io(std::io::Error::other(format!(
+                            "known_hosts file {path}: {err}",
+                            path = path.display()
+                        )));
+                        tracing::error!(
+                            file = %path.display(),
+                            error = %err,
+                            "could not read known_hosts file — failing closed"
+                        );
+                        self.error_slot.set(transport_err);
+                        false
+                    }
+                }
+            }
+        };
         std::future::ready(Ok(allowed))
+    }
+}
+
+/// Convert a `known_hosts::LookupOutcome` into either `Ok(())` (accept) or a
+/// structured [`TransportError`] (reject). Pure — no I/O — so the mapping is
+/// unit-testable.
+fn known_hosts_outcome_to_result(
+    outcome: crate::transport::known_hosts::LookupOutcome,
+    host: &str,
+    port: u16,
+    path: &Path,
+    actual_fp: &str,
+) -> Result<(), TransportError> {
+    use crate::transport::known_hosts::LookupOutcome;
+    match outcome {
+        LookupOutcome::Match => Ok(()),
+        LookupOutcome::Mismatch { file_fp } => Err(TransportError::HostKeyMismatch {
+            host: host.to_string(),
+            expected: file_fp,
+            actual: actual_fp.to_string(),
+        }),
+        LookupOutcome::NotFound => Err(TransportError::HostKeyNotInKnownHosts {
+            host: host.to_string(),
+            port,
+            path: path.display().to_string(),
+        }),
+        LookupOutcome::Revoked => Err(TransportError::HostKeyRevoked {
+            host: host.to_string(),
+        }),
     }
 }
 
@@ -196,6 +329,7 @@ impl client::Handler for SshHandler {
 /// prefix on the expected side.
 fn evaluate_host_key_policy(policy: &HostKeyVerification, actual_fingerprint: &str) -> bool {
     match policy {
+        HostKeyVerification::KnownHosts(_) => false,
         HostKeyVerification::AcceptAll => true,
         HostKeyVerification::RejectAll => false,
         HostKeyVerification::Fingerprint(expected) => {
@@ -455,16 +589,24 @@ impl SshTransport {
 
         for (idx, hop) in config.jump_hosts.iter().enumerate() {
             let label = format!("jump-host {} ({}:{})", idx, hop.host, hop.port);
+            let slot = HostKeyErrorSlot::default();
             let handle = match prev {
                 None => {
                     // First hop: direct TCP connection.
                     let handler = SshHandler {
                         host_key_verification: hop.host_key_verification.clone(),
+                        host: hop.host.clone(),
+                        port: hop.port,
+                        error_slot: slot.clone(),
                     };
                     client::connect(russh_config.clone(), (&*hop.host, hop.port), handler)
                         .await
                         .map_err(|e| {
-                            TransportError::Connect(format!("SSH connect to {label} failed: {e}"))
+                            slot.take().unwrap_or_else(|| {
+                                TransportError::Connect(format!(
+                                    "SSH connect to {label} failed: {e}"
+                                ))
+                            })
                         })?
                 }
                 Some(parent) => {
@@ -478,13 +620,18 @@ impl SshTransport {
                     let stream = channel.into_stream();
                     let handler = SshHandler {
                         host_key_verification: hop.host_key_verification.clone(),
+                        host: hop.host.clone(),
+                        port: hop.port,
+                        error_slot: slot.clone(),
                     };
                     client::connect_stream(russh_config.clone(), stream, handler)
                         .await
                         .map_err(|e| {
-                            TransportError::Connect(format!(
-                                "SSH handshake with {label} failed: {e}"
-                            ))
+                            slot.take().unwrap_or_else(|| {
+                                TransportError::Connect(format!(
+                                    "SSH handshake with {label} failed: {e}"
+                                ))
+                            })
                         })?
                 }
             };
@@ -514,18 +661,24 @@ impl SshTransport {
         //   3. otherwise → direct TCP connection to the target
         let target_label = format!("{}:{}", config.host, config.port);
         let mut proxy_process: Option<Child> = None;
+        let target_slot = HostKeyErrorSlot::default();
         let mut handle = if let Some(cmd) = config.proxy_command.as_deref() {
             let (stream, child) = spawn_proxy_command(cmd, &config.host, config.port)?;
             proxy_process = Some(child);
             let handler = SshHandler {
                 host_key_verification: config.host_key_verification.clone(),
+                host: config.host.clone(),
+                port: config.port,
+                error_slot: target_slot.clone(),
             };
             client::connect_stream(russh_config.clone(), stream, handler)
                 .await
                 .map_err(|e| {
-                    TransportError::Connect(format!(
-                        "SSH handshake with target {target_label} (via ProxyCommand) failed: {e}"
-                    ))
+                    target_slot.take().unwrap_or_else(|| {
+                        TransportError::Connect(format!(
+                            "SSH handshake with target {target_label} (via ProxyCommand) failed: {e}"
+                        ))
+                    })
                 })?
         } else if let Some(parent) = jump_handles.last() {
             let channel = parent
@@ -539,22 +692,34 @@ impl SshTransport {
             let stream = channel.into_stream();
             let handler = SshHandler {
                 host_key_verification: config.host_key_verification.clone(),
+                host: config.host.clone(),
+                port: config.port,
+                error_slot: target_slot.clone(),
             };
             client::connect_stream(russh_config.clone(), stream, handler)
                 .await
                 .map_err(|e| {
-                    TransportError::Connect(format!(
-                        "SSH handshake with target {target_label} failed: {e}"
-                    ))
+                    target_slot.take().unwrap_or_else(|| {
+                        TransportError::Connect(format!(
+                            "SSH handshake with target {target_label} failed: {e}"
+                        ))
+                    })
                 })?
         } else {
             let handler = SshHandler {
                 host_key_verification: config.host_key_verification.clone(),
+                host: config.host.clone(),
+                port: config.port,
+                error_slot: target_slot.clone(),
             };
             client::connect(russh_config.clone(), (&*config.host, config.port), handler)
                 .await
                 .map_err(|e| {
-                    TransportError::Connect(format!("SSH connect to {target_label} failed: {e}"))
+                    target_slot.take().unwrap_or_else(|| {
+                        TransportError::Connect(format!(
+                            "SSH connect to {target_label} failed: {e}"
+                        ))
+                    })
                 })?
         };
 
@@ -912,5 +1077,92 @@ mod tests {
         let policy = HostKeyVerification::Fingerprint("SHA256:abc123".to_string());
         assert!(!evaluate_host_key_policy(&policy, "SHA256:def456"));
         assert!(!evaluate_host_key_policy(&policy, ""));
+    }
+
+    #[test]
+    fn host_key_policy_known_hosts_defers_to_file_lookup_returns_false_here() {
+        // evaluate_host_key_policy is pure (no I/O) — for KnownHosts the
+        // actual decision happens in the handler via known_hosts::lookup().
+        // The pure function must NOT accept on its own.
+        let policy = HostKeyVerification::KnownHosts(std::path::PathBuf::from("/tmp/x"));
+        assert!(!evaluate_host_key_policy(&policy, "SHA256:abc"));
+    }
+
+    #[test]
+    fn known_hosts_outcome_to_error_match_is_ok() {
+        use crate::transport::known_hosts::LookupOutcome;
+        let res = known_hosts_outcome_to_result(
+            LookupOutcome::Match,
+            "device-a.lab",
+            22,
+            std::path::Path::new("/etc/known_hosts"),
+            "SHA256:abc",
+        );
+        assert!(res.is_ok(), "Match must produce Ok(())");
+    }
+
+    #[test]
+    fn known_hosts_outcome_to_error_mismatch_yields_host_key_mismatch() {
+        use crate::error::TransportError;
+        use crate::transport::known_hosts::LookupOutcome;
+        let err = known_hosts_outcome_to_result(
+            LookupOutcome::Mismatch {
+                file_fp: "SHA256:OLD".into(),
+            },
+            "device-a.lab",
+            22,
+            std::path::Path::new("/etc/known_hosts"),
+            "SHA256:NEW",
+        )
+        .unwrap_err();
+        match err {
+            TransportError::HostKeyMismatch {
+                host,
+                expected,
+                actual,
+            } => {
+                assert_eq!(host, "device-a.lab");
+                assert_eq!(expected, "SHA256:OLD");
+                assert_eq!(actual, "SHA256:NEW");
+            }
+            other => panic!("expected HostKeyMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn known_hosts_outcome_to_error_not_found_yields_not_in_known_hosts() {
+        use crate::error::TransportError;
+        use crate::transport::known_hosts::LookupOutcome;
+        let err = known_hosts_outcome_to_result(
+            LookupOutcome::NotFound,
+            "device-a.lab",
+            830,
+            std::path::Path::new("/etc/known_hosts"),
+            "SHA256:any",
+        )
+        .unwrap_err();
+        match err {
+            TransportError::HostKeyNotInKnownHosts { host, port, path } => {
+                assert_eq!(host, "device-a.lab");
+                assert_eq!(port, 830);
+                assert_eq!(path, "/etc/known_hosts");
+            }
+            other => panic!("expected HostKeyNotInKnownHosts, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn known_hosts_outcome_to_error_revoked_yields_host_key_revoked() {
+        use crate::error::TransportError;
+        use crate::transport::known_hosts::LookupOutcome;
+        let err = known_hosts_outcome_to_result(
+            LookupOutcome::Revoked,
+            "device-a.lab",
+            22,
+            std::path::Path::new("/etc/known_hosts"),
+            "SHA256:bad",
+        )
+        .unwrap_err();
+        assert!(matches!(err, TransportError::HostKeyRevoked { host } if host == "device-a.lab"));
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,86 @@
+//! Shared helpers for live-device integration tests.
+//!
+//! These tests are **opt-in**: they only run when the
+//! `RUSTNETCONF_TEST_VSRX_HOST` environment variable is set. Without it,
+//! each test calls [`skip_unless_vsrx_configured`] which returns `None`
+//! and the test early-returns as a no-op.
+//!
+//! ## Configuration
+//!
+//! | Env var | Required | Default | Notes |
+//! |---|---|---|---|
+//! | `RUSTNETCONF_TEST_VSRX_HOST` | yes | — | e.g. `192.168.1.227:830` |
+//! | `RUSTNETCONF_TEST_VSRX_USER` | no | `srxoutpost` | Junos username |
+//! | `RUSTNETCONF_TEST_VSRX_KEY` | no | `$HOME/.ssh/id_ed25519` | SSH private key path |
+//!
+//! ## Examples
+//!
+//! ```sh
+//! # Run all integration tests against VM114 (CI-tester-vSRX):
+//! RUSTNETCONF_TEST_VSRX_HOST=192.168.1.227:830 cargo test --test integration_vsrx
+//!
+//! # Use a different SSH key and user:
+//! RUSTNETCONF_TEST_VSRX_HOST=10.0.0.1:830 \
+//!     RUSTNETCONF_TEST_VSRX_USER=netconf \
+//!     RUSTNETCONF_TEST_VSRX_KEY=~/.ssh/netconf_ed25519 \
+//!     cargo test --test integration_vendor_pool
+//! ```
+
+#![allow(dead_code)] // each integration_*.rs file uses a different subset
+
+/// Resolved coordinates for a live vSRX test target.
+pub struct VsrxTarget {
+    pub host: String,
+    pub username: String,
+    pub key_path: String,
+}
+
+impl VsrxTarget {
+    /// `host:port` string suitable for [`rustnetconf::Client::connect`].
+    pub fn endpoint(&self) -> &str {
+        &self.host
+    }
+}
+
+/// Returns `Some(VsrxTarget)` when `RUSTNETCONF_TEST_VSRX_HOST` is set,
+/// otherwise `None`. Tests should early-return on `None` so the suite is a
+/// no-op for contributors without a lab device.
+pub fn vsrx_target() -> Option<VsrxTarget> {
+    let host = std::env::var("RUSTNETCONF_TEST_VSRX_HOST").ok()?;
+    let username =
+        std::env::var("RUSTNETCONF_TEST_VSRX_USER").unwrap_or_else(|_| "srxoutpost".to_string());
+    let key_path = std::env::var("RUSTNETCONF_TEST_VSRX_KEY").unwrap_or_else(|_| {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/mharman".to_string());
+        format!("{home}/.ssh/id_ed25519")
+    });
+    Some(VsrxTarget {
+        host,
+        username,
+        key_path,
+    })
+}
+
+/// Convenience for tests that just need to bail when no device is configured.
+///
+/// Use at the top of a test:
+/// ```ignore
+/// let target = match common::skip_unless_vsrx_configured() {
+///     Some(t) => t,
+///     None => return,
+/// };
+/// ```
+pub fn skip_unless_vsrx_configured() -> Option<VsrxTarget> {
+    vsrx_target()
+}
+
+/// Split a `host:port` endpoint into its parts. Useful when a test needs to
+/// poke a *different* port on the same host (e.g. testing connection-refused
+/// against a closed port on the live device).
+pub fn split_host_port(endpoint: &str) -> (&str, u16) {
+    if let Some((host, port_str)) = endpoint.rsplit_once(':') {
+        if let Ok(port) = port_str.parse::<u16>() {
+            return (host, port);
+        }
+    }
+    (endpoint, 830)
+}

--- a/tests/integration_vendor_pool.rs
+++ b/tests/integration_vendor_pool.rs
@@ -44,7 +44,9 @@ fn vsrx_device_config(target: &VsrxTarget) -> DeviceConfig {
 /// vSRX is auto-detected as Junos vendor.
 #[tokio::test]
 async fn test_vsrx_auto_detected_as_junos() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let client = connect_vsrx(&target).await;
     assert_eq!(client.vendor_name(), "junos");
@@ -53,7 +55,9 @@ async fn test_vsrx_auto_detected_as_junos() {
 /// edit-config with Junos auto-wrapping — bare config gets <configuration> added.
 #[tokio::test]
 async fn test_edit_config_with_junos_auto_wrap() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
     assert_eq!(client.vendor_name(), "junos");
@@ -95,7 +99,9 @@ async fn test_edit_config_with_junos_auto_wrap() {
 /// get-config with Junos unwrapping strips <configuration> wrapper.
 #[tokio::test]
 async fn test_get_config_junos_unwrap() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
 
@@ -122,7 +128,9 @@ async fn test_get_config_junos_unwrap() {
 /// Pool checkout + use + auto-checkin.
 #[tokio::test]
 async fn test_pool_checkout_and_use() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let pool = DevicePool::builder()
         .max_connections(5)
@@ -148,7 +156,9 @@ async fn test_pool_checkout_and_use() {
 /// Pool reuses connections on second checkout.
 #[tokio::test]
 async fn test_pool_connection_reuse() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let pool = DevicePool::builder()
         .max_connections(5)
@@ -178,7 +188,9 @@ async fn test_pool_connection_reuse() {
 /// Pool returns error for unknown device.
 #[tokio::test]
 async fn test_pool_unknown_device() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let pool = DevicePool::builder()
         .max_connections(5)
@@ -192,7 +204,9 @@ async fn test_pool_unknown_device() {
 /// Pool checkout times out when all connections in use.
 #[tokio::test]
 async fn test_pool_checkout_timeout() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let pool = DevicePool::builder()
         .max_connections(1)
@@ -211,7 +225,9 @@ async fn test_pool_checkout_timeout() {
 /// Concurrent pool checkouts to same device.
 #[tokio::test]
 async fn test_pool_concurrent_checkouts() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let pool = DevicePool::builder()
         .max_connections(3)
@@ -239,7 +255,9 @@ async fn test_pool_concurrent_checkouts() {
 /// Pool auto-detects Junos vendor on connections.
 #[tokio::test]
 async fn test_pool_auto_detects_vendor() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let pool = DevicePool::builder()
         .max_connections(5)

--- a/tests/integration_vendor_pool.rs
+++ b/tests/integration_vendor_pool.rs
@@ -1,38 +1,40 @@
 //! Integration tests for vendor profiles and connection pool against live vSRX.
 //!
-//! Run with: `cargo test --test integration_vendor_pool`
+//! Opt-in via `RUSTNETCONF_TEST_VSRX_HOST` — see `tests/common/mod.rs`.
+//!
+//! Run with:
+//! ```sh
+//! RUSTNETCONF_TEST_VSRX_HOST=192.168.1.227:830 \
+//!     cargo test --test integration_vendor_pool
+//! ```
 
+mod common;
+
+use common::VsrxTarget;
 use rustnetconf::pool::{DeviceConfig, DevicePool};
-use rustnetconf::transport::ssh::SshAuth;
+use rustnetconf::transport::ssh::{HostKeyVerification, SshAuth};
 use rustnetconf::{Client, Datastore};
 use std::time::Duration;
 
-fn should_skip() -> bool {
-    std::env::var("SKIP_INTEGRATION").is_ok()
-}
-
-fn resolve_key_path() -> String {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/mharman".to_string());
-    format!("{home}/.ssh/rustnetconf_test")
-}
-
-async fn connect_vsrx() -> Client {
-    Client::connect("192.168.1.226:830")
-        .username("rustnetconf")
-        .key_file(&resolve_key_path())
+async fn connect_vsrx(target: &VsrxTarget) -> Client {
+    Client::connect(target.endpoint())
+        .username(&target.username)
+        .key_file(&target.key_path)
+        .host_key_verification(HostKeyVerification::AcceptAll)
         .connect()
         .await
         .expect("failed to connect to vSRX")
 }
 
-fn vsrx_device_config() -> DeviceConfig {
+fn vsrx_device_config(target: &VsrxTarget) -> DeviceConfig {
     DeviceConfig {
-        host: "192.168.1.226:830".to_string(),
-        username: "rustnetconf".to_string(),
+        host: target.endpoint().to_string(),
+        username: target.username.clone(),
         auth: SshAuth::KeyFile {
-            path: resolve_key_path(),
+            path: target.key_path.clone(),
             passphrase: None,
         },
+        host_key_verification: Some(HostKeyVerification::AcceptAll),
         vendor: None,
     }
 }
@@ -42,22 +44,18 @@ fn vsrx_device_config() -> DeviceConfig {
 /// vSRX is auto-detected as Junos vendor.
 #[tokio::test]
 async fn test_vsrx_auto_detected_as_junos() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let client = connect_vsrx().await;
+    let client = connect_vsrx(&target).await;
     assert_eq!(client.vendor_name(), "junos");
 }
 
 /// edit-config with Junos auto-wrapping — bare config gets <configuration> added.
 #[tokio::test]
 async fn test_edit_config_with_junos_auto_wrap() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
     assert_eq!(client.vendor_name(), "junos");
 
     client
@@ -97,11 +95,9 @@ async fn test_edit_config_with_junos_auto_wrap() {
 /// get-config with Junos unwrapping strips <configuration> wrapper.
 #[tokio::test]
 async fn test_get_config_junos_unwrap() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     let config = client
         .get_config_filtered(
@@ -126,13 +122,11 @@ async fn test_get_config_junos_unwrap() {
 /// Pool checkout + use + auto-checkin.
 #[tokio::test]
 async fn test_pool_checkout_and_use() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
     let pool = DevicePool::builder()
         .max_connections(5)
-        .add_device("vsrx", vsrx_device_config())
+        .add_device("vsrx", vsrx_device_config(&target))
         .build();
 
     {
@@ -154,13 +148,11 @@ async fn test_pool_checkout_and_use() {
 /// Pool reuses connections on second checkout.
 #[tokio::test]
 async fn test_pool_connection_reuse() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
     let pool = DevicePool::builder()
         .max_connections(5)
-        .add_device("vsrx", vsrx_device_config())
+        .add_device("vsrx", vsrx_device_config(&target))
         .build();
 
     // First checkout + use + checkin
@@ -186,13 +178,11 @@ async fn test_pool_connection_reuse() {
 /// Pool returns error for unknown device.
 #[tokio::test]
 async fn test_pool_unknown_device() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
     let pool = DevicePool::builder()
         .max_connections(5)
-        .add_device("vsrx", vsrx_device_config())
+        .add_device("vsrx", vsrx_device_config(&target))
         .build();
 
     let result = pool.checkout("nonexistent").await;
@@ -202,14 +192,12 @@ async fn test_pool_unknown_device() {
 /// Pool checkout times out when all connections in use.
 #[tokio::test]
 async fn test_pool_checkout_timeout() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
     let pool = DevicePool::builder()
         .max_connections(1)
         .checkout_timeout(Duration::from_secs(2))
-        .add_device("vsrx", vsrx_device_config())
+        .add_device("vsrx", vsrx_device_config(&target))
         .build();
 
     // Hold a connection
@@ -223,13 +211,11 @@ async fn test_pool_checkout_timeout() {
 /// Concurrent pool checkouts to same device.
 #[tokio::test]
 async fn test_pool_concurrent_checkouts() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
     let pool = DevicePool::builder()
         .max_connections(3)
-        .add_device("vsrx", vsrx_device_config())
+        .add_device("vsrx", vsrx_device_config(&target))
         .build();
 
     // Checkout 2 connections concurrently
@@ -253,13 +239,11 @@ async fn test_pool_concurrent_checkouts() {
 /// Pool auto-detects Junos vendor on connections.
 #[tokio::test]
 async fn test_pool_auto_detects_vendor() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
     let pool = DevicePool::builder()
         .max_connections(5)
-        .add_device("vsrx", vsrx_device_config())
+        .add_device("vsrx", vsrx_device_config(&target))
         .build();
 
     let conn = pool.checkout("vsrx").await.expect("checkout failed");

--- a/tests/integration_vsrx.rs
+++ b/tests/integration_vsrx.rs
@@ -1,14 +1,22 @@
 //! Integration tests against a real Juniper vSRX.
 //!
-//! These tests require a running vSRX at 192.168.1.226 with NETCONF enabled
-//! and SSH key auth configured for user "rustnetconf".
+//! These tests are **opt-in**: they run only when the
+//! `RUSTNETCONF_TEST_VSRX_HOST` env var points at a reachable vSRX. See
+//! [`tests/common/mod.rs`] for the full env-var list. Without it, every
+//! test returns immediately as a no-op so the suite is friendly to
+//! contributors without a Junos lab.
 //!
-//! Run with: `cargo test --test integration_vsrx`
-//!
-//! Skip with: set env `SKIP_INTEGRATION=1` to skip these tests when no device
-//! is available.
+//! Run with:
+//! ```sh
+//! RUSTNETCONF_TEST_VSRX_HOST=192.168.1.227:830 \
+//!     cargo test --test integration_vsrx
+//! ```
 
+mod common;
+
+use common::VsrxTarget;
 use rustnetconf::error::NetconfError;
+use rustnetconf::transport::ssh::HostKeyVerification;
 use rustnetconf::{Client, Datastore, DefaultOperation};
 use tokio::sync::Mutex as TokioMutex;
 
@@ -17,22 +25,17 @@ use tokio::sync::Mutex as TokioMutex;
 static CANDIDATE_LOCK: std::sync::LazyLock<TokioMutex<()>> =
     std::sync::LazyLock::new(|| TokioMutex::new(()));
 
-/// Check if integration tests should be skipped.
-fn should_skip() -> bool {
-    std::env::var("SKIP_INTEGRATION").is_ok()
-}
-
-/// Resolve ~ in key path.
-fn resolve_key_path() -> String {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/home/mharman".to_string());
-    format!("{home}/.ssh/rustnetconf_test")
-}
-
-/// Create a connected client to the vSRX using key auth.
-async fn connect_vsrx() -> Client {
-    Client::connect("192.168.1.226:830")
-        .username("rustnetconf")
-        .key_file(&resolve_key_path())
+/// Create a connected client to the configured vSRX using key auth.
+///
+/// Uses `HostKeyVerification::AcceptAll` because the integration suite is
+/// designed for a transient lab device (VM114 / CI-tester-vSRX) whose host
+/// key may rotate on every reboot — pinning would only add CI churn here.
+/// Production users should pin via `Fingerprint(...)` or `KnownHosts(...)`.
+async fn connect_vsrx(target: &VsrxTarget) -> Client {
+    Client::connect(target.endpoint())
+        .username(&target.username)
+        .key_file(&target.key_path)
+        .host_key_verification(HostKeyVerification::AcceptAll)
         .connect()
         .await
         .expect("failed to connect to vSRX — is the device reachable?")
@@ -43,11 +46,9 @@ async fn connect_vsrx() -> Client {
 /// T34/T35: SSH connect + key auth, session establishment.
 #[tokio::test]
 async fn test_connect_and_hello() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     // Verify capabilities were negotiated
     let caps = client
@@ -67,14 +68,14 @@ async fn test_connect_and_hello() {
 /// T38: Connection refused — wrong port should fail with TransportError.
 #[tokio::test]
 async fn test_connection_refused() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    // Port 12345 should be unreachable
-    let result = Client::connect("192.168.1.226:12345")
-        .username("rustnetconf")
-        .key_file(&resolve_key_path())
+    // Port 12345 should be unreachable on the test device
+    let (host, _port) = common::split_host_port(target.endpoint());
+    let bogus_endpoint = format!("{host}:12345");
+    let result = Client::connect(&bogus_endpoint)
+        .username(&target.username)
+        .key_file(&target.key_path)
         .connect()
         .await;
 
@@ -88,13 +89,14 @@ async fn test_connection_refused() {
 /// T39: Auth failure — wrong credentials should fail with TransportError::Auth.
 #[tokio::test]
 async fn test_auth_failure() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let result = Client::connect("192.168.1.226:830")
-        .username("rustnetconf")
+    // We want to assert *auth* failure, so opt out of host-key checking — the
+    // default RejectAll would mask the auth error path we're testing.
+    let result = Client::connect(target.endpoint())
+        .username(&target.username)
         .password("definitely-wrong-password")
+        .host_key_verification(HostKeyVerification::AcceptAll)
         .connect()
         .await;
 
@@ -113,9 +115,10 @@ async fn test_auth_failure() {
 /// T38: Connection to unreachable host should fail with TransportError.
 #[tokio::test]
 async fn test_connection_unreachable_host() {
-    if should_skip() {
-        return;
-    }
+    // Still gated on opt-in env so this stays paired with the rest of the
+    // integration suite, but the test itself targets RFC 5737 TEST-NET-1
+    // rather than the configured device.
+    let Some(_target) = common::skip_unless_vsrx_configured() else { return; };
 
     // 192.0.2.1 is TEST-NET-1 (RFC 5737) — guaranteed unreachable
     let result = tokio::time::timeout(
@@ -141,11 +144,9 @@ async fn test_connection_unreachable_host() {
 /// T42: get-config round trip — fetch running config.
 #[tokio::test]
 async fn test_get_config_running() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     let config = client
         .get_config(Datastore::Running)
@@ -167,11 +168,9 @@ async fn test_get_config_running() {
 /// T42: get-config with subtree filter.
 #[tokio::test]
 async fn test_get_config_filtered() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     let config = client
         .get_config_filtered(
@@ -192,11 +191,9 @@ async fn test_get_config_filtered() {
 /// Get candidate config — should match running when no uncommitted changes.
 #[tokio::test]
 async fn test_get_config_candidate() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     let candidate = client
         .get_config(Datastore::Candidate)
@@ -219,11 +216,9 @@ async fn test_get_config_candidate() {
 /// Get-config with a filter that returns no data — should succeed with empty/minimal response.
 #[tokio::test]
 async fn test_get_config_empty_filter_result() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     // Filter for a specific element that almost certainly doesn't exist
     let config = client
@@ -246,12 +241,10 @@ async fn test_get_config_empty_filter_result() {
 /// T41: Full edit-config round trip — lock → edit → validate → commit → unlock.
 #[tokio::test]
 async fn test_edit_config_round_trip() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
     let _guard = CANDIDATE_LOCK.lock().await;
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     // Lock candidate
     client
@@ -312,12 +305,10 @@ async fn test_edit_config_round_trip() {
 /// Edit-config with replace operation — replaces entire subtree.
 #[tokio::test]
 async fn test_edit_config_replace() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
     let _guard = CANDIDATE_LOCK.lock().await;
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     client
         .lock(Datastore::Candidate)
@@ -366,12 +357,10 @@ async fn test_edit_config_replace() {
 /// Validate with intentionally invalid config — expect a structured RPC error.
 #[tokio::test]
 async fn test_edit_config_invalid_rejected() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
     let _guard = CANDIDATE_LOCK.lock().await;
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     client
         .lock(Datastore::Candidate)
@@ -408,20 +397,18 @@ async fn test_edit_config_invalid_rejected() {
 /// Lock contention — second lock on same datastore should fail with lock-denied.
 #[tokio::test]
 async fn test_lock_contention() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
     let _guard = CANDIDATE_LOCK.lock().await;
 
     // First client locks candidate
-    let mut client1 = connect_vsrx().await;
+    let mut client1 = connect_vsrx(&target).await;
     client1
         .lock(Datastore::Candidate)
         .await
         .expect("first lock should succeed");
 
     // Second client tries to lock the same datastore
-    let mut client2 = connect_vsrx().await;
+    let mut client2 = connect_vsrx(&target).await;
     let result = client2.lock(Datastore::Candidate).await;
 
     assert!(result.is_err(), "second lock should be denied");
@@ -444,12 +431,10 @@ async fn test_lock_contention() {
 /// Unlock without lock — should fail with an RPC error.
 #[tokio::test]
 async fn test_unlock_without_lock() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
     let _guard = CANDIDATE_LOCK.lock().await;
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     let result = client.unlock(Datastore::Candidate).await;
     assert!(result.is_err(), "unlock without lock should fail");
@@ -462,11 +447,9 @@ async fn test_unlock_without_lock() {
 /// T33: Operation after session closed should fail gracefully.
 #[tokio::test]
 async fn test_operation_after_close() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
     client.close_session().await.expect("close_session failed");
 
     // Attempting get-config on a closed session should error
@@ -477,11 +460,9 @@ async fn test_operation_after_close() {
 /// Double close-session should be idempotent — no panic, no error.
 #[tokio::test]
 async fn test_double_close_session() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
     client
         .close_session()
         .await
@@ -495,12 +476,10 @@ async fn test_double_close_session() {
 /// Multiple sequential RPCs on one session — verify message-id incrementing.
 #[tokio::test]
 async fn test_multiple_sequential_rpcs() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
     let _guard = CANDIDATE_LOCK.lock().await;
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     // Issue several RPCs in sequence on the same session
     let config1 = client
@@ -549,11 +528,9 @@ async fn test_multiple_sequential_rpcs() {
 /// T32: Capability-gated operations — commit requires :candidate.
 #[tokio::test]
 async fn test_capability_check() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let client = connect_vsrx().await;
+    let client = connect_vsrx(&target).await;
 
     // vSRX supports :candidate, so this should be true
     assert!(client.supports("urn:ietf:params:netconf:capability:candidate:1.0"));
@@ -570,11 +547,9 @@ async fn test_capability_check() {
 /// Verify all capability URIs are returned and non-empty.
 #[tokio::test]
 async fn test_capabilities_all_uris() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let client = connect_vsrx().await;
+    let client = connect_vsrx(&target).await;
 
     let caps = client.capabilities().expect("capabilities should exist");
     let uris = caps.all_uris();
@@ -600,11 +575,9 @@ async fn test_capabilities_all_uris() {
 /// T37: NETCONF subsystem channel — verify we get proper XML responses.
 #[tokio::test]
 async fn test_get_operational() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     // Junos uses subtree filters on <get> with the Junos operational namespace.
     let data = client
@@ -633,11 +606,9 @@ async fn test_get_operational() {
 /// Get without filter — should return all operational + config data.
 #[tokio::test]
 async fn test_get_unfiltered() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     let data = client.get(None).await.expect("unfiltered get failed");
 
@@ -656,12 +627,11 @@ async fn test_get_unfiltered() {
 /// Multiple independent sessions to the same device — no interference.
 #[tokio::test]
 async fn test_concurrent_sessions() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
     // Open two sessions simultaneously
-    let (mut client1, mut client2) = tokio::join!(connect_vsrx(), connect_vsrx(),);
+    let (mut client1, mut client2) =
+        tokio::join!(connect_vsrx(&target), connect_vsrx(&target));
 
     // Both should have different session IDs
     let id1 = client1.capabilities().unwrap().session_id().unwrap();
@@ -693,11 +663,9 @@ async fn test_concurrent_sessions() {
 /// Large config fetch — verify the framing layer handles multi-read responses.
 #[tokio::test]
 async fn test_large_config_payload() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     // Fetch the entire running config (unfiltered) — typically several KB on a vSRX
     let config = client
@@ -725,12 +693,10 @@ async fn test_large_config_payload() {
 /// Verify that RPC errors from the device include the structured error fields.
 #[tokio::test]
 async fn test_rpc_error_structure() {
-    if should_skip() {
-        return;
-    }
+    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
     let _guard = CANDIDATE_LOCK.lock().await;
 
-    let mut client = connect_vsrx().await;
+    let mut client = connect_vsrx(&target).await;
 
     client
         .lock(Datastore::Candidate)

--- a/tests/integration_vsrx.rs
+++ b/tests/integration_vsrx.rs
@@ -46,7 +46,9 @@ async fn connect_vsrx(target: &VsrxTarget) -> Client {
 /// T34/T35: SSH connect + key auth, session establishment.
 #[tokio::test]
 async fn test_connect_and_hello() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
 
@@ -68,7 +70,9 @@ async fn test_connect_and_hello() {
 /// T38: Connection refused — wrong port should fail with TransportError.
 #[tokio::test]
 async fn test_connection_refused() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     // Port 12345 should be unreachable on the test device
     let (host, _port) = common::split_host_port(target.endpoint());
@@ -89,7 +93,9 @@ async fn test_connection_refused() {
 /// T39: Auth failure — wrong credentials should fail with TransportError::Auth.
 #[tokio::test]
 async fn test_auth_failure() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     // We want to assert *auth* failure, so opt out of host-key checking — the
     // default RejectAll would mask the auth error path we're testing.
@@ -118,7 +124,9 @@ async fn test_connection_unreachable_host() {
     // Still gated on opt-in env so this stays paired with the rest of the
     // integration suite, but the test itself targets RFC 5737 TEST-NET-1
     // rather than the configured device.
-    let Some(_target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(_target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     // 192.0.2.1 is TEST-NET-1 (RFC 5737) — guaranteed unreachable
     let result = tokio::time::timeout(
@@ -144,7 +152,9 @@ async fn test_connection_unreachable_host() {
 /// T42: get-config round trip — fetch running config.
 #[tokio::test]
 async fn test_get_config_running() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
 
@@ -168,7 +178,9 @@ async fn test_get_config_running() {
 /// T42: get-config with subtree filter.
 #[tokio::test]
 async fn test_get_config_filtered() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
 
@@ -191,7 +203,9 @@ async fn test_get_config_filtered() {
 /// Get candidate config — should match running when no uncommitted changes.
 #[tokio::test]
 async fn test_get_config_candidate() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
 
@@ -216,7 +230,9 @@ async fn test_get_config_candidate() {
 /// Get-config with a filter that returns no data — should succeed with empty/minimal response.
 #[tokio::test]
 async fn test_get_config_empty_filter_result() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
 
@@ -241,7 +257,9 @@ async fn test_get_config_empty_filter_result() {
 /// T41: Full edit-config round trip — lock → edit → validate → commit → unlock.
 #[tokio::test]
 async fn test_edit_config_round_trip() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
     let _guard = CANDIDATE_LOCK.lock().await;
 
     let mut client = connect_vsrx(&target).await;
@@ -305,7 +323,9 @@ async fn test_edit_config_round_trip() {
 /// Edit-config with replace operation — replaces entire subtree.
 #[tokio::test]
 async fn test_edit_config_replace() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
     let _guard = CANDIDATE_LOCK.lock().await;
 
     let mut client = connect_vsrx(&target).await;
@@ -357,7 +377,9 @@ async fn test_edit_config_replace() {
 /// Validate with intentionally invalid config — expect a structured RPC error.
 #[tokio::test]
 async fn test_edit_config_invalid_rejected() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
     let _guard = CANDIDATE_LOCK.lock().await;
 
     let mut client = connect_vsrx(&target).await;
@@ -397,7 +419,9 @@ async fn test_edit_config_invalid_rejected() {
 /// Lock contention — second lock on same datastore should fail with lock-denied.
 #[tokio::test]
 async fn test_lock_contention() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
     let _guard = CANDIDATE_LOCK.lock().await;
 
     // First client locks candidate
@@ -431,7 +455,9 @@ async fn test_lock_contention() {
 /// Unlock without lock — should fail with an RPC error.
 #[tokio::test]
 async fn test_unlock_without_lock() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
     let _guard = CANDIDATE_LOCK.lock().await;
 
     let mut client = connect_vsrx(&target).await;
@@ -447,7 +473,9 @@ async fn test_unlock_without_lock() {
 /// T33: Operation after session closed should fail gracefully.
 #[tokio::test]
 async fn test_operation_after_close() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
     client.close_session().await.expect("close_session failed");
@@ -460,7 +488,9 @@ async fn test_operation_after_close() {
 /// Double close-session should be idempotent — no panic, no error.
 #[tokio::test]
 async fn test_double_close_session() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
     client
@@ -476,7 +506,9 @@ async fn test_double_close_session() {
 /// Multiple sequential RPCs on one session — verify message-id incrementing.
 #[tokio::test]
 async fn test_multiple_sequential_rpcs() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
     let _guard = CANDIDATE_LOCK.lock().await;
 
     let mut client = connect_vsrx(&target).await;
@@ -528,7 +560,9 @@ async fn test_multiple_sequential_rpcs() {
 /// T32: Capability-gated operations — commit requires :candidate.
 #[tokio::test]
 async fn test_capability_check() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let client = connect_vsrx(&target).await;
 
@@ -547,7 +581,9 @@ async fn test_capability_check() {
 /// Verify all capability URIs are returned and non-empty.
 #[tokio::test]
 async fn test_capabilities_all_uris() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let client = connect_vsrx(&target).await;
 
@@ -575,7 +611,9 @@ async fn test_capabilities_all_uris() {
 /// T37: NETCONF subsystem channel — verify we get proper XML responses.
 #[tokio::test]
 async fn test_get_operational() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
 
@@ -606,7 +644,9 @@ async fn test_get_operational() {
 /// Get without filter — should return all operational + config data.
 #[tokio::test]
 async fn test_get_unfiltered() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
 
@@ -627,11 +667,12 @@ async fn test_get_unfiltered() {
 /// Multiple independent sessions to the same device — no interference.
 #[tokio::test]
 async fn test_concurrent_sessions() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     // Open two sessions simultaneously
-    let (mut client1, mut client2) =
-        tokio::join!(connect_vsrx(&target), connect_vsrx(&target));
+    let (mut client1, mut client2) = tokio::join!(connect_vsrx(&target), connect_vsrx(&target));
 
     // Both should have different session IDs
     let id1 = client1.capabilities().unwrap().session_id().unwrap();
@@ -663,7 +704,9 @@ async fn test_concurrent_sessions() {
 /// Large config fetch — verify the framing layer handles multi-read responses.
 #[tokio::test]
 async fn test_large_config_payload() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
 
     let mut client = connect_vsrx(&target).await;
 
@@ -693,7 +736,9 @@ async fn test_large_config_payload() {
 /// Verify that RPC errors from the device include the structured error fields.
 #[tokio::test]
 async fn test_rpc_error_structure() {
-    let Some(target) = common::skip_unless_vsrx_configured() else { return; };
+    let Some(target) = common::skip_unless_vsrx_configured() else {
+        return;
+    };
     let _guard = CANDIDATE_LOCK.lock().await;
 
     let mut client = connect_vsrx(&target).await;


### PR DESCRIPTION
## Summary

Implements `HostKeyVerification::KnownHosts(PathBuf)` for OpenSSH-style host-key pinning across a fleet of devices, closing #28. Fail-closed behavior, no new compiled crates.

- **Parser** (`src/transport/known_hosts.rs`, hand-rolled): plain hosts, `[host]:port`, wildcards (`*`/`?`), CIDR networks, hashed entries (`|1|salt|hmac-sha1`), `@revoked` markers. `@cert-authority` lines skipped (out of scope per design discussion).
- **Transport** wiring (`src/transport/ssh.rs`): every connect path (jump-host head, chained, ProxyCommand, direct-tcpip, direct) carries an `Arc<Mutex<Option<TransportError>>>` slot so structured `HostKeyMismatch` / `HostKeyNotInKnownHosts` / `HostKeyRevoked` errors surface past russh's `Result<bool, russh::Error>` callback signature. File is re-read on every connect — no caching.
- **CLI inventory**: new optional `known_hosts_path` field at `[devices.*]` and `[defaults]`. Per-device explicit setting wins; a device that pins fingerprint suppresses defaults inheritance. Setting both `host_key_fingerprint` and `known_hosts_path` on the same device entry is a hard error.
- **Pool API gap fix**: `DeviceConfig` gains `host_key_verification: Option<HostKeyVerification>`. Previously the new `RejectAll` default (from Phase 2) silently broke every pool consumer since the API had no way to set it.
- **Tests opt-in**: integration tests now gate on `RUSTNETCONF_TEST_VSRX_HOST` env var (defaults `srxoutpost` user, `~/.ssh/id_ed25519`); without it they no-op, so contributors without a Junos lab get a clean `cargo test`. Verified end-to-end against the lab's CI vSRX (23/23 vsrx + 9/9 pool).
- **Docs**: new `examples/known_hosts.rs` with the `ssh-keyscan` workflow; README "Security Best Practices" updated.

Dependency-wise: `aws-lc-rs` (for HMAC-SHA1 hashed entries) and `base64ct` are promoted from transitive (via russh) to direct deps — zero new crates compiled. HMAC-SHA1 chosen because OpenSSH's hashed-host format requires it; per NIST SP 800-131A it remains acceptable as a MAC (its security depends on the hash being a PRF, not collision resistance).

## Test plan
- [x] 20 parser unit tests covering plain, hashed, wildcards, CIDR, revoked, multi-entry precedence
- [x] 5 SSH-layer unit tests on `known_hosts_outcome_to_result`
- [x] 11 CLI inventory + connect policy-selection tests including conflict detection
- [x] 235 library + 36 CLI unit tests pass
- [x] Clippy clean (`-D warnings`)
- [x] 23 live `integration_vsrx` + 9 live `integration_vendor_pool` tests pass against lab device
- [x] Tests no-op cleanly when `RUSTNETCONF_TEST_VSRX_HOST` is unset

## Commits
- `feat(transport): add OpenSSH known_hosts parser + lookup` — phase 1
- `feat(transport): wire KnownHosts into SshHandler with structured errors` — phase 2+3
- `feat(cli): add known_hosts_path to inventory and connect policy` — phase 4
- `docs(known-hosts): add example and README pointer` — phase 6
- `test: opt-in env-driven integration tests + expose host_key on pool` — test infra + pool fix
- `ci: drop stale SKIP_INTEGRATION env var` — cleanup