### PR TITLE
feat(session): commit_configuration_with_log + 0.14.2 release prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.14.1](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.14.1)** (warnings-returning candidate change).
-> On crates.io: `rustnetconf` 0.14.1 · `rustnetconf-cli` 0.3.5 · `rustnetconf-yang` 0.1.5.
-> See [What's New in v0.14.1](#whats-new-in-v0141) below.
+> **Latest release — [v0.14.2](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.14.2)** (Junos commit with a log comment).
+> On crates.io: `rustnetconf` 0.14.2 · `rustnetconf-cli` 0.3.5 · `rustnetconf-yang` 0.1.5.
+> See [What's New in v0.14.2](#whats-new-in-v0142) below.
 
 ## Workspace
 
@@ -47,6 +47,20 @@ SSH is present as a *transport for NETCONF*, not as a general-purpose capability
 - Remote shell or command execution
 
 Consumers that need those should use a dedicated SSH crate alongside this one. A native SCP1 client was briefly added and then reverted before it was ever released (#52, reverted by #53) for exactly this reason; issues #47 and #51 were closed as not planned on the same grounds. The round trip is visible in `git log` between v0.13.2 and the next release — it was a deliberate reversal, not an accident.
+
+## What's New in v0.14.2
+
+Follow-up to 0.14.1, from wiring the consumer side in [rustez#41](https://github.com/fastrevmd-lab/rustez/issues/41) (#60). `rustnetconf-cli` and `rustnetconf-yang` are unchanged — their `rustnetconf = "0.14"` requirement already matches.
+
+No API removals and no source-breaking changes, so a drop-in patch upgrade. One deliberate behaviour change, on an error path only: a Junos `commit-configuration` that disconnects before its reply now reports `CommitUnknown` instead of a generic transport error — see the second bullet.
+
+- **New `Session::commit_configuration_with_log()` / `Client::commit_configuration_with_log()`** — additive. A Junos commit carrying a log comment, visible in `show system commit`. The log text is XML-escaped for you. Clears the candidate-dirty flag on success, exactly as `commit_configuration()` does.
+
+  `commit_configuration()` takes no arguments and `commit_configuration_xml()` hard-coded a bare `<commit-configuration/>`, so a caller wanting Junos's `<log>` child had to build the fragment and send it through raw `rpc()`. Every method that clears the dirty flag does so as a private side effect, and there is no public way to clear it — so that raw path could not. The session stayed marked dirty across a commit that genuinely cleaned the candidate, and `close_session()` then discarded afterwards. Harmless for that session's own work; on the **shared** Junos candidate it destroys anything another operator staged between the commit and the close. This is the mirror of #58: that was an RPC that could not atomically *set* the flag, this was a commit that could not *clear* it.
+
+- **`commit_configuration()` keeps its signature and its XML.** Both methods now delegate to one private helper; the no-log path emits byte-identical XML, asserted in a test. `rpc::operations::commit_configuration_xml()` also keeps its one-argument form — the log variant is a separate `commit_configuration_with_log_xml()`, because that module is public API and changing the arity would break existing callers at source.
+
+- **Fixed: a Junos commit that disconnects before its reply now reports `RpcError::CommitUnknown`.** `commit()` and `confirmed_commit()` already bracketed their send with the pending-commit state; `commit_configuration()` never did, so a mid-commit disconnect surfaced as a generic transport EOF. The device may have applied the commit, and a caller that reads that as a clean failure can retry a commit that already took effect. Both `commit_configuration()` and the new log variant now signal it correctly. This is a behaviour change on an error path only — the success path is untouched.
 
 ## What's New in v0.14.1
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -887,6 +887,18 @@ impl Client {
         self.session.commit_configuration().await
     }
 
+    /// Commit with a log comment using the Junos-native `<commit-configuration>` RPC.
+    ///
+    /// Attaches a Junos commit log comment to the commit, visible in `show system commit`.
+    /// The log text is automatically XML-escaped. The candidate-dirty flag is cleared on
+    /// success, just as with [`commit_configuration()`](Self::commit_configuration).
+    ///
+    /// Use this instead of [`commit()`](Self::commit) on Junos devices,
+    /// especially when a private/exclusive configuration database is open.
+    pub async fn commit_configuration_with_log(&mut self, log: &str) -> Result<(), NetconfError> {
+        self.session.commit_configuration_with_log(log).await
+    }
+
     /// Rollback the candidate configuration to a previous commit (Junos).
     ///
     /// `rollback` is the rollback index (0 = most recent commit, up to 49).

--- a/src/rpc/operations.rs
+++ b/src/rpc/operations.rs
@@ -300,11 +300,44 @@ pub fn close_configuration_xml(message_id: &str) -> String {
 /// `<commit>` when working with Junos private/exclusive configuration
 /// databases opened via `<open-configuration>`.
 pub fn commit_configuration_xml(message_id: &str) -> String {
+    build_commit_configuration_xml(message_id, None)
+}
+
+/// Generate a Junos `<commit-configuration>` RPC carrying a `<log>` comment.
+///
+/// The comment is visible in Junos `show system commit`. `log` is XML-escaped
+/// here, so callers pass plain text and must not pre-escape it.
+///
+/// This is a separate function rather than an `Option` parameter on
+/// [`commit_configuration_xml`] deliberately: this module is public API, so
+/// changing that function's arity would break existing callers at source.
+pub fn commit_configuration_with_log_xml(message_id: &str, log: &str) -> String {
+    build_commit_configuration_xml(message_id, Some(log))
+}
+
+/// Shared builder for the two `<commit-configuration>` shapes above.
+///
+/// `None` emits the bare self-closing element, byte-identical to what
+/// `commit_configuration_xml` produced before the log variant existed.
+fn build_commit_configuration_xml(message_id: &str, log: Option<&str>) -> String {
     let safe_id = escape_xml_attr(message_id);
+    let Some(text) = log else {
+        return format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">
+  <nc:commit-configuration/>
+</nc:rpc>"#,
+        );
+    };
+    // The log is element character data, not an attribute — escape_xml_text,
+    // matching how load_configuration_xml escapes its Text-format payload.
+    let escaped_log = escape_xml_text(text);
     format!(
         r#"<?xml version="1.0" encoding="UTF-8"?>
 <nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">
-  <nc:commit-configuration/>
+  <nc:commit-configuration>
+    <nc:log>{escaped_log}</nc:log>
+  </nc:commit-configuration>
 </nc:rpc>"#,
     )
 }
@@ -628,6 +661,41 @@ mod tests {
         let xml = commit_configuration_xml("30");
         assert!(xml.contains("<nc:commit-configuration/>"));
         assert!(xml.contains("message-id=\"30\""));
+        // Verify byte-identical to pre-log form
+        let expected = r#"<?xml version="1.0" encoding="UTF-8"?>
+<nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="30">
+  <nc:commit-configuration/>
+</nc:rpc>"#;
+        assert_eq!(xml, expected, "None should produce exact pre-log output");
+    }
+
+    #[test]
+    fn test_commit_configuration_with_log() {
+        let xml = commit_configuration_with_log_xml("31", "reason for change");
+        assert!(xml.contains("message-id=\"31\""));
+        assert!(xml.contains("<nc:log>reason for change</nc:log>"));
+        assert!(xml.contains("<nc:commit-configuration>"));
+        assert!(!xml.contains("<nc:commit-configuration/>"));
+    }
+
+    #[test]
+    fn test_commit_configuration_log_escaping() {
+        let xml = commit_configuration_with_log_xml("32", "fix & update <critical> items");
+        assert!(xml.contains("<nc:log>fix &amp; update &lt;critical&gt; items</nc:log>"));
+        // Verify raw markup does not appear
+        assert!(!xml.contains("fix & update <critical> items"));
+    }
+
+    #[test]
+    fn test_commit_configuration_log_injection_defense() {
+        let xml = commit_configuration_with_log_xml("33", "evil</nc:log><nc:rollback/>");
+        // The injected markup must be escaped
+        assert!(xml.contains("&lt;/nc:log&gt;&lt;nc:rollback/&gt;"));
+        // The raw injection must NOT appear as live markup
+        assert!(!xml.contains("</nc:log><nc:rollback/>"));
+        // Exactly one <nc:log> open tag should exist
+        assert_eq!(xml.matches("<nc:log>").count(), 1);
+        assert_eq!(xml.matches("</nc:log>").count(), 1);
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -961,9 +961,47 @@ impl Session {
     /// Use this instead of [`commit()`](Self::commit) on Junos devices,
     /// especially when a private/exclusive configuration database is open.
     pub async fn commit_configuration(&mut self) -> Result<(), NetconfError> {
+        self.dispatch_commit_configuration(None).await
+    }
+
+    /// Commit with a log comment using the Junos-native `<commit-configuration>` RPC.
+    ///
+    /// Attaches a Junos commit log comment to the commit, visible in `show system commit`.
+    /// The log text is automatically XML-escaped. The candidate-dirty flag is cleared on
+    /// success, just as with [`commit_configuration()`](Self::commit_configuration).
+    ///
+    /// Use this instead of [`commit()`](Self::commit) on Junos devices,
+    /// especially when a private/exclusive configuration database is open.
+    pub async fn commit_configuration_with_log(&mut self, log: &str) -> Result<(), NetconfError> {
+        self.dispatch_commit_configuration(Some(log)).await
+    }
+
+    /// Internal helper for commit_configuration and commit_configuration_with_log.
+    ///
+    /// Clears the candidate-dirty flag only on success, so a failed commit that
+    /// may have partially applied still leaves the flag set for cleanup on close.
+    ///
+    /// The send is bracketed by `pending_commit` so that a transport EOF while
+    /// awaiting the reply surfaces as [`RpcError::CommitUnknown`] rather than a
+    /// generic I/O error. The device may have applied the commit before the
+    /// connection dropped, and a caller that mistakes that for a clean failure
+    /// may retry a commit that already took effect. `commit()` and
+    /// `confirmed_commit()` already did this; `commit_configuration()` did not.
+    async fn dispatch_commit_configuration(
+        &mut self,
+        log: Option<&str>,
+    ) -> Result<(), NetconfError> {
         let msg_id = self.next_message_id();
-        let xml = operations::commit_configuration_xml(&msg_id);
-        self.send_rpc(&xml, &msg_id).await?;
+        let xml = match log {
+            Some(text) => operations::commit_configuration_with_log_xml(&msg_id, text),
+            None => operations::commit_configuration_xml(&msg_id),
+        };
+
+        self.pending_commit = true;
+        let result = self.send_rpc(&xml, &msg_id).await;
+        self.pending_commit = false;
+
+        result?;
         // Clear dirty flag on success
         self.candidate_dirty = false;
         Ok(())
@@ -1439,6 +1477,28 @@ mod tests {
             Err(NetconfError::Rpc(crate::error::RpcError::CommitUnknown)) => {
                 // This is the expected error
             }
+            other => panic!("expected CommitUnknown, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_commit_configuration_with_log_disconnect_is_commit_unknown() {
+        // A Junos commit that disconnects before its reply is indeterminate: the
+        // device may have applied it. commit_configuration* must report that as
+        // CommitUnknown, not a generic transport error, or a caller can retry a
+        // commit that already took effect.
+        let mut response_data = mock_junos_hello();
+        // No commit reply — EOF after the hello simulates a mid-commit disconnect.
+
+        let transport = MockTransport::new(response_data.split_off(0));
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let result = session
+            .commit_configuration_with_log("attributed change")
+            .await;
+        match result {
+            Err(NetconfError::Rpc(crate::error::RpcError::CommitUnknown)) => {}
             other => panic!("expected CommitUnknown, got: {other:?}"),
         }
     }
@@ -2220,6 +2280,116 @@ mod tests {
         assert_eq!(
             discard_count, 1,
             "explicit discard_changes followed by close should produce exactly 1 discard"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_commit_configuration_with_log_clears_dirty_flag() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // load-configuration reply
+        response_data.extend_from_slice(&mock_ok_reply("2")); // commit-configuration reply
+        response_data.extend_from_slice(&mock_ok_reply("3")); // close-session reply (no discard)
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // Load config (dirties candidate)
+        session
+            .load_configuration(
+                crate::types::LoadAction::Merge,
+                crate::types::LoadFormat::Text,
+                "set system host-name test",
+            )
+            .await
+            .expect("load_configuration failed");
+
+        // Commit with log (clears dirty flag)
+        session
+            .commit_configuration_with_log("test commit comment")
+            .await
+            .expect("commit_configuration_with_log failed");
+
+        // Close (should NOT send discard-changes)
+        session.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 0,
+            "commit_configuration_with_log should clear dirty flag, so close sends no discard-changes"
+        );
+        // Verify the log comment was sent
+        assert!(
+            written_str.contains("<nc:log>test commit comment</nc:log>"),
+            "commit should include log comment"
+        );
+    }
+
+    /// Build a mock commit-configuration error response.
+    fn mock_commit_error_reply(message_id: &str) -> Vec<u8> {
+        let reply = format!(
+            r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{message_id}">
+  <rpc-error>
+    <error-type>protocol</error-type>
+    <error-tag>operation-failed</error-tag>
+    <error-severity>error</error-severity>
+    <error-message>commit failed: configuration check-out failed</error-message>
+  </rpc-error>
+</rpc-reply>"#
+        );
+        let mut buf = reply.into_bytes();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    #[tokio::test]
+    async fn test_commit_configuration_with_log_failed_leaves_dirty() {
+        let mut response_data = mock_junos_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // load-configuration reply
+        response_data.extend_from_slice(&mock_commit_error_reply("2")); // commit-configuration fails
+        response_data.extend_from_slice(&mock_ok_reply("3")); // discard-changes reply
+        response_data.extend_from_slice(&mock_ok_reply("4")); // close-session reply
+
+        let transport = MockTransport::new(response_data);
+        let written_handle = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // Load config (dirties candidate)
+        session
+            .load_configuration(
+                crate::types::LoadAction::Merge,
+                crate::types::LoadFormat::Text,
+                "set system host-name test",
+            )
+            .await
+            .expect("load_configuration failed");
+
+        // Commit with log fails (leaves dirty flag set)
+        let result = session.commit_configuration_with_log("failed commit").await;
+        assert!(
+            result.is_err(),
+            "commit_configuration_with_log should fail with error reply"
+        );
+
+        // Candidate should still be dirty
+        assert!(
+            session.candidate_dirty(),
+            "failed commit should leave candidate dirty"
+        );
+
+        // Close (SHOULD send discard-changes)
+        session.close_session().await.expect("close failed");
+
+        let written = written_handle.lock().unwrap();
+        let written_str = String::from_utf8_lossy(&written);
+        let discard_count = written_str.matches("discard-changes").count();
+        assert_eq!(
+            discard_count, 1,
+            "failed commit should leave candidate dirty, so close sends discard-changes"
         );
     }
 


### PR DESCRIPTION
Closes #60.

## The gap

`commit_configuration()` takes no arguments and `commit_configuration_xml()` emitted a bare `<nc:commit-configuration/>`, so a caller wanting Junos's `<log>` child had to build the fragment and send it through raw `rpc()`. Every method that clears `candidate_dirty` does so as a private side effect on success, and there is no public way to clear it — so the raw path could not.

The session stayed marked dirty across a commit that genuinely cleaned the candidate, and `close_session()` then discarded afterwards. Harmless against that session's own work; on the **shared** Junos candidate it destroys anything another operator staged between the commit and the close.

This is the mirror of #58 — that was an RPC that could not atomically *set* the flag, this is a commit that could not *clear* it.

## Design decisions worth calling out

**A separate `commit_configuration_with_log_xml()`, not an `Option` parameter.** `rpc::operations` is public API — rustez already calls `rpc::validate_xml_fragment` — and Rust has no optional arguments, so changing that function's arity would break existing callers at source in what is otherwise a drop-in patch. Both functions delegate to a private builder, and the no-log path is asserted **byte-identical** to the pre-log output.

**The library escapes the log.** It is element character data, so `escape_xml_text()`, matching how `load_configuration_xml()` escapes its Text-format payload. Escaping here rather than taking a pre-escaped fragment stops callers double-escaping — rustez escapes its own comment today and drops that when it switches.

**Cleared only on success.** The flag clears after `send_rpc()` succeeds, so a commit that fails after partial application stays dirty and `close()` still cleans up.

## Also fixes a pre-existing gap the review caught

`commit()` and `confirmed_commit()` have always bracketed their send with `pending_commit`; `commit_configuration()` never did. Without it a transport EOF while awaiting the reply surfaced as a generic `UnexpectedEof` rather than `RpcError::CommitUnknown` — and the device may have applied the commit, so a caller reading that as a clean failure can retry a commit that already took effect.

**This is a behaviour change on an error path only.** The success path is untouched, and the README release notes say so rather than claiming a pure no-behaviour-change patch.

## Tests

Seven, covering both directions of each property:

- the no-log path is byte-identical to the pre-log output
- the `<log>` child is emitted
- `&`, `<`, `>` are escaped
- an injected `</nc:log><nc:rollback/>` comes out escaped, not as live markup
- a **successful** commit-with-log clears the flag, so close sends **zero** discards
- a **failed** one leaves it set, so close sends **exactly one**
- a mid-commit disconnect yields `CommitUnknown`

That last test was confirmed to **fail** without the `pending_commit` bracket, returning `Err(Transport(Io(... UnexpectedEof ...)))` — so it guards the fix rather than passing vacuously.

## Known, filed separately

`pending_commit` is not cancellation-safe: dropping the future at the `.await` leaves the flag set, so a later unrelated EOF is misreported as `CommitUnknown`. That is **pre-existing** — `commit()` and `confirmed_commit()` on `main` use the identical pattern — and affects all three commit paths, so it is [#61](https://github.com/fastrevmd-lab/rustnetconf/issues/61) rather than scope creep here.

## Verification

- `cargo build` / `test` / `clippy --workspace --all-targets --all-features -- -D warnings` → clean
- 383 lib tests plus the integration suites pass
- `cargo fmt --all -- --check` → clean
- `cargo audit` → clean over 301 crates
- `cargo deny check advisories bans sources licenses` → all ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)