### PR TITLE
refactor(cli): dedup config unwrapping via vendor profile

### DIFF
--- a/docs/superpowers/plans/2026-07-17-dedup-config-unwrap.md
+++ b/docs/superpowers/plans/2026-07-17-dedup-config-unwrap.md
@@ -1,0 +1,233 @@
+# Deduplicate Config Unwrapping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the CLI's hand-copied `strip_configuration_wrapper` with the connected device's real vendor `unwrap_config`, exposed through a new `Client::unwrap_config()` method.
+
+**Architecture:** Add a thin delegating `Session::unwrap_config` → `Client::unwrap_config` (mirroring the existing `vendor_name` delegation chain), then point both CLI call sites at it. The library already applies `vendor_profile.unwrap_config()` to get-config responses (`src/session.rs:609`); this exposes the same operation so the CLI can normalize the *desired* config symmetrically for every vendor.
+
+**Tech Stack:** Rust, tokio, `MockTransport` test harness. No new dependencies.
+
+## Global Constraints
+
+- Do NOT touch the `rustnetconf-yang` crate (needs `cmake`, not installed). Build/test only `rustnetconf` and `rustnetconf-cli`.
+- Additive public API only — do not change existing signatures.
+- Do NOT expose `wrap_config` (YAGNI).
+- No changes to diff formatting, command surface, or output.
+- Verify commands (run for every task that touches Rust):
+  - `cargo test -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls`
+  - `cargo clippy -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls -- -D warnings`
+- Branch: `refactor/dedup-config-unwrap` (already checked out).
+- Commit trailer on every commit:
+  ```
+  Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
+  ```
+
+---
+
+### Task 1: Add `Session::unwrap_config` and `Client::unwrap_config`
+
+**Files:**
+- Modify: `src/session.rs` (insert after `vendor_name`, currently ends at line 244)
+- Modify: `src/client.rs` (insert after `vendor_name`, currently ends at line 496)
+- Test: `src/client.rs` (existing `#[cfg(test)] mod tests` at the bottom, which already uses `MockTransport` and `Client::from_session_for_test`)
+
+**Interfaces:**
+- Consumes: existing `Session.vendor_profile: Arc<dyn VendorProfile>` and its `unwrap_config(&self, &str) -> String`; existing test helpers `crate::transport::mock::MockTransport` and `Client::from_session_for_test(session)`.
+- Produces: `Client::unwrap_config(&self, xml: &str) -> String` and `Session::unwrap_config(&self, xml: &str) -> String`. The CLI (Task 2) relies on `Client::unwrap_config`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the `#[cfg(test)] mod tests` block at the bottom of `src/client.rs`. Uses the same `MockTransport` + `from_session_for_test` pattern as the existing tests there (see the tests around `src/client.rs:1213`). The generic-passthrough assertion is the behavior the old CLI logic got wrong — assert it first.
+
+```rust
+    #[test]
+    fn test_unwrap_config_generic_passes_through() {
+        use crate::transport::mock::MockTransport;
+        // Generic vendor is the default when no hello/detection has run.
+        let transport = MockTransport::new(Vec::new());
+        let session = Session::new(Box::new(transport));
+        let client = Client::from_session_for_test(session);
+
+        let input = "<configuration><foo>bar</foo></configuration>";
+        // Generic unwrap_config is a passthrough: input is returned unchanged.
+        assert_eq!(client.unwrap_config(input), input);
+    }
+
+    #[test]
+    fn test_unwrap_config_junos_strips_configuration_wrapper() {
+        use crate::transport::mock::MockTransport;
+        let transport = MockTransport::new(Vec::new());
+        let mut session = Session::new(Box::new(transport));
+        session.set_vendor_profile(Box::new(crate::vendor::junos::JunosVendor::default()));
+        let client = Client::from_session_for_test(session);
+
+        let input = "<configuration junos:commit-seconds=\"1\"><foo>bar</foo></configuration>";
+        assert_eq!(client.unwrap_config(input), "<foo>bar</foo>");
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test -p rustnetconf --features tls unwrap_config 2>&1 | tail -20`
+Expected: FAIL — compile error `no method named `unwrap_config` found for ... Client`.
+
+- [ ] **Step 3: Implement `Session::unwrap_config`**
+
+In `src/session.rs`, immediately after the `vendor_name` method (after line 244, before the `/// Get the device facts.` doc comment):
+
+```rust
+
+    /// Normalize a config fragment the way this session's vendor profile does
+    /// (e.g. Junos strips the outer `<configuration>` wrapper; generic passes
+    /// through). This is the same operation applied to get-config responses,
+    /// exposed so callers can normalize a *desired* config symmetrically.
+    pub fn unwrap_config(&self, xml: &str) -> String {
+        self.vendor_profile.unwrap_config(xml)
+    }
+```
+
+- [ ] **Step 4: Implement `Client::unwrap_config`**
+
+In `src/client.rs`, immediately after the `vendor_name` method (after line 496, before the `/// Get the device's capabilities.` doc comment):
+
+```rust
+
+    /// Normalize a config fragment using the connected device's vendor profile.
+    ///
+    /// Junos strips the outer `<configuration>` wrapper; generic vendors pass
+    /// the input through unchanged. Useful for diffing a desired config against
+    /// a (already vendor-unwrapped) running config.
+    pub fn unwrap_config(&self, xml: &str) -> String {
+        self.session.unwrap_config(xml)
+    }
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cargo test -p rustnetconf --features tls unwrap_config 2>&1 | tail -20`
+Expected: PASS — both `test_unwrap_config_generic_passes_through` and `test_unwrap_config_junos_strips_configuration_wrapper` pass.
+
+- [ ] **Step 6: Full verify**
+
+Run: `cargo test -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls 2>&1 | grep -E "test result|error\[|FAILED"`
+Expected: all `test result: ok`, no FAILED.
+Run: `cargo clippy -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls -- -D warnings 2>&1 | grep -E "warning|error"; echo done`
+Expected: only `done` (no warnings/errors).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/session.rs src/client.rs
+git commit -m "feat(client): add unwrap_config delegating to vendor profile
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Point CLI at `Client::unwrap_config`, delete the duplicate
+
+**Files:**
+- Modify: `rustnetconf-cli/src/commands/plan.rs` (remove `strip_configuration_wrapper` at lines 64-79; update the call at line 37)
+- Modify: `rustnetconf-cli/src/commands/apply.rs` (update the call at line 73)
+
+**Interfaces:**
+- Consumes: `Client::unwrap_config(&self, xml: &str) -> String` from Task 1. In both files `client` is already connected before the call, so its vendor profile is set.
+- Produces: nothing new; removes the `pub fn strip_configuration_wrapper` and the `apply.rs → plan.rs` cross-module reference.
+
+- [ ] **Step 1: Update the `plan.rs` call site**
+
+In `rustnetconf-cli/src/commands/plan.rs`, line 37, replace:
+
+```rust
+        let desired_inner = strip_configuration_wrapper(&config.xml);
+```
+
+with:
+
+```rust
+        let desired_inner = client.unwrap_config(&config.xml);
+```
+
+- [ ] **Step 2: Delete the duplicated helper from `plan.rs`**
+
+In `rustnetconf-cli/src/commands/plan.rs`, delete the entire function and its doc comment (currently lines 64-79):
+
+```rust
+/// Strip outer `<configuration ...>...</configuration>` wrapper from XML.
+/// Matches the vendor profile's unwrap_config behavior.
+pub fn strip_configuration_wrapper(xml: &str) -> String {
+    let trimmed = xml.trim();
+    if let Some(start) = trimmed.find("<configuration") {
+        if let Some(tag_end) = trimmed[start..].find('>') {
+            let inner_start = start + tag_end + 1;
+            if let Some(close) = trimmed.rfind("</configuration>") {
+                if inner_start < close {
+                    return trimmed[inner_start..close].trim().to_string();
+                }
+            }
+        }
+    }
+    trimmed.to_string()
+}
+```
+
+(Also remove the now-trailing blank line if one remains at end of file.)
+
+- [ ] **Step 3: Update the `apply.rs` call site**
+
+In `rustnetconf-cli/src/commands/apply.rs`, line 73, replace:
+
+```rust
+        let desired_inner = crate::commands::plan::strip_configuration_wrapper(&config.xml);
+```
+
+with:
+
+```rust
+        let desired_inner = client.unwrap_config(&config.xml);
+```
+
+- [ ] **Step 4: Verify no references remain**
+
+Run: `grep -rn "strip_configuration_wrapper" rustnetconf-cli/src; echo "exit: $?"`
+Expected: no matches (grep prints nothing; `exit: 1`).
+
+- [ ] **Step 5: Build and test**
+
+Run: `cargo build -p rustnetconf-cli 2>&1 | tail -5`
+Expected: `Finished` with no errors (in particular, no "unused import"/"unused function" warnings).
+Run: `cargo test -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls 2>&1 | grep -E "test result|error\[|FAILED"`
+Expected: all `test result: ok`, no FAILED — the existing `plan`/`apply` diff tests confirm the Junos path is unchanged.
+Run: `cargo clippy -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls -- -D warnings 2>&1 | grep -E "warning|error"; echo done`
+Expected: only `done`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add rustnetconf-cli/src/commands/plan.rs rustnetconf-cli/src/commands/apply.rs
+git commit -m "refactor(cli): use Client::unwrap_config instead of duplicated strip
+
+Routes desired-config normalization through the connected device's vendor
+profile, fixing the asymmetric diff against generic (non-Junos) devices and
+removing the apply->plan cross-module coupling.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Library `Session::unwrap_config` + `Client::unwrap_config` → Task 1. ✓
+- CLI deletes `strip_configuration_wrapper`, both call sites use `client.unwrap_config` → Task 2. ✓
+- Removes `apply.rs → plan.rs` coupling → Task 2, Step 3. ✓
+- Library test: junos strips / generic passes through, generic-first TDD → Task 1, Steps 1-2. ✓
+- CLI: grep for stale refs + run diff tests → Task 2, Steps 4-5. ✓
+- YAGNI (no `wrap_config`), additive API, no Junos behavior change → Global Constraints + Task boundaries. ✓
+
+**Placeholder scan:** none — all steps carry exact code, paths, and commands.
+
+**Type consistency:** `unwrap_config(&self, xml: &str) -> String` is identical across `Session`, `Client`, both test call sites, and both CLI call sites. Test helper `Client::from_session_for_test` and `MockTransport::new(Vec::new())` match existing usage in `src/client.rs`. `JunosVendor::default()` and `Session::set_vendor_profile(Box::new(...))` match the API confirmed in the prior change.

