### PR TITLE
feat(pool): honor explicit DeviceConfig.vendor; reconcile TODOS

### DIFF
--- a/TODOS.md
+++ b/TODOS.md
@@ -14,28 +14,6 @@
 **Depends on:** CLI v1.0, DevicePool from v0.2.
 **Added:** 2026-03-19 via /plan-eng-review
 
-### RFC 7589 — NETCONF over TLS
-**What:** Investigate and implement TLS as a second transport alongside SSH.
-**Why:** Many enterprise environments prefer or require TLS for NETCONF (especially RESTCONF-adjacent deployments). The transport trait architecture already supports pluggable transports.
-**Investigation:**
-- Evaluate `rustls` vs `native-tls` for the TLS backend (prefer `rustls` to stay pure-Rust)
-- Determine certificate-based mutual auth requirements (RFC 7589 §3)
-- Design `TlsTransport` implementing the existing `Transport` trait
-- Assess impact on connection pooling (DevicePool needs transport-agnostic checkout)
-- Test against devices that support NETCONF over TLS (port 6513)
-**Added:** 2026-04-01
-
-### RFC 5277 — NETCONF Event Notifications
-**What:** Investigate and implement `create-subscription` RPC and async notification stream handling.
-**Why:** Event notifications enable real-time monitoring of device state changes — critical for network automation platforms.
-**Investigation:**
-- Implement `create-subscription` RPC with stream, filter, startTime, stopTime parameters
-- Design async notification receiver (tokio channel or Stream trait) for incoming `<notification>` messages
-- Handle interleaved notifications with RPC replies on the same session
-- Determine if notification parsing should be generic XML or typed via YANG models
-- Test with devices that advertise `:notification` capability
-**Added:** 2026-04-01
-
 ### RFC 5717 — Partial Lock RPC
 **What:** Investigate and implement `partial-lock` and `partial-unlock` RPCs for XPath-scoped locking.
 **Why:** Partial lock enables multiple managers to lock different subtrees concurrently — essential for multi-operator environments.
