### PR TITLE
fix(junos): only discard the candidate on close if this session dirtied it

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -495,6 +495,45 @@ impl Client {
         self.session.vendor_name()
     }
 
+    /// Check if this session may have dirtied the candidate datastore.
+    ///
+    /// Returns `true` if the session has called candidate-modifying operations
+    /// like `edit_config(Datastore::Candidate, ...)`, `load_configuration()`,
+    /// or `rollback_configuration()` since the last `commit()` or `discard_changes()`.
+    pub fn candidate_dirty(&self) -> bool {
+        self.session.candidate_dirty()
+    }
+
+    /// Mark the candidate datastore as dirty.
+    ///
+    /// Call this **before** issuing a candidate-modifying RPC through the raw
+    /// [`rpc()`](Self::rpc) or [`rpc_with_warnings()`](Self::rpc_with_warnings)
+    /// escape hatch, so [`close_session()`](Self::close_session) will send
+    /// `<discard-changes/>` to clean up the shared candidate datastore.
+    ///
+    /// This is a safety mechanism for Junos and other devices with a shared
+    /// candidate datastore. When a session closes without committing, uncommitted
+    /// changes must be discarded so they don't interfere with the next operator's
+    /// session.
+    ///
+    /// # Why mark BEFORE the RPC?
+    ///
+    /// Marking before (not after) the RPC ensures that a timeout, cancellation,
+    /// or error-after-partial-application still counts as dirty, matching the
+    /// behavior of built-in operations like `load_configuration()`. A failed or
+    /// partially-applied RPC may still leave uncommitted changes that need cleanup.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Mark BEFORE awaiting the RPC
+    /// client.mark_candidate_dirty();
+    /// client.rpc("<load-configuration>...</load-configuration>").await?;
+    /// ```
+    pub fn mark_candidate_dirty(&mut self) {
+        self.session.mark_candidate_dirty()
+    }
+
     /// Normalize a config fragment using the connected device's vendor profile.
     ///
     /// Junos strips the outer `<configuration>` wrapper; generic vendors pass