--- a/docs/superpowers/specs/2026-07-17-dedup-config-unwrap-design.md
+++ b/docs/superpowers/specs/2026-07-17-dedup-config-unwrap-design.md
@@ -1,0 +1,93 @@
+# Design: Deduplicate config unwrapping via the vendor profile
+
+**Date:** 2026-07-17
+**Branch:** `refactor/dedup-config-unwrap`
+**Status:** Approved
+
+## Problem
+
+The CLI's `strip_configuration_wrapper` (`rustnetconf-cli/src/commands/plan.rs:66`) is a
+hand-copied clone of the library's `JunosVendor::unwrap_config`
+(`src/vendor/junos.rs:76`). Its own doc comment states it "Matches the vendor profile's
+unwrap_config behavior." `apply.rs` reaches across command modules to reuse it
+(`crate::commands::plan::strip_configuration_wrapper`).
+
+Two problems follow:
+
+1. **Drift.** The duplicated string-slicing logic will diverge from the real vendor
+   implementation over time — a maintenance hazard with no compiler backstop.
+2. **Latent correctness gap.** The CLI strips `<configuration>` from the *desired*
+   config **unconditionally**. Against a generic (non-Junos) device — whose real
+   `unwrap_config` is a passthrough — the running config is *not* unwrapped by the
+   session, but the desired config *is* stripped by the CLI. The diff is asymmetric
+   and can be wrong for non-Junos devices.
+
+## Goal
+
+The CLI must normalize the *desired* config the same way the session already
+normalizes the *running* config it fetches — using the **connected device's actual
+vendor profile**, not a hardcoded Junos-style strip.
+
+Decision (approved): fix the correctness gap (vendor-aware), and expose the shared
+logic as a focused `Client::unwrap_config()` method rather than leaking the trait
+object.
+
+## Design
+
+### Library (`rustnetconf`)
+
+- Add `Session::unwrap_config(&self, xml: &str) -> String` delegating to
+  `self.vendor_profile.unwrap_config(xml)`. The session already calls this internally
+  on get-config responses (`src/session.rs:609`); this exposes the same operation.
+- Add `Client::unwrap_config(&self, xml: &str) -> String` delegating to the session.
+  Public, `&self`, generally useful to any library consumer doing config diffs. This
+  is the sole new public surface — the vendor trait object stays encapsulated.
+
+### CLI (`rustnetconf-cli`)
+
+- Delete `strip_configuration_wrapper` from `plan.rs` (both the function and its
+  doc comment).
+- In `plan.rs` and `apply.rs`, replace `strip_configuration_wrapper(&config.xml)`
+  with `client.unwrap_config(&config.xml)`. Because `client` carries the
+  detected/overridden vendor:
+  - Junos device → strips `<configuration>` (unchanged behavior).
+  - Generic device → passes through, making the diff symmetric with the
+    (already vendor-unwrapped) running config.
+- This also removes the `apply.rs → plan.rs` cross-command coupling.
+
+## Data flow (after change)
+
+```
+desired.xml ──► client.unwrap_config() ─┐
+                                         ├─► diff_xml() ──► entries
+running (get-config, session already ────┘
+        vendor-unwrapped via session.rs:609)
+```
+
+Both sides of the diff now pass through the *same* vendor `unwrap_config`, so they are
+normalized consistently for every vendor.
+
+## Testing
+
+- **Library unit test (TDD, write first):** a `JunosVendor`-backed client unwraps
+  `<configuration>…</configuration>` to its inner content; a `GenericVendor`-backed
+  client leaves the XML untouched. Reuse the existing `MockTransport` hello harness /
+  `Client::from_session_for_test`. Write the **generic-passthrough** assertion first —
+  it is the behavior the old CLI logic got wrong — confirm it is red against the old
+  path, then implement and confirm green.
+- **CLI:** grep to confirm no remaining references to `strip_configuration_wrapper`;
+  run the existing `plan`/`apply` diff tests to confirm the Junos path is unchanged.
+- **Full suite + strict clippy** on `rustnetconf` and `rustnetconf-cli` with the `tls`
+  feature, as in the prior change.
+
+## Scope guard (YAGNI)
+
+- Do **not** expose `wrap_config` — nothing needs it yet.
+- No changes to diff formatting, command surface, or output.
+- No behavior change for Junos devices (the common case).
+
+## Risk
+
+- Behavior changes only for **non-Junos** devices, which are currently unusual in this
+  project's usage. The change makes those diffs *more* correct, not less.
+- `Client::unwrap_config` is additive public API; no existing signatures change.

