### PR TITLE
chore(deps): bump russh from 0.62.4 to 0.62.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "russh"
-version = "0.62.4"
+version = "0.62.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8b67b5a0d8068c89dcbe9d95df986af7a851d1f3c604525274c37468e60464f"
+checksum = "da7c230e0ed9cbeb92fbad6c8848985d6df2a1464c0dc247a021abd666e9005e"
 dependencies = [
  "aes",
  "aws-lc-rs",


### PR DESCRIPTION
Lockfile-only bump of `russh` 0.62.4 → 0.62.5. `Cargo.toml` needs no change — the existing `russh = "0.62"` caret already permits it.

## What's in the release

- **`Channel::data()` backpressure** ([russh#725](https://github.com/warp-tech/russh/issues/725)) — a real, if minor, client-side fix.
- **[GHSA-m65r-rprj-r5rg](https://github.com/Eugeny/russh/security/advisories/GHSA-m65r-rprj-r5rg)** — `Handler` callbacks fired for non-existent channel IDs. This is **server-side only**. rustnetconf uses `russh::client` exclusively (`src/transport/ssh.rs`), with no `russh::server` anywhere in `src/`, so this is not remediation for an exposure here.

## Why this supersedes #48

Dependabot opened #48 for the same bump and CI passed on its original head `5273588`. It then fell behind `main`, and no recovery path could produce a head with the required checks: `gh pr update-branch`, `@dependabot recreate`, and a plain user push to this branch all produced zero workflow runs.

The cause is a **GitHub Actions outage** on 2026-08-06 (githubstatus.com, impact `critical`) — no workflow has run in this repo since 2026-08-05 17:58 UTC. With `main` requiring all six checks under strict up-to-date, nothing is mergeable until Actions recovers.

This branch carries the identical lockfile diff on a clean, non-dependabot-managed branch, so it can be re-triggered freely once CI is back. Local `cargo test --locked --all-features` passes.

Closes #48