### PR TITLE
chore: bump rustnetconf 0.13.0 + rustnetconf-cli 0.3.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1834,7 +1834,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.12.3"
+version = "0.13.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -1855,7 +1855,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-cli"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.12.3"
+version = "0.13.0"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.12.3](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.12.3)** (parser correctness patch).
-> Now on crates.io: `rustnetconf` 0.12.3 · `rustnetconf-cli` 0.3.3 · `rustnetconf-yang` 0.1.4.
-> See [What's New in v0.12.3](#whats-new-in-v0123) below for five XML parser fixes from a full code review.
+> **Latest release — [v0.13.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.13.0)** (vendor-profile plumbing).
+> Now on crates.io: `rustnetconf` 0.13.0 · `rustnetconf-cli` 0.3.4 · `rustnetconf-yang` 0.1.4.
+> See [What's New in v0.13.0](#whats-new-in-v0130) below for the pool vendor-override fix and vendor-aware CLI diffs.
 
 ## Workspace
 
@@ -35,6 +35,15 @@ Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and
 | **rustnetconf** | Async NETCONF 1.0/1.1 client library |
 | **rustnetconf-yang** | YANG model code generation (compile-time config validation) |
 | **rustnetconf-cli** | Terraform-like CLI tool (`netconf` binary) |
+
+## What's New in v0.13.0
+
+Vendor-profile plumbing for `rustnetconf` (0.13.0) and `rustnetconf-cli` (0.3.4), from a project review (PRs #37, #38). `rustnetconf-yang` is unchanged at 0.1.4.
+
+- **`DevicePool` honors an explicit vendor profile.** `DeviceConfig.vendor` is now wired into connection setup — previously it was silently ignored. The field changed from `Box<dyn VendorProfile>` to `Arc<dyn VendorProfile>`; new `ClientBuilder::vendor_profile_arc()` and `Session::set_vendor_profile_arc()` support the shared-ownership path. The existing `vendor_profile(Box<…>)` API is unchanged.
+- **New `Client::unwrap_config()`** (and `Session::unwrap_config()`) exposes the connected device's vendor `unwrap_config` — additive public API.
+- **Vendor-aware CLI diffs.** `netconf plan`/`apply` now normalize the desired config through the connected device's vendor profile instead of a hardcoded `<configuration>` strip. This fixes an asymmetric, potentially wrong diff against generic (non-Junos) devices; Junos behavior is unchanged.
+- Internally, `VendorProfile::post_facts_hook` takes `&self` (with `JunosVendor` cluster state moved to interior mutability) so profiles work under `Arc`.
 
 ## What's New in v0.12.3
 

--- a/rustnetconf-cli/Cargo.toml
+++ b/rustnetconf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-cli"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "Terraform-like CLI for declarative NETCONF network config management"
@@ -13,7 +13,7 @@ name = "netconf"
 path = "src/main.rs"
 
 [dependencies]
-rustnetconf = { version = "0.12", path = ".." }
+rustnetconf = { version = "0.13", path = ".." }
 clap = { version = "4", features = ["derive"] }
 colored = "3"
 toml = "0.8"

--- a/rustnetconf-yang/Cargo.toml
+++ b/rustnetconf-yang/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming"]
 generated = []
 
 [dependencies]
-rustnetconf = { version = "0.12", path = ".." }
+rustnetconf = { version = "0.13", path = ".." }
 serde = { version = "1", features = ["derive"] }
 quick-xml = "0.41"
 thiserror = "2"


### PR DESCRIPTION
Release bump covering the vendor-profile work merged in #37 and #38.

## Versions
| Crate | From | To | Why |
|---|---|---|---|
| `rustnetconf` | 0.12.3 | **0.13.0** | New public API (`Client`/`Session::unwrap_config`, `vendor_profile_arc`, `set_vendor_profile_arc`) + source-breaking `DeviceConfig.vendor` `Box→Arc` |
| `rustnetconf-cli` | 0.3.3 | **0.3.4** | Vendor-aware `plan`/`apply` diffs (behavior fix, no API change) |
| `rustnetconf-yang` | 0.1.4 | 0.1.4 | Unchanged |

## Changes
- Bump `[package] version` in `rustnetconf` and `rustnetconf-cli`.
- Bump the internal `rustnetconf = "0.13"` version requirement in the `cli` and `yang` crates (the old `"0.12"` req would fail to resolve against 0.13.0).
- Regenerate `Cargo.lock`.
- Add a **What's New in v0.13.0** section to the README and update the latest-release header.

## Verification
- `cargo build`/`cargo test -p rustnetconf -p rustnetconf-cli --features rustnetconf/tls` — 347 pass, 0 fail at the new versions.

Merge this, then tag `v0.13.0` and publish to crates.io per the usual flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)