### PR TITLE
fix(security): upgrade quick-xml 0.37 → 0.41 (RUSTSEC-2026-0194 / -0195 DoS)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,12 +1555,11 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
- "serde",
 ]
 
 [[package]]
@@ -1835,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -1856,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "clap",
  "colored",
@@ -1873,7 +1872,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-yang"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "quick-xml",
  "rustnetconf",
@@ -2210,7 +2209,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"
@@ -22,7 +22,7 @@ tokio = { version = "1", features = ["full"] }
 russh = { version = "0.61", default-features = false, features = ["flate2", "aws-lc-rs"] }
 aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"] }
 base64ct = { version = "1", features = ["std"] }
-quick-xml = "0.37"
+quick-xml = "0.41"
 thiserror = "2"
 tracing = "0.1"
 async-trait = "0.1"

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A Rust network automation platform: async NETCONF client library, YANG code gene
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.12.1](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.12.1)** (security/robustness patch).
-> Now on crates.io: `rustnetconf` 0.12.1 · `rustnetconf-cli` 0.3.1 · `rustnetconf-yang` 0.1.3.
-> See [What's New in v0.12.1](#whats-new-in-v0121) below for the XML re-escaping fix, cleared yanked dependency, and non-Unix state-file warning.
+> **Latest release — [v0.12.2](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.12.2)** (security patch).
+> Now on crates.io: `rustnetconf` 0.12.2 · `rustnetconf-cli` 0.3.2 · `rustnetconf-yang` 0.1.4.
+> See [What's New in v0.12.2](#whats-new-in-v0122) below for the quick-xml 0.41 upgrade clearing RUSTSEC-2026-0194/-0195.
 
 ## Workspace
 
@@ -21,6 +21,14 @@ Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and
 | **rustnetconf** | Async NETCONF 1.0/1.1 client library |
 | **rustnetconf-yang** | YANG model code generation (compile-time config validation) |
 | **rustnetconf-cli** | Terraform-like CLI tool (`netconf` binary) |
+
+## What's New in v0.12.2
+
+Security patch for all three crates (`rustnetconf` 0.12.2, `rustnetconf-cli` 0.3.2, `rustnetconf-yang` 0.1.4), closing #31. No API changes.
+
+- **quick-xml 0.37 → 0.41:** clears two RUSTSEC advisories in the XML parser that handles device-returned NETCONF data — [RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) (quadratic duplicate-attribute check) and [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195) (unbounded namespace-declaration allocation, memory-exhaustion DoS).
+- **Entity handling adapted to quick-xml 0.38+ semantics:** entity references (`&amp;`, `&#38;`, …) now stream as separate `GeneralRef` events instead of arriving decoded inside text. All reader loops accumulate and resolve them, so element values containing `&`, `<`, `>` (Junos descriptions, URLs, error messages) round-trip whole instead of being silently truncated. Covered by new round-trip regression tests in every parser.
+- **Dropped the unused `serialize` (serde) feature** of quick-xml in `rustnetconf-yang` — the crate only uses the manual `Writer` API.
 
 ## What's New in v0.12.1
 

--- a/rustnetconf-cli/Cargo.toml
+++ b/rustnetconf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-cli"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "Terraform-like CLI for declarative NETCONF network config management"
@@ -19,7 +19,7 @@ colored = "3"
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-quick-xml = "0.37"
+quick-xml = "0.41"
 tokio = { version = "1", features = ["full"] }
 dialoguer = "0.11"
 zeroize = "1"

--- a/rustnetconf-cli/src/diff/tree.rs
+++ b/rustnetconf-cli/src/diff/tree.rs
@@ -342,7 +342,10 @@ mod tests {
         // a split/truncated capture would produce spurious diffs.
         let xml = "<interfaces><interface><name>ge-0/0/0</name><description>up &amp; down link</description></interface></interfaces>";
         let entries = diff_xml(xml, xml).unwrap();
-        assert!(entries.is_empty(), "identical entity values should not diff: {entries:?}");
+        assert!(
+            entries.is_empty(),
+            "identical entity values should not diff: {entries:?}"
+        );
     }
 
     #[test]

--- a/rustnetconf-cli/src/diff/tree.rs
+++ b/rustnetconf-cli/src/diff/tree.rs
@@ -47,20 +47,48 @@ pub fn diff_xml(desired: &str, running: &str) -> Result<Vec<DiffEntry>, String> 
     Ok(entries)
 }
 
+/// Resolve a `GeneralRef` entity reference (`&amp;`, `&#38;`, …) to its text.
+///
+/// Returns `None` for unknown user-defined entities, which are skipped.
+fn resolve_entity_ref(entity: &quick_xml::events::BytesRef<'_>) -> Option<String> {
+    if let Ok(Some(ch)) = entity.resolve_char_ref() {
+        return Some(ch.to_string());
+    }
+    let name = entity.decode().ok()?;
+    quick_xml::escape::resolve_predefined_entity(&name).map(|s| s.to_string())
+}
+
 /// Parse an XML string into a simplified tree.
 fn parse_xml_tree(xml: &str) -> Result<Vec<XmlNode>, String> {
     let mut reader = Reader::from_str(xml);
     let mut buf = Vec::new();
     let mut stack: Vec<(String, Vec<XmlNode>)> = Vec::new();
     let mut root_children: Vec<XmlNode> = Vec::new();
+    // Element text accumulates across events: quick-xml splits text around
+    // entity references (GeneralRef), so a leaf value may span several
+    // events. Flushed as one Text node at the next structural event.
+    let mut pending_text = String::new();
+
+    fn flush_text(pending: &mut String, stack: &mut [(String, Vec<XmlNode>)]) {
+        let value = pending.trim().to_string();
+        pending.clear();
+        if value.is_empty() {
+            return;
+        }
+        if let Some(parent) = stack.last_mut() {
+            parent.1.push(XmlNode::Text(value));
+        }
+    }
 
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref tag)) => {
+                flush_text(&mut pending_text, &mut stack);
                 let name = String::from_utf8_lossy(tag.local_name().as_ref()).to_string();
                 stack.push((name, Vec::new()));
             }
             Ok(Event::End(_)) => {
+                flush_text(&mut pending_text, &mut stack);
                 if let Some((name, children)) = stack.pop() {
                     let node = XmlNode::Element { name, children };
                     if let Some(parent) = stack.last_mut() {
@@ -71,14 +99,15 @@ fn parse_xml_tree(xml: &str) -> Result<Vec<XmlNode>, String> {
                 }
             }
             Ok(Event::Text(ref text)) => {
-                let value = text.unescape().unwrap_or_default().trim().to_string();
-                if !value.is_empty() {
-                    if let Some(parent) = stack.last_mut() {
-                        parent.1.push(XmlNode::Text(value));
-                    }
+                pending_text.push_str(&text.decode().unwrap_or_default());
+            }
+            Ok(Event::GeneralRef(ref entity)) => {
+                if let Some(resolved) = resolve_entity_ref(entity) {
+                    pending_text.push_str(&resolved);
                 }
             }
             Ok(Event::Empty(ref tag)) => {
+                flush_text(&mut pending_text, &mut stack);
                 let name = String::from_utf8_lossy(tag.local_name().as_ref()).to_string();
                 let node = XmlNode::Element {
                     name,
@@ -305,6 +334,25 @@ mod tests {
         assert!(matches!(&entries[0].kind, DiffKind::Modified { from, to }
             if from == "old uplink" && to == "new uplink"));
         assert!(entries[0].path.contains("description"));
+    }
+
+    #[test]
+    fn test_identical_entity_values_no_diff() {
+        // Leaf values containing XML entities must decode to one whole string;
+        // a split/truncated capture would produce spurious diffs.
+        let xml = "<interfaces><interface><name>ge-0/0/0</name><description>up &amp; down link</description></interface></interfaces>";
+        let entries = diff_xml(xml, xml).unwrap();
+        assert!(entries.is_empty(), "identical entity values should not diff: {entries:?}");
+    }
+
+    #[test]
+    fn test_modified_leaf_with_entity_value() {
+        let desired = "<interface><description>a &amp; b</description></interface>";
+        let running = "<interface><description>a</description></interface>";
+        let entries = diff_xml(desired, running).unwrap();
+        assert_eq!(entries.len(), 1, "{entries:?}");
+        assert!(matches!(&entries[0].kind, DiffKind::Modified { from, to }
+            if from == "a" && to == "a & b"));
     }
 
     #[test]

--- a/rustnetconf-yang/Cargo.toml
+++ b/rustnetconf-yang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-yang"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "YANG model code generation for rustnetconf — compile-time config validation"
@@ -15,7 +15,7 @@ generated = []
 [dependencies]
 rustnetconf = { version = "0.12", path = ".." }
 serde = { version = "1", features = ["derive"] }
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = "0.41"
 thiserror = "2"
 
 [dev-dependencies]

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -163,6 +163,7 @@ pub fn client_hello_xml() -> String {
 
 /// Parse a device `<hello>` message and extract capabilities and session-id.
 pub fn parse_device_hello(xml: &str) -> Result<Capabilities, String> {
+    use crate::xml_entity::resolve_entity_ref;
     use quick_xml::events::Event;
     use quick_xml::Reader;
 
@@ -171,6 +172,10 @@ pub fn parse_device_hello(xml: &str) -> Result<Capabilities, String> {
     let mut session_id: Option<u32> = None;
     let mut in_capability = false;
     let mut in_session_id = false;
+    // Element text accumulates across events: quick-xml splits text around
+    // entity references, so a URI like `...?a=1&amp;b=2` spans several
+    // Text/GeneralRef events. Flush at the closing tag.
+    let mut text_buf = String::new();
     let mut buf = Vec::new();
 
     loop {
@@ -179,28 +184,34 @@ pub fn parse_device_hello(xml: &str) -> Result<Capabilities, String> {
                 let local_name = tag.local_name();
                 if local_name.as_ref() == b"capability" {
                     in_capability = true;
+                    text_buf.clear();
                 } else if local_name.as_ref() == b"session-id" {
                     in_session_id = true;
+                    text_buf.clear();
                 }
             }
-            Ok(Event::Text(ref text)) => {
-                if in_capability {
-                    let cap_text = text.unescape().map_err(|e| e.to_string())?;
-                    let trimmed = cap_text.trim().to_string();
-                    if !trimmed.is_empty() {
-                        capabilities.insert(trimmed);
-                    }
-                } else if in_session_id {
-                    let id_text = text.unescape().map_err(|e| e.to_string())?;
-                    session_id = id_text.trim().parse().ok();
+            Ok(Event::Text(ref text)) if in_capability || in_session_id => {
+                let value = text.decode().map_err(|e| e.to_string())?;
+                text_buf.push_str(&value);
+            }
+            Ok(Event::GeneralRef(ref entity)) if in_capability || in_session_id => {
+                if let Some(resolved) = resolve_entity_ref(entity) {
+                    text_buf.push_str(&resolved);
                 }
             }
             Ok(Event::End(ref tag)) => {
                 let local_name = tag.local_name();
                 if local_name.as_ref() == b"capability" {
                     in_capability = false;
+                    let trimmed = text_buf.trim();
+                    if !trimmed.is_empty() {
+                        capabilities.insert(trimmed.to_string());
+                    }
+                    text_buf.clear();
                 } else if local_name.as_ref() == b"session-id" {
                     in_session_id = false;
+                    session_id = text_buf.trim().parse().ok();
+                    text_buf.clear();
                 }
             }
             Ok(Event::Eof) => break,
@@ -254,6 +265,28 @@ mod tests {
         assert_eq!(caps.negotiate_version(), Some(NetconfVersion::V1_1));
         assert!(caps.has_candidate());
         assert!(caps.has_validate());
+    }
+
+    #[test]
+    fn test_parse_capability_uri_with_entities() {
+        // Capability URIs carry query parameters joined by '&', escaped as
+        // &amp; on the wire. The parsed URI must contain the full decoded
+        // string, not a fragment truncated at the entity.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+    <capability>http://example.com/yang?module=foo&amp;revision=2020-01-01</capability>
+  </capabilities>
+  <session-id>7</session-id>
+</hello>"#;
+        let caps = parse_device_hello(xml).unwrap();
+        assert!(
+            caps.supports("http://example.com/yang?module=foo&revision=2020-01-01"),
+            "entity in capability URI must be decoded without truncation: {:?}",
+            caps.all_uris()
+        );
+        assert_eq!(caps.session_id(), Some(7));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,7 @@ pub mod ssh_config;
 pub mod transport;
 pub mod types;
 pub mod vendor;
+pub(crate) mod xml_entity;
 
 // Re-export the primary public API types
 pub use client::{Client, ClientBuilder, EditConfigBuilder};

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -57,6 +57,7 @@ pub fn classify_message(xml: &str) -> Option<MessageKind> {
 /// event content as raw XML using string slicing to preserve the original
 /// XML structure (namespaces, attributes, etc.).
 pub fn parse_notification(xml: &str) -> Result<Notification, RpcError> {
+    use crate::xml_entity::resolve_entity_ref;
     use quick_xml::events::Event;
     use quick_xml::Reader;
 
@@ -65,23 +66,35 @@ pub fn parse_notification(xml: &str) -> Result<Notification, RpcError> {
     let mut buf = Vec::new();
     let mut event_time: Option<String> = None;
     let mut in_event_time = false;
+    // Accumulates across Text/GeneralRef events (quick-xml splits text
+    // around entity references); None until any text is seen.
+    let mut time_buf: Option<String> = None;
 
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref tag)) => {
                 if tag.local_name().as_ref() == b"eventTime" {
                     in_event_time = true;
+                    time_buf = None;
                 }
             }
             Ok(Event::Text(ref text)) if in_event_time => {
                 let t = text
-                    .unescape()
+                    .decode()
                     .map_err(|e| RpcError::ParseError(format!("failed to parse eventTime: {e}")))?;
-                event_time = Some(t.trim().to_string());
+                time_buf.get_or_insert_with(String::new).push_str(&t);
+            }
+            Ok(Event::GeneralRef(ref entity)) if in_event_time => {
+                if let Some(resolved) = resolve_entity_ref(entity) {
+                    time_buf.get_or_insert_with(String::new).push_str(&resolved);
+                }
             }
             Ok(Event::End(ref tag)) => {
                 if tag.local_name().as_ref() == b"eventTime" {
                     in_event_time = false;
+                    if let Some(t) = time_buf.take() {
+                        event_time = Some(t.trim().to_string());
+                    }
                 }
             }
             Ok(Event::Eof) => break,
@@ -207,6 +220,18 @@ mod tests {
         assert_eq!(notif.event_time, "2026-04-01T12:00:00Z");
         assert!(notif.event_xml.contains("netconf-config-change"));
         assert!(notif.event_xml.contains("admin"));
+    }
+
+    #[test]
+    fn test_parse_notification_event_time_with_char_ref() {
+        // A character reference inside <eventTime> must be resolved in place,
+        // not dropped or allowed to truncate the surrounding text.
+        let xml = r#"<notification xmlns="urn:ietf:params:xml:ns:netconf:notification:1.0">
+  <eventTime>2026-04-01T12&#58;00:00Z</eventTime>
+  <some-event/>
+</notification>"#;
+        let notif = parse_notification(xml).unwrap();
+        assert_eq!(notif.event_time, "2026-04-01T12:00:00Z");
     }
 
     #[test]

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -860,7 +860,10 @@ mod tests {
             RpcReply::Data(data) => data,
             other => panic!("expected Data, got {other:?}"),
         };
-        assert!(data.contains("&amp;"), "ampersand must stay escaped: {data}");
+        assert!(
+            data.contains("&amp;"),
+            "ampersand must stay escaped: {data}"
+        );
         validate_xml_fragment(&data).expect("reconstructed inner content must be well-formed");
     }
 
@@ -920,7 +923,9 @@ mod tests {
 </rpc-reply>"#;
         let err = parse_rpc_reply(xml, "7").unwrap_err();
         match err {
-            RpcError::ServerError { info: Some(info), .. } => {
+            RpcError::ServerError {
+                info: Some(info), ..
+            } => {
                 validate_xml_fragment(&info).expect("error-info must stay well-formed");
                 let decoded = quick_xml::escape::unescape(&info).expect("must unescape");
                 assert!(

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -157,6 +157,7 @@ pub struct RpcErrorInfo {
 /// Returns `Ok(RpcReply)` for successful responses, or `Err(RpcError)` if
 /// the reply contains `<rpc-error>` elements.
 pub fn parse_rpc_reply(xml: &str, expected_message_id: &str) -> Result<RpcReply, RpcError> {
+    use crate::xml_entity::{raw_entity_ref, resolve_entity_ref};
     use quick_xml::events::Event;
     use quick_xml::Reader;
 
@@ -178,6 +179,10 @@ pub fn parse_rpc_reply(xml: &str, expected_message_id: &str) -> Result<RpcReply,
     // rpc-error field tracking
     let mut current_error: Option<RpcErrorBuilder> = None;
     let mut current_field: Option<ErrorField> = None;
+    // Element text accumulates across events: quick-xml 0.38+ splits text
+    // around entity references (`GeneralRef`), so a field's value may span
+    // several Text/GeneralRef events before the closing tag.
+    let mut field_text = String::new();
     // error-info can contain child elements — accumulate inner XML
     let mut in_error_info = false;
     let mut _error_info_depth: u32 = 0;
@@ -237,6 +242,7 @@ pub fn parse_rpc_reply(xml: &str, expected_message_id: &str) -> Result<RpcReply,
                             error_info_xml.clear();
                         } else {
                             current_field = ErrorField::from_name(name);
+                            field_text.clear();
                         }
                     }
                     _ => {}
@@ -266,19 +272,29 @@ pub fn parse_rpc_reply(xml: &str, expected_message_id: &str) -> Result<RpcReply,
                 }
             }
             Ok(Event::Text(ref text)) => {
-                let value = text.unescape().unwrap_or_default().to_string();
+                // Text events never contain entity refs (those arrive as
+                // GeneralRef), so decoding the encoding is all that's needed.
+                let value = text.decode().unwrap_or_default();
 
                 if in_data {
-                    // Re-escape: `unescape()` decoded entities, so we must
-                    // re-encode them to keep the reconstructed XML well-formed.
+                    // Re-escape any raw special chars so the reconstructed
+                    // XML stays well-formed.
                     data_xml.push_str(&escape_xml_text(&value));
                 } else if in_error_info {
                     error_info_xml.push_str(&escape_xml_text(&value));
-                } else if in_rpc_error {
-                    if let (Some(ref mut builder), Some(ref field)) =
-                        (&mut current_error, &current_field)
-                    {
-                        builder.set_field(field, &value);
+                } else if in_rpc_error && current_field.is_some() {
+                    field_text.push_str(&value);
+                }
+            }
+            Ok(Event::GeneralRef(ref entity)) => {
+                if in_data {
+                    // Keep the reference escaped verbatim in reconstructed XML.
+                    data_xml.push_str(&raw_entity_ref(entity));
+                } else if in_error_info {
+                    error_info_xml.push_str(&raw_entity_ref(entity));
+                } else if in_rpc_error && current_field.is_some() {
+                    if let Some(resolved) = resolve_entity_ref(entity) {
+                        field_text.push_str(&resolved);
                     }
                 }
             }
@@ -322,7 +338,14 @@ pub fn parse_rpc_reply(xml: &str, expected_message_id: &str) -> Result<RpcReply,
                         error_info_xml.push('>');
                     }
                     _ if in_rpc_error => {
-                        current_field = None;
+                        // Field text is complete at the closing tag; flush the
+                        // accumulated value into the builder.
+                        if let (Some(ref mut builder), Some(field)) =
+                            (&mut current_error, current_field.take())
+                        {
+                            builder.set_field(&field, &field_text);
+                        }
+                        field_text.clear();
                     }
                     _ => {}
                 }
@@ -508,6 +531,7 @@ impl RpcErrorBuilder {
 /// directly under `<rpc-reply>` without a `<data>` wrapper. This function
 /// extracts all child element content from the reply.
 fn extract_rpc_reply_inner_content(xml: &str) -> Option<String> {
+    use crate::xml_entity::raw_entity_ref;
     use quick_xml::events::Event;
     use quick_xml::Reader;
 
@@ -559,9 +583,14 @@ fn extract_rpc_reply_inner_content(xml: &str) -> Option<String> {
                 content.push_str("/>");
             }
             Ok(Event::Text(ref text)) if in_rpc_reply && depth > 0 => {
-                let value = text.unescape().unwrap_or_default().to_string();
-                // Re-escape decoded entities so the reconstructed XML stays well-formed.
+                let value = text.decode().unwrap_or_default();
+                // Re-escape any raw special chars so the reconstructed XML
+                // stays well-formed.
                 content.push_str(&escape_xml_text(&value));
+            }
+            Ok(Event::GeneralRef(ref entity)) if in_rpc_reply && depth > 0 => {
+                // Keep entity references escaped verbatim.
+                content.push_str(&raw_entity_ref(entity));
             }
             Ok(Event::End(ref tag)) => {
                 let local = tag.local_name();
@@ -833,5 +862,73 @@ mod tests {
         };
         assert!(data.contains("&amp;"), "ampersand must stay escaped: {data}");
         validate_xml_fragment(&data).expect("reconstructed inner content must be well-formed");
+    }
+
+    #[test]
+    fn test_error_message_with_entities_is_fully_decoded() {
+        // Junos error messages routinely contain <, >, & (e.g. quoting config
+        // syntax). The decoded message must contain the full text, not a
+        // truncated fragment around the entity.
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="5">
+  <rpc-error>
+    <error-type>protocol</error-type>
+    <error-tag>operation-failed</error-tag>
+    <error-severity>error</error-severity>
+    <error-message>syntax error before &lt;get&gt; &amp; after</error-message>
+  </rpc-error>
+</rpc-reply>"#;
+        let err = parse_rpc_reply(xml, "5").unwrap_err();
+        match err {
+            RpcError::ServerError { message, .. } => {
+                assert_eq!(message, "syntax error before <get> & after");
+            }
+            other => panic!("expected ServerError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_data_text_with_char_ref_roundtrips() {
+        // Numeric character references must survive data reconstruction.
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="6">
+  <data><description>A &#38; B &#x3C; C</description></data>
+</rpc-reply>"#;
+        let result = parse_rpc_reply(xml, "6").unwrap();
+        let data = match result {
+            RpcReply::Data(data) => data,
+            other => panic!("expected Data, got {other:?}"),
+        };
+        validate_xml_fragment(&data).expect("reconstructed data must be well-formed");
+        // Semantic check: independently unescaping the reconstructed XML must
+        // yield the full original text (no truncation around the refs).
+        let decoded = quick_xml::escape::unescape(&data).expect("must unescape");
+        assert!(
+            decoded.contains("A & B < C"),
+            "char refs must round-trip: {decoded}"
+        );
+    }
+
+    #[test]
+    fn test_error_info_with_entities_stays_well_formed() {
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="7">
+  <rpc-error>
+    <error-type>application</error-type>
+    <error-tag>operation-failed</error-tag>
+    <error-severity>error</error-severity>
+    <error-message>bad element</error-message>
+    <error-info><bad-element>a &amp; b</bad-element></error-info>
+  </rpc-error>
+</rpc-reply>"#;
+        let err = parse_rpc_reply(xml, "7").unwrap_err();
+        match err {
+            RpcError::ServerError { info: Some(info), .. } => {
+                validate_xml_fragment(&info).expect("error-info must stay well-formed");
+                let decoded = quick_xml::escape::unescape(&info).expect("must unescape");
+                assert!(
+                    decoded.contains("a & b"),
+                    "entity in error-info must round-trip: {decoded}"
+                );
+            }
+            other => panic!("expected ServerError with info, got {other:?}"),
+        }
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -957,12 +957,16 @@ impl Session {
 fn parse_session_id_from_info(info: &str) -> Option<u32> {
     // Try structured XML parsing with quick_xml
     if info.contains('<') {
+        use crate::xml_entity::resolve_entity_ref;
         use quick_xml::events::Event;
         use quick_xml::Reader;
 
         let mut reader = Reader::from_str(info);
         let mut buf = Vec::new();
         let mut in_session_id = false;
+        // Accumulates across Text/GeneralRef events (quick-xml splits text
+        // around entity references); parsed at the closing tag.
+        let mut id_buf = String::new();
 
         loop {
             match reader.read_event_into(&mut buf) {
@@ -971,17 +975,25 @@ fn parse_session_id_from_info(info: &str) -> Option<u32> {
                     let name = std::str::from_utf8(local.as_ref()).unwrap_or("");
                     if name == "session-id" {
                         in_session_id = true;
+                        id_buf.clear();
                     }
                 }
                 Ok(Event::Text(ref text)) if in_session_id => {
-                    if let Ok(value) = text.unescape() {
-                        if let Ok(id) = value.trim().parse::<u32>() {
+                    if let Ok(value) = text.decode() {
+                        id_buf.push_str(&value);
+                    }
+                }
+                Ok(Event::GeneralRef(ref entity)) if in_session_id => {
+                    if let Some(resolved) = resolve_entity_ref(entity) {
+                        id_buf.push_str(&resolved);
+                    }
+                }
+                Ok(Event::End(_)) => {
+                    if in_session_id {
+                        if let Ok(id) = id_buf.trim().parse::<u32>() {
                             return Some(id);
                         }
                     }
-                    in_session_id = false;
-                }
-                Ok(Event::End(_)) => {
                     in_session_id = false;
                 }
                 Ok(Event::Eof) => break,
@@ -1260,6 +1272,14 @@ mod tests {
     fn test_parse_session_id_from_xml_with_whitespace() {
         let info = "\n<session-id> 99 </session-id>\n";
         assert_eq!(parse_session_id_from_info(info), Some(99));
+    }
+
+    #[test]
+    fn test_parse_session_id_from_xml_with_char_ref() {
+        // A numeric character reference splitting the digits must still parse
+        // to the full session-id (not a truncated prefix/suffix).
+        let info = "<session-id>4&#50;</session-id>";
+        assert_eq!(parse_session_id_from_info(info), Some(42));
     }
 
     #[test]

--- a/src/xml_entity.rs
+++ b/src/xml_entity.rs
@@ -1,0 +1,32 @@
+//! Helpers for quick-xml 0.38+ entity-reference events.
+//!
+//! Since quick-xml 0.38, entity references (`&amp;`, `&#38;`, …) no longer
+//! arrive inside `Event::Text` — they stream as separate `Event::GeneralRef`
+//! events. Reader loops must resolve these and stitch them back into the
+//! surrounding text, otherwise any value containing an entity is silently
+//! truncated.
+
+use quick_xml::events::BytesRef;
+
+/// Resolve a general entity reference to its decoded text value.
+///
+/// Handles numeric character references (`&#38;`, `&#x26;`) and the five
+/// predefined XML entities (`amp`, `lt`, `gt`, `apos`, `quot`). Returns
+/// `None` for unknown user-defined entities, which callers should skip
+/// (matching the old `unescape()` error behavior of not inventing content).
+pub(crate) fn resolve_entity_ref(entity: &BytesRef<'_>) -> Option<String> {
+    if let Ok(Some(ch)) = entity.resolve_char_ref() {
+        return Some(ch.to_string());
+    }
+    let name = entity.decode().ok()?;
+    quick_xml::escape::resolve_predefined_entity(&name).map(|s| s.to_string())
+}
+
+/// Reconstruct the raw wire form (`&name;`) of an entity reference.
+///
+/// Used when rebuilding inner XML verbatim: the reference is kept escaped so
+/// the reconstructed fragment stays well-formed and round-trips exactly,
+/// including user-defined entities we cannot resolve.
+pub(crate) fn raw_entity_ref(entity: &BytesRef<'_>) -> String {
+    format!("&{};", entity.decode().unwrap_or_default())
+}


### PR DESCRIPTION
Closes #31.

## What

Upgrades `quick-xml` 0.37 → 0.41 across all three crates, clearing two DoS advisories in the parser that handles device-returned NETCONF XML:

- **RUSTSEC-2026-0194** — quadratic run time checking a start tag for duplicate attribute names
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS)

## The behavioral migration (not a rename)

quick-xml 0.38 removed `BytesText::unescape()` and introduced `Event::GeneralRef`: entity references (`&amp;`, `&#38;`, …) no longer arrive decoded inside `Text` events — they stream as separate events. A naive `unescape()` → `decode()` rename compiles cleanly but silently truncates any element value containing `&`, `<`, `>` (common in Junos descriptions, URLs, error messages).

All five reader loops were reworked to accumulate `Text` + resolved `GeneralRef` events up to the closing tag:

- `src/rpc/mod.rs` — reply/error parser: error fields accumulate across events; reconstructed `<data>`/`error-info`/Junos inner XML keeps references escaped verbatim (round-trips exactly, including user-defined entities)
- `src/capability.rs` — capability URIs / session-id flush at the closing tag (a URI like `?module=foo&amp;rev=…` now parses whole)
- `src/notification.rs` — `<eventTime>` accumulation
- `src/session.rs` — stale-lock session-id extraction
- `rustnetconf-cli/src/diff/tree.rs` — leaf values accumulate into a single text node (no spurious diffs)

Shared resolution lives in the new `src/xml_entity.rs` (char refs via `resolve_char_ref()`, predefined entities via `escape::resolve_predefined_entity()`; unknown user-defined entities are skipped, matching the old error behavior of not inventing content).

Also: dropped the unused `serialize` (serde) feature of quick-xml in `rustnetconf-yang` (only the manual `Writer` API is used, verified write-only and source-compatible).

## Tests

TDD: round-trip entity tests (`&amp;`/`&lt;`/`&gt;` + numeric char refs) were written first and verified green on 0.37, the bump produced the expected compile failures at all `unescape()` sites, then the fix brought everything back green.

- `cargo test --workspace`: 315 tests + 12 doctests pass
- `cargo clippy --workspace --all-targets`: no warnings
- `cargo audit`: RUSTSEC-2026-0194/-0195 cleared. (Pre-existing, unrelated: RUSTSEC-2026-0190 in `anyhow` via the `yang2`/`tempfile` build/dev-dep chain — present on `main`, worth a separate issue.)

## Release

rustnetconf 0.12.1 → **0.12.2**, rustnetconf-cli 0.3.1 → **0.3.2**, rustnetconf-yang 0.1.3 → **0.1.4** (lockstep). Publishing to crates.io after merge unblocks rustEZ and RustJunosMCP#103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqzszEPLxs8ooRAGMqfhHL