### PR TITLE
chore: license gating, documented scope, and 0.13.3 release prep

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -42,7 +42,10 @@ jobs:
         uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: cargo-deny (bans + sources)
+      - name: cargo-deny (bans + sources + licenses)
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
-          command: check bans sources
+          # Licenses are gated by the allow-list in deny.toml. Before that file
+          # existed this ran `check bans sources` only, because with no config
+          # cargo-deny rejects every license by default.
+          command: check bans sources licenses

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.13.2"
+version = "0.13.3"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.13.2"
+version = "0.13.3"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.13.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.13.0)** (vendor-profile plumbing).
-> Now on crates.io: `rustnetconf` 0.13.0 · `rustnetconf-cli` 0.3.4 · `rustnetconf-yang` 0.1.4.
-> See [What's New in v0.13.0](#whats-new-in-v0130) below for the pool vendor-override fix and vendor-aware CLI diffs.
+> **Latest release — [v0.13.3](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.13.3)** (dependency and parser maintenance).
+> On crates.io: `rustnetconf` 0.13.3 · `rustnetconf-cli` 0.3.4 · `rustnetconf-yang` 0.1.4.
+> See [What's New in v0.13.3](#whats-new-in-v0133) below.
 
 ## Workspace
 
@@ -47,6 +47,16 @@ SSH is present as a *transport for NETCONF*, not as a general-purpose capability
 - Remote shell or command execution
 
 Consumers that need those should use a dedicated SSH crate alongside this one. A native SCP1 client was briefly added and then reverted before it was ever released (#52, reverted by #53) for exactly this reason; issues #47 and #51 were closed as not planned on the same grounds. The round trip is visible in `git log` between v0.13.2 and the next release — it was a deliberate reversal, not an accident.
+
+## What's New in v0.13.3
+
+Maintenance release for `rustnetconf` (0.13.3). `rustnetconf-cli` (0.3.4) and `rustnetconf-yang` (0.1.4) are unchanged. No public API changes — a drop-in patch upgrade from 0.13.2.
+
+- **RPC reply parsing hardened** (#49). Reply parsing and repair moved into a dedicated `reply` module with tightened handling of malformed and partial replies. `parse_rpc_reply`, `RpcReply`, and `RpcErrorInfo` keep their existing paths and signatures via re-export.
+- **russh 0.62.4 → 0.62.5** (#50). Picks up the `Channel::data()` backpressure fix. The GHSA-m65r-rprj-r5rg advisory in that release is server-side only; this crate uses `russh::client` exclusively and was never exposed to it.
+- **cmov 0.5.3 → 0.5.4** (#46).
+- **License gating in CI.** A `deny.toml` allow-list now exists, and CI runs `cargo deny check bans sources licenses`. Previously licenses were ungated, because with no config cargo-deny rejects every license by default.
+- **Scope documented** — see [Scope](#scope). A native SCP1 client was added (#52) and reverted (#53) within this cycle, before any release; issues #47 and #51 were closed on the same grounds. No released version ever contained it.
 
 ## What's New in v0.13.0
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and
 | **rustnetconf-yang** | YANG model code generation (compile-time config validation) |
 | **rustnetconf-cli** | Terraform-like CLI tool (`netconf` binary) |
 
+## Scope
+
+This is a **NETCONF library** — RFC 6241 (the protocol) and RFC 6242 (NETCONF over SSH) — plus YANG code generation and a CLI built on it.
+
+SSH is present as a *transport for NETCONF*, not as a general-purpose capability. The crate deliberately does **not** provide:
+
+- File transfer (SFTP, SCP) — it is not a file-transfer library
+- A public `russh` handle, or a generic "open any SSH subsystem" escape hatch — the SSH connection is an implementation detail of the NETCONF transport, and keeping it private is what stops this crate's public API from becoming russh's version surface
+- Remote shell or command execution
+
+Consumers that need those should use a dedicated SSH crate alongside this one. A native SCP1 client was briefly added and then reverted before it was ever released (#52, reverted by #53) for exactly this reason; issues #47 and #51 were closed as not planned on the same grounds. The round trip is visible in `git log` between v0.13.2 and the next release — it was a deliberate reversal, not an accident.
+
 ## What's New in v0.13.0
 
 Vendor-profile plumbing for `rustnetconf` (0.13.0) and `rustnetconf-cli` (0.3.4), from a project review (PRs #37, #38). `rustnetconf-yang` is unchanged at 0.1.4.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,49 @@
+# cargo-deny configuration.
+#
+# CI runs `cargo deny check bans sources licenses` (.github/workflows/security.yml).
+# Advisories are covered separately by `cargo audit` in the same workflow.
+
+[graph]
+all-features = true
+
+[licenses]
+# Permissive licenses only. Every entry below is present in the current
+# dependency tree — this is an inventory, not an aspirational list. Adding a
+# license here is a deliberate act: check the obligations it imposes first.
+#
+# Deliberately absent: LGPL-2.1-or-later. It appears in the tree via r-efi,
+# which is `MIT OR Apache-2.0 OR LGPL-2.1-or-later`, so the MIT arm satisfies
+# it and no copyleft obligation attaches. If a crate ever arrives that offers
+# LGPL *only*, this check should fail and prompt a decision rather than
+# silently accept it.
+allow = [
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-1-Clause",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "CC0-1.0",
+    # Mozilla's CA root bundle (webpki-roots), reached via the `tls` feature.
+    # A permissive *data* license — no copyleft, no source obligation.
+    "CDLA-Permissive-2.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "Unicode-3.0",
+    "Unlicense",
+    "Zlib",
+]
+
+# Refuse to guess when a license file is ambiguous — an unclear license should
+# fail the check, not be approximated.
+confidence-threshold = 0.93
+
+[bans]
+multiple-versions = "allow"
+wildcards = "deny"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
Three related follow-ups: close the ungated license check, write down the library's scope so the SCP round trip reads as deliberate, and prepare the 0.13.3 patch release.

## 1. License gating (`deny.toml`)

The repo had no `deny.toml`, so `cargo deny check licenses` rejected every license by default and failed on any tree. CI worked around that by running `check bans sources` only — leaving licenses effectively ungated.

This adds an allow-list built from the crate's actual dependency graph under `--all-features`, and wires `licenses` into the CI command.

- **`LGPL-2.1-or-later` is deliberately not allowed.** It appears via `r-efi`, which is `MIT OR Apache-2.0 OR LGPL-2.1-or-later`, so the MIT arm satisfies it and no copyleft obligation attaches. A crate offering LGPL *only* should fail this check and force a decision.
- **`CDLA-Permissive-2.0` is allowed** for `webpki-roots` (Mozilla's CA bundle, reached through the `tls` feature) — a permissive data license with no source obligation.

Verified: `cargo deny check bans sources licenses` → `bans ok, licenses ok, sources ok`.

## 2. Documented scope (README)

States plainly that this is a NETCONF library (RFC 6241/6242), and that SSH is a transport for NETCONF rather than a general capability — no file transfer, no public `russh` handle, no generic subsystem escape hatch.

Records that the SCP1 client was added (#52) and reverted (#53) before any release, and that #47 and #51 were closed on the same grounds, so the round trip in `git log` reads as a deliberate reversal.

## 3. Release prep — 0.13.3

Patch bump. **No public API changes**, so it is a drop-in upgrade from 0.13.2 and is picked up automatically by consumers requiring `"0.13"` (which is how `rust-junosmcp` depends on it).

Contents since v0.13.2 — all currently unreleased:

| Change | |
|---|---|
| #49 | RPC reply parsing/repair hardened; `parse_rpc_reply`, `RpcReply`, `RpcErrorInfo` moved to a `reply` module but re-exported at existing paths with unchanged signatures |
| #50 | russh 0.62.4 → 0.62.5 (`Channel::data()` backpressure) |
| #46 | cmov 0.5.3 → 0.5.4 |
| #52/#53 | SCP1 client added and reverted in-cycle — net zero |

`rustnetconf-cli` (0.3.4) and `rustnetconf-yang` (0.1.4) are unchanged since v0.13.2 and are not republished; both pin `rustnetconf = "0.13"`, which 0.13.3 satisfies.

Also fixes the README "Latest release" callout, which still advertised v0.13.0 after 0.13.1 and 0.13.2 shipped.

## Verification

- `cargo test --locked --all-features` — 412 pass, 0 fail
- `cargo fmt --check`, clippy under `-D warnings` — clean
- `cargo package -p rustnetconf` — clean 0.13.3 artifact, 60 files / 187.9 KiB compressed
- `cargo audit` clean · `cargo deny check bans sources licenses` ok
- Codex review, commit and branch scope — no actionable defects

**Not done here:** tagging and `cargo publish`. Those stay manual.