### PR TITLE
chore: bump rustnetconf 0.13.2 (#43 cluster commit-check parse fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.13.1"
+version = "0.13.2"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.13.1"
+version = "0.13.2"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"


### PR DESCRIPTION
Patch release carrying the #43 fix (PR #44): tolerate unclosed `<routing-engine>` in Junos chassis-cluster validate/commit-check replies.

- `rustnetconf` 0.13.1 → 0.13.2 (Cargo.toml + Cargo.lock).
- CLI and yang crates pin `rustnetconf = "0.13"`, so no changes needed there.
- Unblocks downstream rustjunosmcp#180 once it depends on 0.13.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)