### PR TITLE
feat(session): rpc_candidate_change_with_warnings + 0.14.1 (#58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.14.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.14.0)** (Junos candidate-datastore safety).
-> On crates.io: `rustnetconf` 0.14.0 · `rustnetconf-cli` 0.3.5 · `rustnetconf-yang` 0.1.5.
-> See [What's New in v0.14.0](#whats-new-in-v0140) below.
+> **Latest release — [v0.14.1](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.14.1)** (warnings-returning candidate change).
+> On crates.io: `rustnetconf` 0.14.1 · `rustnetconf-cli` 0.3.5 · `rustnetconf-yang` 0.1.5.
+> See [What's New in v0.14.1](#whats-new-in-v0141) below.
 
 ## Workspace
 
@@ -47,6 +47,16 @@ SSH is present as a *transport for NETCONF*, not as a general-purpose capability
 - Remote shell or command execution
 
 Consumers that need those should use a dedicated SSH crate alongside this one. A native SCP1 client was briefly added and then reverted before it was ever released (#52, reverted by #53) for exactly this reason; issues #47 and #51 were closed as not planned on the same grounds. The round trip is visible in `git log` between v0.13.2 and the next release — it was a deliberate reversal, not an accident.
+
+## What's New in v0.14.1
+
+Additive follow-up to 0.14.0 for `rustnetconf` (0.14.1), from wiring the consumer side in [rustez#36](https://github.com/fastrevmd-lab/rustez/issues/36) (#58). `rustnetconf-cli` (0.3.5) and `rustnetconf-yang` (0.1.5) are unchanged — their `rustnetconf = "0.14"` requirement already matches. No behaviour changes and no API removals: a drop-in patch upgrade from 0.14.0.
+
+- **New `Session::rpc_candidate_change_with_warnings()` / `Client::rpc_candidate_change_with_warnings()`** — additive. The warnings-returning counterpart of `rpc_candidate_change()`, returning the same `(String, Vec<RpcErrorInfo>)` tuple as `rpc_with_warnings()` with the same preflight-then-mark ordering.
+
+  0.14.0 left the warnings path without an atomic option. A caller who needed the warnings back from a candidate-modifying RPC had only `rpc_with_warnings()` plus a hand call to `mark_candidate_dirty()`, and that is not equivalent: `rpc_with_warnings()` validates the fragment and returns *before sending anything*, so a hand-marked malformed fragment left the candidate marked dirty for an RPC that never reached the device — and the next `close_session()` would then send `<discard-changes/>` against another operator's uncommitted work. That is the #55 bug reached by a different route. Hand-marking also could not replicate the keepalive and session-state preflight, since neither is public.
+
+- **No change needed if you already use `rpc_candidate_change()`.** Its ordering and behaviour are identical; the sequence simply moved into a shared internal helper that both methods now call.
 
 ## What's New in v0.14.0
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -516,6 +516,39 @@ impl Client {
         self.session.rpc_candidate_change(rpc_content).await
     }
 
+    /// Send an arbitrary candidate-modifying RPC, returning the response and any warnings.
+    ///
+    /// The warnings-returning counterpart of
+    /// [`rpc_candidate_change()`](Self::rpc_candidate_change): identical
+    /// preflight-then-mark ordering, but it returns the `(data, warnings)` tuple
+    /// that [`rpc_with_warnings()`](Self::rpc_with_warnings) returns. Use it for
+    /// Junos `<load-configuration>` and other candidate-modifying RPCs whose
+    /// warnings carry diagnostic value.
+    ///
+    /// Prefer this over marking by hand and calling `rpc_with_warnings()`.
+    /// `rpc_with_warnings()` validates the fragment and returns *before sending
+    /// anything*, so a hand-marked malformed fragment leaves the candidate marked
+    /// dirty for an RPC that never reached the device — and the next
+    /// [`close_session()`](Self::close_session) would then send
+    /// `<discard-changes/>`, destroying another operator's uncommitted work on a
+    /// shared candidate.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let (data, warnings) = client.rpc_candidate_change_with_warnings(
+    ///     "<load-configuration><configuration><foo/></configuration></load-configuration>"
+    /// ).await?;
+    /// ```
+    pub async fn rpc_candidate_change_with_warnings(
+        &mut self,
+        rpc_content: &str,
+    ) -> Result<(String, Vec<RpcErrorInfo>), NetconfError> {
+        self.session
+            .rpc_candidate_change_with_warnings(rpc_content)
+            .await
+    }
+
     /// Check if the device supports a specific capability URI.
     pub fn supports(&self, capability_uri: &str) -> bool {
         self.session.supports(capability_uri)
@@ -538,10 +571,12 @@ impl Client {
     /// Mark the candidate datastore as dirty.
     ///
     /// For vendor-specific candidate-modifying RPCs, prefer
-    /// [`rpc_candidate_change()`](Self::rpc_candidate_change) over manually
-    /// marking with this method. `rpc_candidate_change()` validates the fragment
-    /// locally first and only marks dirty if validation passes, preventing a
-    /// locally-rejected RPC from incorrectly marking the candidate dirty.
+    /// [`rpc_candidate_change()`](Self::rpc_candidate_change) — or
+    /// [`rpc_candidate_change_with_warnings()`](Self::rpc_candidate_change_with_warnings)
+    /// when you need the warnings back — over manually marking with this method.
+    /// Those methods validate the fragment locally first and only mark dirty if
+    /// validation and the transport preflight pass, preventing a locally-rejected
+    /// RPC from incorrectly marking the candidate dirty.
     ///
     /// If you must use the raw [`rpc()`](Self::rpc) or
     /// [`rpc_with_warnings()`](Self::rpc_with_warnings) escape hatch, call this
@@ -816,6 +851,11 @@ impl Client {
     /// Send an arbitrary RPC, returning both the response and any warnings.
     ///
     /// Like [`rpc()`](Self::rpc), but returns warnings alongside the data.
+    ///
+    /// If the RPC modifies the candidate datastore, use
+    /// [`rpc_candidate_change_with_warnings()`](Self::rpc_candidate_change_with_warnings)
+    /// instead — it marks the candidate dirty atomically with the send, which
+    /// hand-marking before this method cannot do safely.
     pub async fn rpc_with_warnings(
         &mut self,
         rpc_content: &str,
@@ -1305,6 +1345,17 @@ mod tests {
         buf
     }
 
+    /// An `<ok/>` reply carrying one `warning`-severity `<rpc-error>`, as Junos
+    /// returns from `<load-configuration>` for a non-fatal complaint.
+    fn mock_ok_with_warning_reply(message_id: &str) -> Vec<u8> {
+        let reply = format!(
+            r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{message_id}"><rpc-error><error-type>application</error-type><error-tag>operation-failed</error-tag><error-severity>warning</error-severity><error-message>statement not found</error-message></rpc-error><ok/></rpc-reply>"#
+        );
+        let mut buf = reply.into_bytes();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
     fn mock_rpc_error_reply(message_id: &str) -> Vec<u8> {
         let reply = format!(
             r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{message_id}"><rpc-error><error-type>protocol</error-type><error-tag>operation-failed</error-tag><error-severity>error</error-severity></rpc-error></rpc-reply>"#
@@ -1658,6 +1709,154 @@ mod tests {
         assert_eq!(
             discard_count, 1,
             "Junos session with marked candidate should send discard-changes once on close"
+        );
+    }
+
+    /// `rpc_candidate_change_with_warnings` returns the warnings AND marks dirty,
+    /// so a well-formed candidate change still discards on close.
+    #[tokio::test]
+    async fn rpc_candidate_change_with_warnings_returns_warnings_and_causes_discard() {
+        use crate::transport::mock::MockTransport;
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_with_warning_reply("1")); // candidate change reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        let mut client = Client::from_session_for_test(session);
+
+        let (data, warnings) = client
+            .rpc_candidate_change_with_warnings(
+                "<load-configuration><configuration><foo/></configuration></load-configuration>",
+            )
+            .await
+            .expect("rpc_candidate_change_with_warnings failed");
+
+        assert!(data.is_empty(), "an <ok/> reply carries no data");
+        assert_eq!(warnings.len(), 1, "the warning should be surfaced");
+        assert!(
+            warnings[0].message.contains("statement not found"),
+            "warning text should survive: {:?}",
+            warnings[0]
+        );
+        assert!(
+            client.candidate_dirty(),
+            "a sent candidate change must mark dirty"
+        );
+
+        client.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        assert_eq!(
+            written_str.matches("discard-changes").count(),
+            1,
+            "warnings path should send discard-changes once on close"
+        );
+    }
+
+    /// The core regression test for the warnings path: a locally-malformed
+    /// fragment must not mark dirty, and must not provoke a discard on close.
+    /// This is the hole that hand-marking before `rpc_with_warnings()` left open.
+    #[tokio::test]
+    async fn rpc_candidate_change_with_warnings_malformed_does_not_mark_dirty() {
+        use crate::transport::mock::MockTransport;
+        let mut response_data = mock_junos_hello();
+        // No RPC reply needed - the malformed XML is rejected locally before sending
+        response_data.extend_from_slice(&mock_ok_reply("1")); // close-session reply (no discard)
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.vendor_name(), "junos");
+
+        let mut client = Client::from_session_for_test(session);
+
+        let result = client
+            .rpc_candidate_change_with_warnings(
+                "<load-configuration><configuration><foo></configuration></load-configuration>",
+            )
+            .await;
+
+        assert!(result.is_err(), "Malformed XML should be rejected");
+        assert!(
+            !client.candidate_dirty(),
+            "candidate should not be dirty after locally-rejected RPC"
+        );
+
+        client.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        assert_eq!(
+            written_str.matches("discard-changes").count(),
+            0,
+            "locally-rejected RPC should NOT send discard-changes on close"
+        );
+    }
+
+    /// Once the write has begun, a failure still marks dirty, so a partially
+    /// applied change gets cleaned up. Mirrors `rpc_candidate_change_eof_still_marks_dirty`.
+    #[tokio::test]
+    async fn rpc_candidate_change_with_warnings_eof_still_marks_dirty() {
+        use crate::transport::mock::MockTransport;
+        let response_data = mock_junos_hello();
+        // No reply for the RPC - EOF
+
+        let transport = MockTransport::new(response_data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let mut client = Client::from_session_for_test(session);
+
+        let result = client
+            .rpc_candidate_change_with_warnings(
+                "<load-configuration><configuration><foo/></configuration></load-configuration>",
+            )
+            .await;
+
+        assert!(result.is_err(), "RPC with no reply should fail");
+        assert!(
+            client.candidate_dirty(),
+            "candidate should be dirty after RPC was sent (even though it failed)"
+        );
+    }
+
+    /// An un-established session fails preflight, so nothing is marked and
+    /// nothing is written. This is the check hand-marking cannot replicate,
+    /// since `ensure_established()` is not public.
+    #[tokio::test]
+    async fn rpc_candidate_change_with_warnings_unestablished_does_not_mark_dirty() {
+        use crate::transport::mock::MockTransport;
+        // Never establish: no hello exchanged, session stays Connected.
+        let transport = MockTransport::new(Vec::new());
+        let written_handle = transport.written_handle();
+        let session = Session::new(Box::new(transport));
+
+        let mut client = Client::from_session_for_test(session);
+
+        let result = client
+            .rpc_candidate_change_with_warnings(
+                "<load-configuration><configuration><foo/></configuration></load-configuration>",
+            )
+            .await;
+
+        assert!(result.is_err(), "un-established session should be rejected");
+        assert!(
+            !client.candidate_dirty(),
+            "failed preflight must not mark the candidate dirty"
+        );
+
+        let written = written_handle.lock().unwrap();
+        assert!(
+            written.is_empty(),
+            "nothing should reach the wire when preflight fails"
         );
     }
 }

--- a/src/session.rs
+++ b/src/session.rs
@@ -260,10 +260,12 @@ impl Session {
     /// Mark the candidate datastore as dirty.
     ///
     /// For vendor-specific candidate-modifying RPCs, prefer
-    /// [`rpc_candidate_change()`](Self::rpc_candidate_change) over manually
-    /// marking with this method. `rpc_candidate_change()` validates the fragment
-    /// locally first and only marks dirty if validation passes, preventing a
-    /// locally-rejected RPC from incorrectly marking the candidate dirty.
+    /// [`rpc_candidate_change()`](Self::rpc_candidate_change) — or
+    /// [`rpc_candidate_change_with_warnings()`](Self::rpc_candidate_change_with_warnings)
+    /// when you need the warnings back — over manually marking with this method.
+    /// Those methods validate the fragment locally first and only mark dirty if
+    /// validation and the transport preflight pass, preventing a locally-rejected
+    /// RPC from incorrectly marking the candidate dirty.
     ///
     /// If you must use the raw [`rpc()`](Self::rpc) escape hatch, call this
     /// **before** sending the RPC, so [`close_session()`](Self::close_session)
@@ -648,6 +650,69 @@ impl Session {
         &mut self,
         rpc_content: &str,
     ) -> Result<String, NetconfError> {
+        let reply = self.dispatch_candidate_change(rpc_content).await?;
+
+        // Map reply to String the same way rpc() does
+        match reply {
+            RpcReply::Data(data) | RpcReply::DataWithWarnings(data, _) => Ok(data),
+            RpcReply::Ok | RpcReply::OkWithWarnings(_) => Ok(String::new()),
+        }
+    }
+
+    /// Send an arbitrary candidate-modifying RPC, returning the response and any warnings.
+    ///
+    /// The warnings-returning counterpart of
+    /// [`rpc_candidate_change()`](Self::rpc_candidate_change): identical
+    /// preflight-then-mark ordering, but it returns the `(data, warnings)` tuple
+    /// that [`rpc_with_warnings()`](Self::rpc_with_warnings) returns.
+    ///
+    /// Prefer this over marking by hand and calling `rpc_with_warnings()`.
+    /// `rpc_with_warnings()` validates the fragment and returns *before sending
+    /// anything*, so a hand-marked malformed fragment leaves the candidate marked
+    /// dirty for an RPC that never reached the device — and the next
+    /// `close_session()` would then send `<discard-changes/>`, destroying another
+    /// operator's uncommitted work on a shared candidate. Marking by hand also
+    /// cannot replicate the keepalive and session-state preflight, which is not
+    /// otherwise reachable from outside the crate.
+    ///
+    /// Marking happens AFTER all preflight checks but BEFORE the write begins, so:
+    /// - A locally-malformed fragment does not incorrectly mark dirty
+    /// - A failed preflight check (e.g., un-established session) does not mark dirty
+    /// - A timeout or error AFTER the write begins still marks dirty for cleanup
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// let (data, warnings) = session.rpc_candidate_change_with_warnings(
+    ///     "<load-configuration><configuration><foo/></configuration></load-configuration>"
+    /// ).await?;
+    /// ```
+    pub async fn rpc_candidate_change_with_warnings(
+        &mut self,
+        rpc_content: &str,
+    ) -> Result<(String, Vec<RpcErrorInfo>), NetconfError> {
+        let reply = self.dispatch_candidate_change(rpc_content).await?;
+
+        // Map reply the same way rpc_with_warnings() does
+        match reply {
+            RpcReply::Data(data) => Ok((data, Vec::new())),
+            RpcReply::DataWithWarnings(data, warnings) => Ok((data, warnings)),
+            RpcReply::Ok => Ok((String::new(), Vec::new())),
+            RpcReply::OkWithWarnings(warnings) => Ok((String::new(), warnings)),
+        }
+    }
+
+    /// Internal helper: the atomic validate-preflight-mark-send sequence shared by
+    /// [`rpc_candidate_change()`](Self::rpc_candidate_change) and
+    /// [`rpc_candidate_change_with_warnings()`](Self::rpc_candidate_change_with_warnings).
+    ///
+    /// Returns the raw [`RpcReply`] so each caller can map it to its own return shape.
+    /// The ordering here is the whole point: nothing marks the candidate dirty until
+    /// every check that can fail *before* the write has passed.
+    async fn dispatch_candidate_change(
+        &mut self,
+        rpc_content: &str,
+    ) -> Result<RpcReply, NetconfError> {
         // 1. Validate locally first - if this fails, do NOT mark dirty
         rpc::validate_xml_fragment(rpc_content)?;
 
@@ -663,13 +728,7 @@ impl Session {
         // 5. Build the RPC envelope and send via send_rpc_raw (bypasses keepalive re-check)
         let msg_id = self.next_message_id();
         let xml = Self::wrap_rpc_envelope(&msg_id, rpc_content);
-        let reply = self.send_rpc_raw(&xml, &msg_id).await?;
-
-        // 6. Map reply to String the same way rpc() does
-        match reply {
-            RpcReply::Data(data) | RpcReply::DataWithWarnings(data, _) => Ok(data),
-            RpcReply::Ok | RpcReply::OkWithWarnings(_) => Ok(String::new()),
-        }
+        self.send_rpc_raw(&xml, &msg_id).await
     }
 
     /// Internal helper: wrap a validated fragment in the `<rpc>` envelope.
@@ -704,6 +763,11 @@ impl Session {
     ///
     /// `rpc_content` is validated as well-formed XML before sending; see
     /// [`rpc()`](Self::rpc) for details.
+    ///
+    /// If the RPC modifies the candidate datastore, use
+    /// [`rpc_candidate_change_with_warnings()`](Self::rpc_candidate_change_with_warnings)
+    /// instead — it marks the candidate dirty atomically with the send, which
+    /// hand-marking before this method cannot do safely.
     pub async fn rpc_with_warnings(
         &mut self,
         rpc_content: &str,


### PR DESCRIPTION
Closes #58.

## What changed

`rpc_candidate_change()` (0.14.0, #56) is the atomic validate → preflight → mark → send path for vendor candidate-modifying RPCs. The **warnings** path had no equivalent: a caller who needed `(String, Vec<RpcErrorInfo>)` back from a candidate-modifying RPC had only `rpc_with_warnings()` plus a hand call to `mark_candidate_dirty()`.

That workaround was never equivalent. `rpc_with_warnings()` starts with `rpc::validate_xml_fragment()` and returns **before sending anything**, so a hand-marked malformed fragment left `candidate_dirty = true` for an RPC that never reached the device. The next `close_session()` then sends `<discard-changes/>` — destroying another operator's uncommitted work on the shared Junos candidate. That is exactly the failure #55 set out to eliminate, reached by a different route. The hand-mark also could not replicate the `keepalive_check()` / `ensure_established()` preflight, since neither is public.

Reported from wiring the consumer side in [rustez#36](https://github.com/fastrevmd-lab/rustez/issues/36), where `ConfigManager::load_with_warnings()` sends `<load-configuration>` and needs the warnings, so it had no atomic option.

### `a985f90` — the feature

- **New `Session::rpc_candidate_change_with_warnings()` / `Client::rpc_candidate_change_with_warnings()`** — returns the same tuple as `rpc_with_warnings()`, with the same preflight-then-mark ordering as `rpc_candidate_change()`.
- The sequence moved into a shared private `dispatch_candidate_change()` returning the raw `RpcReply`, so both public methods map it to their own shape. `rpc_candidate_change()` keeps **identical** ordering and behaviour — the refactor is mechanical.
- Doc comments on `mark_candidate_dirty()` and `rpc_with_warnings()` (both `Session` and `Client`) now point at the new method.

### `a098349` — release prep

0.14.0 → **0.14.1**. Purely additive, no behaviour change and no API removals, so a patch — 0.14.0 was minor specifically because it changed what `close_session()` sends. `rustnetconf-cli` (0.3.5) and `rustnetconf-yang` (0.1.5) are untouched; their `rustnetconf = { version = "0.14", path = ".." }` requirement already matches 0.14.1.

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --all` — 370 lib + 83 integration + 12 doc, 0 failed
- `cargo audit` (301 deps) and `cargo deny check bans sources licenses` clean
- `cargo package -p rustnetconf` builds the 0.14.1 tarball
- Codex review of the branch: no findings

Four new tests mirror the existing `rpc_candidate_change` set:

| Test | Asserts |
|---|---|
| `..._returns_warnings_and_causes_discard` | warnings surface **and** `discard-changes` fires once on close |
| `..._malformed_does_not_mark_dirty` | locally-rejected fragment marks nothing, sends zero discards — the core regression |
| `..._eof_still_marks_dirty` | failure *after* the write still marks dirty, so partial changes get cleaned up |
| `..._unestablished_does_not_mark_dirty` | failed preflight marks nothing and puts nothing on the wire — the check hand-marking could not replicate |

🤖 Generated with [Claude Code](https://claude.com/claude-code)