### PR TITLE
chore: bump rustnetconf 0.13.1 (russh 0.62, #40)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.13.0"
+version = "0.13.1"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"


### PR DESCRIPTION
Patch release carrying the russh 0.61 → 0.62 bump from #40.

## What
- `rustnetconf` 0.13.0 → **0.13.1**

## Why
#40 (merged) moved the SSH transport's crypto dependency tree off most prerelease (`-rc`) crates by bumping russh to 0.62. This release publishes that so downstream consumers (rustEZ, rustjunosmcp) can pick it up via `cargo update`.

## Scope
- Patch bump: russh is an internal impl detail, public API is unchanged.
- `rustnetconf-cli` / `rustnetconf-yang` pin `rustnetconf = "0.13"` and pick this up automatically — no bump needed.
- `cargo publish --dry-run --all-features` passes (packages + compiles clean).

Publish to crates.io + tag `v0.13.1` + GitHub release will follow once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)