@@ -142,3 +120,9 @@ Also fixed `<error-info>` parsing to preserve child element XML (e.g., `<session
 
 ### ~~TODO-003: Framing mismatch detection (device says 1.1, sends EOM)~~ DONE
 **Completed:** 2026-03-19. ChunkedFramer detects EOM-framed data (XML start, `<!--` comments, `]]>]]>` delimiter) and returns `FramingError::Mismatch` with actionable message. 5 unit tests added.
+
+### ~~RFC 7589 — NETCONF over TLS~~ DONE
+**Completed:** 2026-07-17. Implemented TLS transport (RFC 7589) via `TlsTransport` in src/transport/tls.rs using `rustls` backend. Supports both server-only and mutual TLS authentication. Exposed via `TlsClientBuilder` and `TlsConfig`, behind the `tls` feature flag. Re-exported in src/lib.rs.
+
+### ~~RFC 5277 — NETCONF Event Notifications~~ DONE
+**Completed:** 2026-07-17. Implemented `create-subscription` RPC and async notification stream handling (RFC 5277) in src/notification.rs. Session tracks subscription state and buffers interleaved notifications during RPC exchanges. Client methods: `create_subscription()`, `drain_notifications()`, `recv_notification()`.

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,6 +3,7 @@
 //! `Client` provides builder-pattern connection setup and delegates all
 //! protocol operations to the underlying `Session`. It owns no protocol state.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use crate::capability::Capabilities;
@@ -61,7 +62,7 @@ pub struct ClientBuilder {
     /// as `password`.
     key_passphrase: Option<Zeroizing<String>>,
     use_agent: bool,
-    vendor_profile: Option<Box<dyn VendorProfile>>,
+    vendor_profile: Option<Arc<dyn VendorProfile>>,
     gather_facts: bool,
     keepalive_interval: Option<Duration>,
     host_key_verification: HostKeyVerification,
@@ -113,6 +114,15 @@ impl ClientBuilder {
     /// Use this when auto-detection doesn't work for your device, or
     /// when using a custom vendor implementation.
     pub fn vendor_profile(mut self, profile: Box<dyn VendorProfile>) -> Self {
+        self.vendor_profile = Some(Arc::from(profile));
+        self
+    }
+
+    /// Set an explicit vendor profile (Arc), overriding auto-detection.
+    ///
+    /// Use this when sharing a vendor profile across multiple clients or
+    /// when integrating with connection pooling.
+    pub fn vendor_profile_arc(mut self, profile: Arc<dyn VendorProfile>) -> Self {
         self.vendor_profile = Some(profile);
         self
     }
@@ -313,7 +323,7 @@ impl ClientBuilder {
 
         // Set explicit vendor profile if provided (overrides auto-detection)
         if let Some(profile) = self.vendor_profile {
-            session.set_vendor_profile(profile);
+            session.set_vendor_profile_arc(profile);
         }
 
         session.establish().await?;
@@ -889,7 +899,7 @@ impl<'a> EditConfigBuilder<'a> {
 #[cfg(feature = "tls")]
 pub struct TlsClientBuilder {
     tls_config: TlsConfig,
-    vendor_profile: Option<Box<dyn VendorProfile>>,
+    vendor_profile: Option<Arc<dyn VendorProfile>>,
     gather_facts: bool,
     keepalive_interval: Option<Duration>,
     rpc_timeout: Option<Duration>,
@@ -899,6 +909,12 @@ pub struct TlsClientBuilder {
 impl TlsClientBuilder {
     /// Set an explicit vendor profile, overriding auto-detection.
     pub fn vendor_profile(mut self, profile: Box<dyn VendorProfile>) -> Self {
+        self.vendor_profile = Some(Arc::from(profile));
+        self
+    }
+
+    /// Set an explicit vendor profile (Arc), overriding auto-detection.
+    pub fn vendor_profile_arc(mut self, profile: Arc<dyn VendorProfile>) -> Self {
         self.vendor_profile = Some(profile);
         self
     }
@@ -937,7 +953,7 @@ impl TlsClientBuilder {
         }
 
         if let Some(profile) = self.vendor_profile {
-            session.set_vendor_profile(profile);
+            session.set_vendor_profile_arc(profile);
         }
 
         session.establish().await?;

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -64,14 +64,7 @@ pub struct DeviceConfig {
     /// (for labs only) `AcceptAll`.
     pub host_key_verification: Option<HostKeyVerification>,
     /// Optional explicit vendor profile. `None` = auto-detect.
-    ///
-    /// TODO: This field is not yet wired into connection setup. `connect_device()`
-    /// takes `&DeviceConfig` (shared reference via `Arc`), so the `Box<dyn VendorProfile>`
-    /// cannot be moved out. To wire this, either change the field to
-    /// `Option<Arc<dyn VendorProfile>>` and add a corresponding `Session::set_vendor_profile_arc()`
-    /// method, or restructure the pool to use per-device mutexes so the config
-    /// can be consumed on first connect.
-    pub vendor: Option<Box<dyn VendorProfile>>,
+    pub vendor: Option<Arc<dyn VendorProfile>>,
 }
 
 /// Builder for constructing a `DevicePool`.
@@ -298,6 +291,10 @@ async fn connect_device(config: &DeviceConfig) -> Result<Client, NetconfError> {
 
     if let Some(policy) = &config.host_key_verification {
         builder = builder.host_key_verification(policy.clone());
+    }
+
+    if let Some(vendor) = &config.vendor {
+        builder = builder.vendor_profile_arc(Arc::clone(vendor));
     }
 
     builder.connect().await

--- a/src/session.rs
+++ b/src/session.rs
@@ -18,6 +18,7 @@
 //! ```
 
 use std::collections::VecDeque;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::capability::{self, Capabilities, NetconfVersion};