--- a/rustnetconf-cli/src/commands/apply.rs
+++ b/rustnetconf-cli/src/commands/apply.rs
@@ -70,7 +70,7 @@ pub async fn run(
             .await
             .map_err(|e| format!("get-config failed for {}: {e}", config.name))?;
 
-        let desired_inner = crate::commands::plan::strip_configuration_wrapper(&config.xml);
+        let desired_inner = client.unwrap_config(&config.xml);
         let entries = diff_xml(&desired_inner, &running)?;
         print!("{}", format_colored(&entries, &config.name));
 

--- a/rustnetconf-cli/src/commands/plan.rs
+++ b/rustnetconf-cli/src/commands/plan.rs
@@ -34,7 +34,7 @@ pub async fn run(
         // Strip <configuration> wrapper from desired to match the vendor-unwrapped
         // running config. The vendor profile strips this from get-config responses,
         // so the desired XML needs the same treatment for an accurate diff.
-        let desired_inner = strip_configuration_wrapper(&config.xml);
+        let desired_inner = client.unwrap_config(&config.xml);
         let entries = diff_xml(&desired_inner, &running)?;
 
         if !entries.is_empty() {
@@ -59,21 +59,4 @@ pub async fn run(
         .map_err(|e| format!("close failed: {e}"))?;
 
     Ok(has_changes)
-}
-
-/// Strip outer `<configuration ...>...</configuration>` wrapper from XML.
-/// Matches the vendor profile's unwrap_config behavior.
-pub fn strip_configuration_wrapper(xml: &str) -> String {
-    let trimmed = xml.trim();
-    if let Some(start) = trimmed.find("<configuration") {
-        if let Some(tag_end) = trimmed[start..].find('>') {
-            let inner_start = start + tag_end + 1;
-            if let Some(close) = trimmed.rfind("</configuration>") {
-                if inner_start < close {
-                    return trimmed[inner_start..close].trim().to_string();
-                }
-            }
-        }
-    }
-    trimmed.to_string()
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -495,6 +495,15 @@ impl Client {
         self.session.vendor_name()
     }
 
+    /// Normalize a config fragment using the connected device's vendor profile.
+    ///
+    /// Junos strips the outer `<configuration>` wrapper; generic vendors pass
+    /// the input through unchanged. Useful for diffing a desired config against
+    /// a (already vendor-unwrapped) running config.
+    pub fn unwrap_config(&self, xml: &str) -> String {
+        self.session.unwrap_config(xml)
+    }
+
     /// Get the device's capabilities.
     pub fn capabilities(&self) -> Option<&Capabilities> {
         self.session.capabilities()
@@ -1283,5 +1292,30 @@ mod tests {
 
         let mut client = Client::from_session_for_test(session);
         client.release_candidate_lock_best_effort().await;
+    }
+
+    #[test]
+    fn test_unwrap_config_generic_passes_through() {
+        use crate::transport::mock::MockTransport;
+        // Generic vendor is the default when no hello/detection has run.
+        let transport = MockTransport::new(Vec::new());
+        let session = Session::new(Box::new(transport));
+        let client = Client::from_session_for_test(session);
+
+        let input = "<configuration><foo>bar</foo></configuration>";
+        // Generic unwrap_config is a passthrough: input is returned unchanged.
+        assert_eq!(client.unwrap_config(input), input);
+    }
+
+    #[test]
+    fn test_unwrap_config_junos_strips_configuration_wrapper() {
+        use crate::transport::mock::MockTransport;
+        let transport = MockTransport::new(Vec::new());
+        let mut session = Session::new(Box::new(transport));
+        session.set_vendor_profile(Box::new(crate::vendor::junos::JunosVendor::default()));
+        let client = Client::from_session_for_test(session);
+
+        let input = "<configuration junos:commit-seconds=\"1\"><foo>bar</foo></configuration>";
+        assert_eq!(client.unwrap_config(input), "<foo>bar</foo>");
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -243,6 +243,14 @@ impl Session {
         self.vendor_profile.name()
     }
 
+    /// Normalize a config fragment the way this session's vendor profile does
+    /// (e.g. Junos strips the outer `<configuration>` wrapper; generic passes
+    /// through). This is the same operation applied to get-config responses,
+    /// exposed so callers can normalize a *desired* config symmetrically.
+    pub fn unwrap_config(&self, xml: &str) -> String {
+        self.vendor_profile.unwrap_config(xml)
+    }
+
     /// Get the device facts.
     pub fn facts(&self) -> &Facts {
         &self.facts


### PR DESCRIPTION
## Summary

The CLI's `strip_configuration_wrapper` was a hand-copied clone of `JunosVendor::unwrap_config`, and `apply.rs` reached across into `plan.rs` to reuse it. This routes desired-config normalization through the **connected device's real vendor profile** instead.

- **Library:** new `Session::unwrap_config` + `Client::unwrap_config`, delegating to the vendor profile's `unwrap_config` (mirrors the existing `vendor_name` delegation chain). Additive public API — no existing signatures change.
- **CLI:** `plan.rs` and `apply.rs` now call `client.unwrap_config(&config.xml)`; the duplicated helper and the `apply → plan` cross-module coupling are deleted.

### Latent bug fixed
The CLI stripped `<configuration>` from the desired config **unconditionally** — even against a generic (non-Junos) device, whose real `unwrap_config` is a passthrough. That made the diff asymmetric (desired stripped, running not). Now both sides pass through the same vendor path, so the diff is correct for every vendor. **Junos behavior is unchanged;** only non-Junos diffs change (they get more correct).

## Testing
- `cargo test -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls` — 347 pass, 0 fail (2 new unit tests: junos strips, generic passes through; generic-passthrough written TDD-first as the previously-wrong behavior)
- `cargo clippy … -- -D warnings` — clean

## Process
Brainstormed → spec → plan → subagent-driven execution (implementer + task review per task, plus a final whole-branch review, all clean). Design spec and implementation plan are included under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)