@@ -1317,5 +1356,144 @@ mod tests {
 
         let input = "<configuration junos:commit-seconds=\"1\"><foo>bar</foo></configuration>";
         assert_eq!(client.unwrap_config(input), "<foo>bar</foo>");
+    }
+
+    /// Build a mock Junos hello response with EOM framing.
+    fn mock_junos_hello() -> Vec<u8> {
+        let hello = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+    <capability>urn:ietf:params:netconf:capability:candidate:1.0</capability>
+    <capability>http://xml.juniper.net/netconf/junos/1.0</capability>
+  </capabilities>
+  <session-id>1</session-id>
+</hello>"#;
+        let mut buf = hello.as_bytes().to_vec();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    /// Test that Client exposes mark_candidate_dirty and that it causes
+    /// close_session to send discard-changes on Junos.
+    #[tokio::test]
+    async fn client_mark_candidate_dirty_causes_discard_on_close() {
+        use crate::transport::mock::MockTransport;
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // raw rpc reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        let mut client = Client::from_session_for_test(session);
+
+        // Send a raw RPC (simulating a candidate-modifying vendor RPC)
+        client
+            .rpc("<load-configuration><configuration><foo/></configuration></load-configuration>")
+            .await
+            .expect("raw rpc failed");
+
+        // Mark candidate as dirty
+        client.mark_candidate_dirty();
+
+        // Close session
+        client.close_session().await.expect("close failed");
+
+        // Verify discard-changes was sent exactly once
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "Junos session with marked candidate should send discard-changes once on close"
+        );
+    }
+
+    /// Test that Client without mark_candidate_dirty does not send discard.
+    #[tokio::test]
+    async fn client_without_mark_dirty_does_not_send_discard() {
+        use crate::transport::mock::MockTransport;
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // raw rpc reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // close-session reply (no discard)
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        let mut client = Client::from_session_for_test(session);
+
+        // Send a read-only raw RPC
+        client
+            .rpc("<get-configuration><configuration/></get-configuration>")
+            .await
+            .expect("raw rpc failed");
+
+        // Do NOT mark candidate as dirty
+
+        // Close session
+        client.close_session().await.expect("close failed");
+
+        // Verify no discard-changes was sent
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 0,
+            "Junos session without mark_candidate_dirty should NOT send discard-changes on close"
+        );
+    }
+
+    /// Test that candidate_dirty() reflects state correctly.
+    #[tokio::test]
+    async fn client_candidate_dirty_reflects_state() {
+        use crate::transport::mock::MockTransport;
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // raw rpc reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let mut client = Client::from_session_for_test(session);
+
+        // Initially false
+        assert!(
+            !client.candidate_dirty(),
+            "candidate should not be dirty initially"
+        );
+
+        // Send a raw RPC
+        client
+            .rpc("<load-configuration><configuration><foo/></configuration></load-configuration>")
+            .await
+            .expect("raw rpc failed");
+
+        // Still false (not marked)
+        assert!(
+            !client.candidate_dirty(),
+            "candidate should not be dirty before marking"
+        );
+
+        // Mark it
+        client.mark_candidate_dirty();
+
+        // Now true
+        assert!(
+            client.candidate_dirty(),
+            "candidate should be dirty after marking"
+        );
+
+        // Close to clean up
+        client.close_session().await.expect("close failed");
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -485,6 +485,37 @@ impl Client {
         self.session.rpc(rpc_content).await
     }
 
+    /// Send an arbitrary RPC that modifies the candidate datastore.
+    ///
+    /// This is the preferred way to send vendor-specific candidate-modifying RPCs
+    /// (e.g., Junos `<load-configuration>`). It validates the XML fragment locally
+    /// first; if validation fails, the error is returned WITHOUT marking the
+    /// candidate dirty. If validation passes, the candidate is marked dirty and
+    /// the RPC is sent.
+    ///
+    /// Marking happens AFTER local validation but BEFORE sending to ensure that:
+    /// - A locally-malformed fragment does not incorrectly mark dirty
+    /// - A timeout or partially-applied change still marks dirty for cleanup
+    ///
+    /// When [`close_session()`](Self::close_session) is called, it will send
+    /// `<discard-changes/>` to clean up this session's uncommitted changes on
+    /// devices with a shared candidate datastore (e.g., Junos).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Atomic: validates first, marks only if valid, then sends
+    /// client.rpc_candidate_change(
+    ///     "<load-configuration><configuration><foo/></configuration></load-configuration>"
+    /// ).await?;
+    /// ```
+    pub async fn rpc_candidate_change(
+        &mut self,
+        rpc_content: &str,
+    ) -> Result<String, NetconfError> {
+        self.session.rpc_candidate_change(rpc_content).await
+    }
+
     /// Check if the device supports a specific capability URI.
     pub fn supports(&self, capability_uri: &str) -> bool {
         self.session.supports(capability_uri)
@@ -506,15 +537,28 @@ impl Client {
 
     /// Mark the candidate datastore as dirty.
     ///
-    /// Call this **before** issuing a candidate-modifying RPC through the raw
-    /// [`rpc()`](Self::rpc) or [`rpc_with_warnings()`](Self::rpc_with_warnings)
-    /// escape hatch, so [`close_session()`](Self::close_session) will send
-    /// `<discard-changes/>` to clean up the shared candidate datastore.
+    /// For vendor-specific candidate-modifying RPCs, prefer
+    /// [`rpc_candidate_change()`](Self::rpc_candidate_change) over manually
+    /// marking with this method. `rpc_candidate_change()` validates the fragment
+    /// locally first and only marks dirty if validation passes, preventing a
+    /// locally-rejected RPC from incorrectly marking the candidate dirty.
+    ///
+    /// If you must use the raw [`rpc()`](Self::rpc) or
+    /// [`rpc_with_warnings()`](Self::rpc_with_warnings) escape hatch, call this
+    /// **before** sending the RPC, so [`close_session()`](Self::close_session)
+    /// will send `<discard-changes/>` to clean up the shared candidate datastore.
     ///
     /// This is a safety mechanism for Junos and other devices with a shared
     /// candidate datastore. When a session closes without committing, uncommitted
     /// changes must be discarded so they don't interfere with the next operator's
     /// session.
+    ///
+    /// # Warning
+    ///
+    /// If you mark manually, ensure the RPC actually reached the device. Marking
+    /// before a locally-rejected RPC (e.g., malformed XML) can cause
+    /// [`close_session()`](Self::close_session) to discard another session's work
+    /// on a shared candidate.
     ///
     /// # Why mark BEFORE the RPC?
     ///
@@ -1374,46 +1418,6 @@ mod tests {
         buf
     }
 
-    /// Test that Client exposes mark_candidate_dirty and that it causes
-    /// close_session to send discard-changes on Junos.
-    #[tokio::test]
-    async fn client_mark_candidate_dirty_causes_discard_on_close() {
-        use crate::transport::mock::MockTransport;
-        let mut response_data = mock_junos_hello();
-        response_data.extend_from_slice(&mock_ok_reply("1")); // raw rpc reply
-        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
-        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
-
-        let transport = MockTransport::new(response_data);
-        let written_handle = transport.written_handle();
-        let mut session = Session::new(Box::new(transport));
-        session.establish().await.expect("establish failed");
-        assert_eq!(session.vendor_name(), "junos");
-
-        let mut client = Client::from_session_for_test(session);
-
-        // Send a raw RPC (simulating a candidate-modifying vendor RPC)
-        client
-            .rpc("<load-configuration><configuration><foo/></configuration></load-configuration>")
-            .await
-            .expect("raw rpc failed");
-
-        // Mark candidate as dirty
-        client.mark_candidate_dirty();
-
-        // Close session
-        client.close_session().await.expect("close failed");
-
-        // Verify discard-changes was sent exactly once
-        let written = written_handle.lock().unwrap();
-        let written_str = String::from_utf8_lossy(&written);
-        let discard_count = written_str.matches("discard-changes").count();
-        assert_eq!(
-            discard_count, 1,
-            "Junos session with marked candidate should send discard-changes once on close"
-        );
-    }
-
     /// Test that Client without mark_candidate_dirty does not send discard.
     #[tokio::test]
     async fn client_without_mark_dirty_does_not_send_discard() {
@@ -1495,5 +1499,165 @@ mod tests {
 
         // Close to clean up
         client.close_session().await.expect("close failed");
+    }
+
+    /// Test 1: rpc_candidate_change with well-formed fragment causes discard on close.
+    #[tokio::test]
+    async fn rpc_candidate_change_well_formed_causes_discard() {
+        use crate::transport::mock::MockTransport;
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // rpc_candidate_change reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        let mut client = Client::from_session_for_test(session);
+
+        // Use rpc_candidate_change with well-formed XML
+        client
+            .rpc_candidate_change(
+                "<load-configuration><configuration><foo/></configuration></load-configuration>",
+            )
+            .await
+            .expect("rpc_candidate_change failed");
+
+        // Close session
+        client.close_session().await.expect("close failed");
+
+        // Verify discard-changes was sent exactly once
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "Junos session with rpc_candidate_change should send discard-changes once on close"
+        );
+    }
+
+    /// Test 2: rpc_candidate_change with MALFORMED fragment does NOT mark dirty
+    /// and does NOT send discard on close. This is the core regression test for
+    /// defect 1 - locally-rejected RPC must not mark dirty.
+    #[tokio::test]
+    async fn rpc_candidate_change_malformed_does_not_mark_dirty() {
+        use crate::transport::mock::MockTransport;
+        let mut response_data = mock_junos_hello();
+        // No RPC reply needed - the malformed XML is rejected locally before sending
+        response_data.extend_from_slice(&mock_ok_reply("1")); // close-session reply (no discard)
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        let mut client = Client::from_session_for_test(session);
+
+        // Use rpc_candidate_change with MALFORMED XML (unclosed tag)
+        let result = client
+            .rpc_candidate_change(
+                "<load-configuration><configuration><foo></configuration></load-configuration>",
+            )
+            .await;
+
+        // Should fail with an error
+        assert!(result.is_err(), "Malformed XML should be rejected");
+
+        // Candidate should NOT be dirty
+        assert!(
+            !client.candidate_dirty(),
+            "candidate should not be dirty after locally-rejected RPC"
+        );
+
+        // Close session
+        client.close_session().await.expect("close failed");
+
+        // Verify NO discard-changes was sent
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 0,
+            "Junos session with locally-rejected RPC should NOT send discard-changes on close"
+        );
+    }
+
+    /// Test 3: rpc_candidate_change where RPC is sent but device never replies
+    /// (EOF) should still mark dirty, so partial changes get cleaned up.
+    #[tokio::test]
+    async fn rpc_candidate_change_eof_still_marks_dirty() {
+        use crate::transport::mock::MockTransport;
+        let response_data = mock_junos_hello();
+        // No reply for the RPC - EOF
+
+        let transport = MockTransport::new(response_data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        let mut client = Client::from_session_for_test(session);
+
+        // Use rpc_candidate_change with well-formed XML, but no reply comes back
+        let result = client
+            .rpc_candidate_change(
+                "<load-configuration><configuration><foo/></configuration></load-configuration>",
+            )
+            .await;
+
+        // Should fail with an error (EOF/transport error)
+        assert!(result.is_err(), "RPC with no reply should fail");
+
+        // Candidate SHOULD be dirty - the RPC was sent, may have been partially applied
+        assert!(
+            client.candidate_dirty(),
+            "candidate should be dirty after RPC was sent (even though it failed)"
+        );
+
+        // Note: we can't test close_session here because the transport is dead (EOF).
+        // The important assertion is that candidate_dirty() is true.
+    }
+
+    /// Test 4: Rewrite of client_mark_candidate_dirty_causes_discard_on_close
+    /// to use the DOCUMENTED ordering (mark BEFORE rpc).
+    #[tokio::test]
+    async fn client_mark_candidate_dirty_before_rpc_causes_discard_on_close() {
+        use crate::transport::mock::MockTransport;
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // raw rpc reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        let mut client = Client::from_session_for_test(session);
+
+        // Mark candidate as dirty BEFORE the RPC (documented order)
+        client.mark_candidate_dirty();
+
+        // Send a raw RPC (simulating a candidate-modifying vendor RPC)
+        client
+            .rpc("<load-configuration><configuration><foo/></configuration></load-configuration>")
+            .await
+            .expect("raw rpc failed");
+
+        // Close session
+        client.close_session().await.expect("close failed");
+
+        // Verify discard-changes was sent exactly once
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "Junos session with marked candidate should send discard-changes once on close"
+        );
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -259,7 +259,7 @@ impl Session {
 
     /// Mark the candidate datastore as dirty.
     ///
-    /// Call this after issuing a candidate-modifying RPC through the raw `rpc()`
+    /// Call this **before** issuing a candidate-modifying RPC through the raw `rpc()`
     /// escape hatch, so `close_session()` will send `<discard-changes/>` to clean
     /// up the shared candidate datastore.
     ///
@@ -267,6 +267,21 @@ impl Session {
     /// candidate datastore. When a session closes without committing, uncommitted
     /// changes must be discarded so they don't interfere with the next operator's
     /// session.
+    ///
+    /// # Why mark BEFORE the RPC?
+    ///
+    /// Marking before (not after) the RPC ensures that a timeout, cancellation,
+    /// or error-after-partial-application still counts as dirty, matching the
+    /// behavior of built-in operations like `load_configuration()`. A failed or
+    /// partially-applied RPC may still leave uncommitted changes that need cleanup.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Mark BEFORE awaiting the RPC
+    /// session.mark_candidate_dirty();
+    /// session.rpc("<load-configuration>...</load-configuration>").await?;
+    /// ```
     pub fn mark_candidate_dirty(&mut self) {
         self.candidate_dirty = true;
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -259,14 +259,26 @@ impl Session {
 
     /// Mark the candidate datastore as dirty.
     ///
-    /// Call this **before** issuing a candidate-modifying RPC through the raw `rpc()`
-    /// escape hatch, so `close_session()` will send `<discard-changes/>` to clean
-    /// up the shared candidate datastore.
+    /// For vendor-specific candidate-modifying RPCs, prefer
+    /// [`rpc_candidate_change()`](Self::rpc_candidate_change) over manually
+    /// marking with this method. `rpc_candidate_change()` validates the fragment
+    /// locally first and only marks dirty if validation passes, preventing a
+    /// locally-rejected RPC from incorrectly marking the candidate dirty.
+    ///
+    /// If you must use the raw [`rpc()`](Self::rpc) escape hatch, call this
+    /// **before** sending the RPC, so [`close_session()`](Self::close_session)
+    /// will send `<discard-changes/>` to clean up the shared candidate datastore.
     ///
     /// This is a safety mechanism for Junos and other devices with a shared
     /// candidate datastore. When a session closes without committing, uncommitted
     /// changes must be discarded so they don't interfere with the next operator's
     /// session.
+    ///
+    /// # Warning
+    ///
+    /// If you mark manually, ensure the RPC actually reached the device. Marking
+    /// before a locally-rejected RPC (e.g., malformed XML) can cause `close_session()`
+    /// to discard another session's work on a shared candidate.
     ///
     /// # Why mark BEFORE the RPC?
     ///
@@ -605,6 +617,50 @@ impl Session {
     /// sanitized before passing to this method.
     pub async fn rpc(&mut self, rpc_content: &str) -> Result<String, NetconfError> {
         rpc::validate_xml_fragment(rpc_content)?;
+        self.send_raw_rpc(rpc_content).await
+    }
+
+    /// Send an arbitrary RPC that modifies the candidate datastore.
+    ///
+    /// This is the preferred way to send vendor-specific candidate-modifying RPCs
+    /// (e.g., Junos `<load-configuration>`). It validates the XML fragment locally
+    /// first; if validation fails, the error is returned WITHOUT marking the
+    /// candidate dirty. If validation passes, the candidate is marked dirty and
+    /// the RPC is sent.
+    ///
+    /// Marking happens AFTER local validation but BEFORE sending to ensure that:
+    /// - A locally-malformed fragment does not incorrectly mark dirty
+    /// - A timeout or partially-applied change still marks dirty for cleanup
+    ///
+    /// When `close_session()` is called, it will send `<discard-changes/>` to
+    /// clean up this session's uncommitted changes on devices with a shared
+    /// candidate datastore (e.g., Junos).
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// // Atomic: validates first, marks only if valid, then sends
+    /// session.rpc_candidate_change(
+    ///     "<load-configuration><configuration><foo/></configuration></load-configuration>"
+    /// ).await?;
+    /// ```
+    pub async fn rpc_candidate_change(
+        &mut self,
+        rpc_content: &str,
+    ) -> Result<String, NetconfError> {
+        // Validate locally first - if this fails, do NOT mark dirty
+        rpc::validate_xml_fragment(rpc_content)?;
+
+        // Validation passed - mark dirty BEFORE sending
+        self.candidate_dirty = true;
+
+        // Send the RPC
+        self.send_raw_rpc(rpc_content).await
+    }
+
+    /// Internal helper: send an already-validated RPC fragment.
+    /// Used by both `rpc()` and `rpc_candidate_change()` after validation.
+    async fn send_raw_rpc(&mut self, rpc_content: &str) -> Result<String, NetconfError> {
         let msg_id = self.next_message_id();
         let safe_id = crate::rpc::operations::escape_xml_attr(&msg_id);
         let xml = format!(

--- a/src/session.rs
+++ b/src/session.rs
@@ -617,20 +617,20 @@ impl Session {
     /// sanitized before passing to this method.
     pub async fn rpc(&mut self, rpc_content: &str) -> Result<String, NetconfError> {
         rpc::validate_xml_fragment(rpc_content)?;
-        self.send_raw_rpc(rpc_content).await
+        self.dispatch_rpc_fragment(rpc_content).await
     }
 
     /// Send an arbitrary RPC that modifies the candidate datastore.
     ///
     /// This is the preferred way to send vendor-specific candidate-modifying RPCs
     /// (e.g., Junos `<load-configuration>`). It validates the XML fragment locally
-    /// first; if validation fails, the error is returned WITHOUT marking the
-    /// candidate dirty. If validation passes, the candidate is marked dirty and
-    /// the RPC is sent.
+    /// first, then runs all preflight checks (keepalive probe and session state).
+    /// Only after all checks pass does it mark the candidate dirty and send the RPC.
     ///
-    /// Marking happens AFTER local validation but BEFORE sending to ensure that:
+    /// Marking happens AFTER all preflight checks but BEFORE the write begins, so:
     /// - A locally-malformed fragment does not incorrectly mark dirty
-    /// - A timeout or partially-applied change still marks dirty for cleanup
+    /// - A failed preflight check (e.g., un-established session) does not mark dirty
+    /// - A timeout or error AFTER the write begins still marks dirty for cleanup
     ///
     /// When `close_session()` is called, it will send `<discard-changes/>` to
     /// clean up this session's uncommitted changes on devices with a shared
@@ -639,7 +639,7 @@ impl Session {
     /// # Example
     ///
     /// ```ignore
-    /// // Atomic: validates first, marks only if valid, then sends
+    /// // Atomic: validates, runs preflight, marks only if preflight passes, then sends
     /// session.rpc_candidate_change(
     ///     "<load-configuration><configuration><foo/></configuration></load-configuration>"
     /// ).await?;
@@ -648,24 +648,47 @@ impl Session {
         &mut self,
         rpc_content: &str,
     ) -> Result<String, NetconfError> {
-        // Validate locally first - if this fails, do NOT mark dirty
+        // 1. Validate locally first - if this fails, do NOT mark dirty
         rpc::validate_xml_fragment(rpc_content)?;
 
-        // Validation passed - mark dirty BEFORE sending
+        // 2. Run keepalive check if configured - if this fails, do NOT mark dirty
+        self.keepalive_check().await?;
+
+        // 3. Ensure session is established - if this fails, do NOT mark dirty
+        self.ensure_established()?;
+
+        // 4. All preflight passed - mark dirty NOW, before the write begins
         self.candidate_dirty = true;
 
-        // Send the RPC
-        self.send_raw_rpc(rpc_content).await
+        // 5. Build the RPC envelope and send via send_rpc_raw (bypasses keepalive re-check)
+        let msg_id = self.next_message_id();
+        let xml = Self::wrap_rpc_envelope(&msg_id, rpc_content);
+        let reply = self.send_rpc_raw(&xml, &msg_id).await?;
+
+        // 6. Map reply to String the same way rpc() does
+        match reply {
+            RpcReply::Data(data) | RpcReply::DataWithWarnings(data, _) => Ok(data),
+            RpcReply::Ok | RpcReply::OkWithWarnings(_) => Ok(String::new()),
+        }
     }
 
-    /// Internal helper: send an already-validated RPC fragment.
-    /// Used by both `rpc()` and `rpc_candidate_change()` after validation.
-    async fn send_raw_rpc(&mut self, rpc_content: &str) -> Result<String, NetconfError> {
-        let msg_id = self.next_message_id();
-        let safe_id = crate::rpc::operations::escape_xml_attr(&msg_id);
-        let xml = format!(
+    /// Internal helper: wrap a validated fragment in the `<rpc>` envelope.
+    ///
+    /// Shared by the raw-RPC paths so the envelope is built identically
+    /// whether or not the call marks the candidate dirty.
+    fn wrap_rpc_envelope(message_id: &str, rpc_content: &str) -> String {
+        let safe_id = crate::rpc::operations::escape_xml_attr(message_id);
+        format!(
             r#"<?xml version="1.0" encoding="UTF-8"?><nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">{rpc_content}</nc:rpc>"#
-        );
+        )
+    }
+
+    /// Internal helper: dispatch an already-validated RPC fragment.
+    /// Wraps the fragment in an `<rpc>` envelope, sends it, and extracts the response.
+    /// Used by `rpc()` after validation. Calls `send_rpc()` which runs the keepalive check.
+    async fn dispatch_rpc_fragment(&mut self, rpc_content: &str) -> Result<String, NetconfError> {
+        let msg_id = self.next_message_id();
+        let xml = Self::wrap_rpc_envelope(&msg_id, rpc_content);
         let reply = self.send_rpc(&xml, &msg_id).await?;
         match reply {
             RpcReply::Data(data) | RpcReply::DataWithWarnings(data, _) => Ok(data),
@@ -687,10 +710,7 @@ impl Session {
     ) -> Result<(String, Vec<RpcErrorInfo>), NetconfError> {
         rpc::validate_xml_fragment(rpc_content)?;
         let msg_id = self.next_message_id();
-        let safe_id = crate::rpc::operations::escape_xml_attr(&msg_id);
-        let xml = format!(
-            r#"<?xml version="1.0" encoding="UTF-8"?><nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">{rpc_content}</nc:rpc>"#
-        );
+        let xml = Self::wrap_rpc_envelope(&msg_id, rpc_content);
         let reply = self.send_rpc(&xml, &msg_id).await?;
         match reply {
             RpcReply::Data(data) => Ok((data, Vec::new())),
@@ -2232,6 +2252,118 @@ mod tests {
         assert_eq!(
             discard_count, 0,
             "generic vendor should never send discard-changes, even if candidate was edited"
+        );
+    }
+
+    // ── rpc_candidate_change preflight regression tests ────────────────
+
+    /// Test 1: rpc_candidate_change on un-established session returns error
+    /// and does NOT mark dirty. This is the core regression test for the
+    /// ensure_established preflight failure path.
+    #[tokio::test]
+    async fn test_rpc_candidate_change_failed_keepalive_does_not_mark_dirty() {
+        // Hello only: the keepalive probe that fires before the candidate RPC
+        // gets EOF, so nothing of the candidate change ever reaches the wire.
+        let response_data = mock_junos_hello();
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // A zero interval makes `last.elapsed() >= interval` true immediately,
+        // so the next RPC probes first — no sleeping, fully deterministic.
+        session.set_keepalive_interval(Duration::ZERO);
+
+        let result = session
+            .rpc_candidate_change(
+                "<load-configuration><configuration><foo/></configuration></load-configuration>",
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "keepalive probe hit EOF, so the RPC must fail"
+        );
+        assert!(
+            !session.candidate_dirty(),
+            "a candidate RPC that died in the keepalive preflight never reached \
+             the device, so it must not mark the shared candidate dirty"
+        );
+
+        let written = String::from_utf8_lossy(&written_handle.lock().unwrap()).into_owned();
+        assert!(
+            !written.contains("load-configuration"),
+            "the candidate change must not have been written"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rpc_candidate_change_not_established_does_not_mark_dirty() {
+        let transport = MockTransport::new(vec![]);
+        let mut session = Session::new(Box::new(transport));
+
+        // Do NOT call establish()
+
+        let result = session
+            .rpc_candidate_change(
+                "<load-configuration><configuration><foo/></configuration></load-configuration>",
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "rpc_candidate_change on un-established session should fail"
+        );
+
+        // Candidate must NOT be marked dirty
+        assert!(
+            !session.candidate_dirty(),
+            "candidate_dirty must be false when ensure_established() fails"
+        );
+    }
+
+    /// Test 2: rpc_candidate_change on properly established Junos session
+    /// with well-formed fragment still marks dirty and causes close_session
+    /// to send discard-changes. This is a guard against the restructure
+    /// breaking the happy path.
+    #[tokio::test]
+    async fn test_rpc_candidate_change_established_marks_dirty() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // rpc_candidate_change reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        // Call rpc_candidate_change with well-formed XML
+        session
+            .rpc_candidate_change(
+                "<load-configuration><configuration><foo/></configuration></load-configuration>",
+            )
+            .await
+            .expect("rpc_candidate_change failed");
+
+        // Candidate should be marked dirty
+        assert!(
+            session.candidate_dirty(),
+            "candidate should be dirty after successful rpc_candidate_change"
+        );
+
+        // Close session
+        session.close_session().await.expect("close failed");
+
+        // Verify discard-changes was sent exactly once
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "Junos session with rpc_candidate_change should send discard-changes once on close"
         );
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -101,6 +101,10 @@ pub struct Session {
     /// Maximum number of bytes that may accumulate in `read_buffer` before
     /// the read is aborted. Defaults to [`MAX_READ_BUFFER`].
     max_read_buffer: usize,
+    /// True if this session may have left uncommitted changes in the shared
+    /// candidate datastore. Used to decide whether to send `<discard-changes/>`
+    /// on close.
+    candidate_dirty: bool,
 }
 
 impl Session {
@@ -128,6 +132,7 @@ impl Session {
             has_subscription: false,
             rpc_timeout: None,
             max_read_buffer: MAX_READ_BUFFER,
+            candidate_dirty: false,
         }
     }
 
@@ -241,6 +246,29 @@ impl Session {
     /// Get the vendor profile name (e.g., "junos", "generic").
     pub fn vendor_name(&self) -> &str {
         self.vendor_profile.name()
+    }
+
+    /// Check if this session may have dirtied the candidate datastore.
+    ///
+    /// Returns `true` if the session has called candidate-modifying operations
+    /// like `edit_config(Datastore::Candidate, ...)`, `load_configuration()`,
+    /// or `rollback_configuration()` since the last `commit()` or `discard_changes()`.
+    pub fn candidate_dirty(&self) -> bool {
+        self.candidate_dirty
+    }
+
+    /// Mark the candidate datastore as dirty.
+    ///
+    /// Call this after issuing a candidate-modifying RPC through the raw `rpc()`
+    /// escape hatch, so `close_session()` will send `<discard-changes/>` to clean
+    /// up the shared candidate datastore.
+    ///
+    /// This is a safety mechanism for Junos and other devices with a shared
+    /// candidate datastore. When a session closes without committing, uncommitted
+    /// changes must be discarded so they don't interfere with the next operator's
+    /// session.
+    pub fn mark_candidate_dirty(&mut self) {
+        self.candidate_dirty = true;
     }
 
     /// Normalize a config fragment the way this session's vendor profile does
@@ -674,6 +702,12 @@ impl Session {
             error_option,
         };
         let xml = operations::edit_config_xml(&msg_id, &params);
+
+        // Mark candidate as dirty BEFORE sending, so a partial edit still counts
+        if target == Datastore::Candidate {
+            self.candidate_dirty = true;
+        }
+
         self.send_rpc(&xml, &msg_id).await?;
         Ok(())
     }
@@ -711,6 +745,8 @@ impl Session {
         self.pending_commit = false;
 
         result?;
+        // Clear dirty flag on success
+        self.candidate_dirty = false;
         Ok(())
     }
 
@@ -730,6 +766,8 @@ impl Session {
         let msg_id = self.next_message_id();
         let xml = operations::discard_changes_xml(&msg_id);
         self.send_rpc(&xml, &msg_id).await?;
+        // Clear dirty flag on success
+        self.candidate_dirty = false;
         Ok(())
     }
 
@@ -758,6 +796,8 @@ impl Session {
         let xml = operations::close_configuration_xml(&msg_id);
         self.send_rpc(&xml, &msg_id).await?;
         self.private_config_open = false;
+        // Clear dirty flag on success
+        self.candidate_dirty = false;
         Ok(())
     }
 
@@ -769,6 +809,8 @@ impl Session {
         let msg_id = self.next_message_id();
         let xml = operations::commit_configuration_xml(&msg_id);
         self.send_rpc(&xml, &msg_id).await?;
+        // Clear dirty flag on success
+        self.candidate_dirty = false;
         Ok(())
     }
 
@@ -778,6 +820,10 @@ impl Session {
     pub async fn rollback_configuration(&mut self, rollback: u32) -> Result<(), NetconfError> {
         let msg_id = self.next_message_id();
         let xml = operations::rollback_configuration_xml(&msg_id, rollback);
+
+        // Mark candidate as dirty before sending
+        self.candidate_dirty = true;
+
         self.send_rpc(&xml, &msg_id).await?;
         Ok(())
     }
@@ -819,6 +865,10 @@ impl Session {
     ) -> Result<String, NetconfError> {
         let msg_id = self.next_message_id();
         let xml = operations::load_configuration_xml(&msg_id, action, format, config);
+
+        // Mark candidate as dirty before sending
+        self.candidate_dirty = true;
+
         let reply = self.send_rpc(&xml, &msg_id).await?;
         match reply {
             RpcReply::Data(data) | RpcReply::DataWithWarnings(data, _) => Ok(data),
@@ -839,8 +889,9 @@ impl Session {
     /// Close the NETCONF session gracefully.
     ///
     /// Respects the vendor profile's close sequence. For example, Junos
-    /// discards uncommitted candidate changes before closing to avoid
-    /// leaving dirty state.
+    /// discards uncommitted candidate changes before closing, but only if
+    /// this session dirtied the candidate (to avoid destroying another
+    /// operator's uncommitted work in the shared candidate datastore).
     pub async fn close_session(&mut self) -> Result<(), NetconfError> {
         if self.state == SessionState::Closed {
             return Ok(());
@@ -852,8 +903,11 @@ impl Session {
             self.private_config_open = false;
         }
 
-        // Vendor-specific pre-close actions
-        if self.vendor_profile.close_sequence() == CloseSequence::DiscardThenClose {
+        // Vendor-specific pre-close actions: discard uncommitted changes
+        // if this session dirtied the candidate
+        if self.vendor_profile.close_sequence() == CloseSequence::DiscardThenClose
+            && self.candidate_dirty
+        {
             // Best-effort discard — don't fail the close if this errors
             let _ = self.discard_changes().await;
         }
@@ -909,6 +963,8 @@ impl Session {
         self.pending_commit = false;
 
         result?;
+        // Clear dirty flag on success
+        self.candidate_dirty = false;
         Ok(())
     }
 
@@ -1778,6 +1834,333 @@ mod tests {
             session.vendor_name(),
             "junos",
             "explicit Arc vendor override should survive auto-detection"
+        );
+    }
+
+    // ── Candidate dirty tracking tests ─────────────────────────────────
+
+    /// Build a mock Junos device hello response with EOM framing.
+    fn mock_junos_hello() -> Vec<u8> {
+        let hello = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+    <capability>urn:ietf:params:netconf:capability:candidate:1.0</capability>
+    <capability>http://xml.juniper.net/netconf/junos/1.0</capability>
+  </capabilities>
+  <session-id>1</session-id>
+</hello>"#;
+        let mut buf = hello.as_bytes().to_vec();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    #[tokio::test]
+    async fn test_junos_read_only_session_does_not_discard_on_close() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // get-config reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // close-session reply (no discard)
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        // Read-only operation
+        session
+            .get_config(Datastore::Candidate, None)
+            .await
+            .expect("get_config failed");
+
+        // Close session
+        session.close_session().await.expect("close failed");
+
+        // Verify no discard-changes was sent
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 0,
+            "read-only Junos session should NOT send discard-changes on close"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_junos_load_configuration_dirties_candidate() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // load-configuration reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        // Load configuration (dirties candidate)
+        session
+            .load_configuration(
+                crate::types::LoadAction::Merge,
+                crate::types::LoadFormat::Text,
+                "set system host-name test",
+            )
+            .await
+            .expect("load_configuration failed");
+
+        // Close session
+        session.close_session().await.expect("close failed");
+
+        // Verify discard-changes WAS sent
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "Junos session that loaded config should send discard-changes on close"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_junos_edit_config_candidate_dirties() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // edit-config reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // Edit candidate (dirties it)
+        session
+            .edit_config(
+                Datastore::Candidate,
+                "<system><host-name>test</host-name></system>",
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("edit_config failed");
+
+        session.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "edit-config on candidate should send discard-changes on close"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_junos_edit_config_running_does_not_dirty_candidate() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // edit-config reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // close-session reply (no discard)
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // Edit running (does NOT dirty candidate)
+        session
+            .edit_config(
+                Datastore::Running,
+                "<system><host-name>test</host-name></system>",
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("edit_config failed");
+
+        session.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 0,
+            "edit-config on running should NOT send discard-changes on close"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_junos_commit_clears_dirty_flag() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // load-configuration reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // commit reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply (no discard)
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // Load config (dirties candidate)
+        session
+            .load_configuration(
+                crate::types::LoadAction::Merge,
+                crate::types::LoadFormat::Text,
+                "set system host-name test",
+            )
+            .await
+            .expect("load_configuration failed");
+
+        // Commit (clears dirty flag)
+        session.commit().await.expect("commit failed");
+
+        // Close (should NOT send discard-changes)
+        session.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 0,
+            "commit should clear dirty flag, so close sends no discard-changes"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_junos_explicit_discard_clears_dirty_flag() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // load-configuration reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // explicit discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply (no second discard)
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // Load config (dirties candidate)
+        session
+            .load_configuration(
+                crate::types::LoadAction::Merge,
+                crate::types::LoadFormat::Text,
+                "set system host-name test",
+            )
+            .await
+            .expect("load_configuration failed");
+
+        // Explicit discard (clears dirty flag)
+        session
+            .discard_changes()
+            .await
+            .expect("discard_changes failed");
+
+        // Close (should NOT send another discard-changes)
+        session.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "explicit discard_changes followed by close should produce exactly 1 discard"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_junos_rollback_dirties_candidate() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // rollback-configuration reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // Rollback (dirties candidate)
+        session
+            .rollback_configuration(0)
+            .await
+            .expect("rollback_configuration failed");
+
+        session.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "rollback_configuration should send discard-changes on close"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_junos_mark_candidate_dirty_forces_discard() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // get-config reply (read-only)
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // Read-only operation
+        session
+            .get_config(Datastore::Candidate, None)
+            .await
+            .expect("get_config failed");
+
+        // Manually mark dirty (escape hatch for raw rpc() calls)
+        session.mark_candidate_dirty();
+
+        session.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "mark_candidate_dirty should force discard-changes on close"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generic_vendor_never_discards_on_close() {
+        let mut response_data = mock_device_hello(); // generic, NOT Junos
+        response_data.extend_from_slice(&mock_ok_reply("1")); // edit-config reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // close-session reply (no discard)
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "generic");
+
+        // Edit candidate (would dirty it on Junos)
+        session
+            .edit_config(
+                Datastore::Candidate,
+                "<system><host-name>test</host-name></system>",
+                None,
+                None,
+                None,
+            )
+            .await
+            .expect("edit_config failed");
+
+        session.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 0,
+            "generic vendor should never send discard-changes, even if candidate was edited"
         );
     }
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -38,13 +38,14 @@ pub trait Transport: Send + Sync {
 #[cfg(test)]
 pub mod mock {
     use super::*;
+    use std::sync::{Arc, Mutex};
 
     pub struct MockTransport {
         /// Data the "device" will send back (pre-loaded).
         read_data: Vec<u8>,
         read_pos: usize,
         /// Data written by the client (captured for assertions).
-        pub written: Vec<u8>,
+        written: Arc<Mutex<Vec<u8>>>,
         /// Whether the transport has been closed.
         pub closed: bool,
     }
@@ -55,9 +56,15 @@ pub mod mock {
             Self {
                 read_data,
                 read_pos: 0,
-                written: Vec::new(),
+                written: Arc::new(Mutex::new(Vec::new())),
                 closed: false,
             }
+        }
+
+        /// Get a handle to the written data that remains accessible after the
+        /// transport is moved into a Session.
+        pub fn written_handle(&self) -> Arc<Mutex<Vec<u8>>> {
+            Arc::clone(&self.written)
         }
     }
 
@@ -70,7 +77,7 @@ pub mod mock {
                     "transport closed",
                 )));
             }
-            self.written.extend_from_slice(data);
+            self.written.lock().unwrap().extend_from_slice(data);
             Ok(())
         }
 

--- a/src/vendor/junos.rs
+++ b/src/vendor/junos.rs
@@ -122,8 +122,11 @@ impl VendorProfile for JunosVendor {
     }
 
     fn close_sequence(&self) -> CloseSequence {
-        // Junos may have uncommitted candidate changes. Discard before closing
-        // to avoid leaving dirty state that blocks the next session's lock.
+        // Junos has a shared candidate datastore. If this session dirtied the
+        // candidate, discard uncommitted changes before closing to avoid leaving
+        // dirty state that blocks the next session's lock or destroys another
+        // operator's uncommitted work. The session tracks whether it dirtied the
+        // candidate and only sends discard-changes when necessary.
         CloseSequence::DiscardThenClose
     }
 


### PR DESCRIPTION
Closes #55.

## The bug

`Session::close_session()` sent `<discard-changes/>` unconditionally whenever the vendor profile returned `CloseSequence::DiscardThenClose`, which Junos does. On a standalone Junos device the candidate datastore is **shared**, so a session that never touched it would still wipe an operator's or another NETCONF client's uncommitted work on the way out. Reproduced on hardware.

The cruel part, from the issue: a consumer that locks gets refused with `configuration database modified` *because* somebody had uncommitted work — and then destroys precisely that work on close.

## The fix

Track whether *this* session dirtied the candidate, and gate the discard on it.

- **Set dirty**, before sending so a partial or failed edit still counts: `edit_config` (candidate target only), `load_configuration`, `rollback_configuration`.
- **Clear dirty**, on success only: `commit`, `commit_configuration`, `confirmed_commit`, `discard_changes`, `close_configuration`.
- `close_session()` discards only when the flag is set.

Callers using the raw `rpc()` escape hatch can dirty the candidate invisibly to the library, so there is a supported path for them: **`rpc_candidate_change()`** validates the fragment, completes the send preflight, marks, then sends — atomically. `mark_candidate_dirty()` / `candidate_dirty()` are also public on both `Session` and `Client` for callers who need manual control.

The marking boundary is deliberate: anything failing **after** the write begins still marks dirty, because a partially applied change does need cleaning up. Anything failing **before** a byte reaches the transport must not mark, because that is the original bug in miniature.

## Review history

Each commit was gated through a codex review, and rounds 2–4 each found a real defect in the previous round's fix — all the same shape, `candidate_dirty` set with nothing on the wire:

1. `51560e2` — core fix.
2. `179f177` — the escape hatch was unreachable from `Client` (private field, public `rpc()`), so that path silently lost the cleanup it used to get. Documented call order was also backwards.
3. `35773bb` — "mark before you await" reintroduced the bug: `rpc()` starts with a local `validate_xml_fragment()` that returns before anything is sent. Added the atomic API.
4. `f76a610` — same hazard one layer down: `send_rpc()` awaits `keepalive_check()` and `send_rpc_raw()` calls `ensure_established()`, both before the write. Preflight now completes before the mark.

Round 5 came back clean: *"No actionable defects were found."*

## Verification

- 478 tests pass, 0 failed (18 new)
- `cargo clippy --all-targets --all-features` — zero warnings
- `cargo fmt --all --check` — clean
- `cargo deny check` — advisories, bans, licenses, sources all ok
- No dependency changes

The two preflight regression tests were confirmed genuine by reverting the ordering and watching them fail, rather than trusting a green run. The keepalive one is deterministic without time manipulation: `keepalive_check()` probes when `last_activity.elapsed() >= interval`, so a zero interval fires it on the next RPC.

## Note on the issue text

The issue suggests reusing `config_db_open`. That field is actually `private_config_open` and only tracks Junos `<open-configuration>` — it never sees `edit-config` or `load-configuration` — so this needed new tracking rather than a reuse.

## Not included

No version bump. This adds public API and changes close-time behaviour, so it wants `0.14.0` rather than a patch; release prep is left as its own change, matching #54.

🤖 Generated with [Claude Code](https://claude.com/claude-code)