@@ -80,7 +81,7 @@ pub struct Session {
     pending_commit: bool,
     /// Vendor-specific behavior profile. Set during establish() via auto-detection,
     /// or overridden by the user via Client::vendor() / Client::vendor_profile().
-    vendor_profile: Box<dyn VendorProfile>,
+    vendor_profile: Arc<dyn VendorProfile>,
     /// Device facts gathered after session establishment.
     facts: Facts,
     /// Keepalive interval — if set, a probe is sent before RPCs when idle
@@ -118,7 +119,7 @@ impl Session {
             read_buffer: Vec::new(),
             version: None,
             pending_commit: false,
-            vendor_profile: Box::new(crate::vendor::generic::GenericVendor),
+            vendor_profile: Arc::new(crate::vendor::generic::GenericVendor),
             facts: Facts::default(),
             keepalive_interval: None,
             last_activity: None,
@@ -135,6 +136,15 @@ impl Session {
     /// Must be called before `establish()`. After establish, the vendor
     /// profile is locked in.
     pub fn set_vendor_profile(&mut self, profile: Box<dyn VendorProfile>) {
+        self.vendor_profile = Arc::from(profile);
+    }
+
+    /// Set an explicit vendor profile (Arc), overriding auto-detection.
+    ///
+    /// Must be called before `establish()`. After establish, the vendor
+    /// profile is locked in. Use this when sharing a vendor profile across
+    /// multiple sessions.
+    pub fn set_vendor_profile_arc(&mut self, profile: Arc<dyn VendorProfile>) {
         self.vendor_profile = profile;
     }
 
@@ -182,7 +192,7 @@ impl Session {
 
         // Auto-detect vendor from capabilities (unless explicitly overridden)
         if self.vendor_profile.name() == "generic" {
-            self.vendor_profile = vendor::detect_vendor(&caps);
+            self.vendor_profile = Arc::from(vendor::detect_vendor(&caps));
         }
 
         // Normalize legacy capability URIs to their standard forms using the
@@ -1737,5 +1747,29 @@ mod tests {
             .expect("lock failed");
         assert_eq!(session.drain_notifications().len(), 1);
         assert_eq!(session.drain_notifications().len(), 0); // buffer cleared
+    }
+
+    #[tokio::test]
+    async fn test_explicit_vendor_profile_arc_survives_auto_detection() {
+        use std::sync::Arc;
+
+        // Mock transport: hello WITHOUT Junos capability (generic device)
+        let response_data = mock_device_hello();
+
+        let transport = MockTransport::new(response_data);
+        let mut session = Session::new(Box::new(transport));
+
+        // Set explicit Junos vendor profile via Arc BEFORE establish
+        session.set_vendor_profile_arc(Arc::new(crate::vendor::junos::JunosVendor::default()));
+
+        // Establish should NOT override the explicit vendor because it's not "generic"
+        session.establish().await.expect("establish failed");
+
+        // Vendor should still be "junos" after establish (not auto-detected to "generic")
+        assert_eq!(
+            session.vendor_name(),
+            "junos",
+            "explicit Arc vendor override should survive auto-detection"
+        );
     }
 }

--- a/src/vendor/junos.rs
+++ b/src/vendor/junos.rs
@@ -8,6 +8,8 @@
 //! - Capability normalization: Junos uses both `urn:ietf:params:netconf:` and
 //!   `urn:ietf:params:xml:ns:netconf:` prefixes for the same capabilities
 
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use super::{CloseSequence, VendorProfile};
 use crate::capability::Capabilities;
 use crate::facts::{self, Facts};
@@ -19,11 +21,20 @@ const JUNOS_CAPABILITY: &str = "http://xml.juniper.net/netconf/junos/1.0";
 ///
 /// Tracks chassis cluster state to determine whether
 /// `<open-configuration>` is required before loading configuration.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct JunosVendor {
     /// True when the device is part of a chassis cluster.
     /// Detected from `<multi-routing-engine-results>` in the facts response.
-    is_cluster: bool,
+    /// Uses AtomicBool for interior mutability (required for Arc<dyn VendorProfile>).
+    is_cluster: AtomicBool,
+}
+
+impl Default for JunosVendor {
+    fn default() -> Self {
+        Self {
+            is_cluster: AtomicBool::new(false),
+        }
+    }
 }
 
 impl JunosVendor {
@@ -41,7 +52,7 @@ impl JunosVendor {
 
     /// Whether this device is part of a chassis cluster.
     pub fn is_cluster(&self) -> bool {
-        self.is_cluster
+        self.is_cluster.load(Ordering::Relaxed)
     }
 }
 
@@ -124,17 +135,17 @@ impl VendorProfile for JunosVendor {
         facts::parse_junos_system_information(response)
     }
 
-    fn post_facts_hook(&mut self, _facts: &Facts, raw_response: &str) {
+    fn post_facts_hook(&self, _facts: &Facts, raw_response: &str) {
         // Chassis cluster devices wrap facts in <multi-routing-engine-results>.
         // Use this as a reliable signal for cluster mode.
         if raw_response.contains("<multi-routing-engine-results>") {
-            self.is_cluster = true;
+            self.is_cluster.store(true, Ordering::Relaxed);
             tracing::info!("Junos chassis cluster detected");
         }
     }
 
     fn requires_open_configuration(&self) -> bool {
-        self.is_cluster
+        self.is_cluster.load(Ordering::Relaxed)
     }
 }
 
@@ -257,7 +268,7 @@ mod tests {
 
     #[test]
     fn test_cluster_detection_from_multi_re() {
-        let mut vendor = JunosVendor::default();
+        let vendor = JunosVendor::default();
         assert!(!vendor.is_cluster());
         assert!(!vendor.requires_open_configuration());
 
@@ -277,7 +288,7 @@ mod tests {
 
     #[test]
     fn test_non_cluster_detection() {
-        let mut vendor = JunosVendor::default();
+        let vendor = JunosVendor::default();
         let response = r#"<software-information>
   <host-name>vsrx1</host-name>
   <product-model>vSRX</product-model>

--- a/src/vendor/mod.rs
+++ b/src/vendor/mod.rs
@@ -104,7 +104,10 @@ pub trait VendorProfile: Send + Sync {
     /// Receives the parsed facts and the raw XML response from the facts RPC.
     /// Vendors can use this to detect device characteristics (e.g., chassis
     /// cluster mode) that are only visible in the facts response.
-    fn post_facts_hook(&mut self, _facts: &Facts, _raw_response: &str) {}
+    ///
+    /// Uses interior mutability (e.g., `AtomicBool`, `Mutex`) if the hook
+    /// needs to update vendor state, to support `Arc<dyn VendorProfile>`.
+    fn post_facts_hook(&self, _facts: &Facts, _raw_response: &str) {}
 
     /// Whether this device requires `<open-configuration>` before loading config.
     ///


### PR DESCRIPTION
## Summary

Two changes bundled from a project review pass:

**Wire the dead `DeviceConfig.vendor` field.** An explicit vendor profile set on a pooled device was silently dropped — `connect_device()` never applied it. Now honored:
- `Session.vendor_profile` is stored as `Arc<dyn VendorProfile>`; added `Session::set_vendor_profile_arc()`.
- `ClientBuilder` + `TlsClientBuilder` gain `vendor_profile_arc()`. The existing `vendor_profile(Box<dyn VendorProfile>)` API is **unchanged** (converts `Box→Arc` internally) — additive, not breaking.
- `connect_device()` forwards `config.vendor` into the builder.
- Required side effect: `VendorProfile::post_facts_hook` moves from `&mut self` to `&self`, and `JunosVendor.is_cluster` becomes an `AtomicBool` — `Arc` (shared ownership) can't hand out `&mut`, so vendor state that mutates on the facts hook needs interior mutability.

**Reconcile TODOS.md.** RFC 7589 (TLS) and RFC 5277 (notifications) were already implemented but still listed as un-started backlog; moved to the Done section with their implementing files cited.

## Testing
- `cargo test -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls` — 345 pass, 0 fail
- `cargo clippy -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls -- -D warnings` — clean
- New TDD test `test_explicit_vendor_profile_arc_survives_auto_detection` confirmed red-before / green-after

## Note
Sharing a single `JunosVendor` `Arc` across many pooled devices would let one device's cluster detection set the flag for all sharers — safe-direction only (errs toward requiring `<open-configuration>`), and not a regression since the field was previously unusable. Give each device its own `Arc::new(...)` to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)