### PR TITLE
fix(session): classify commits by parameter, not session state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.14.2](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.14.2)** (Junos commit with a log comment).
-> On crates.io: `rustnetconf` 0.14.2 · `rustnetconf-cli` 0.3.5 · `rustnetconf-yang` 0.1.5.
-> See [What's New in v0.14.2](#whats-new-in-v0142) below.
+> **Latest release — [v0.14.3](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.14.3)** (cancellation-safe commit classification).
+> On crates.io: `rustnetconf` 0.14.3 · `rustnetconf-cli` 0.3.5 · `rustnetconf-yang` 0.1.5.
+> See [What's New in v0.14.3](#whats-new-in-v0143) below.
 
 ## Workspace
 
@@ -47,6 +47,20 @@ SSH is present as a *transport for NETCONF*, not as a general-purpose capability
 - Remote shell or command execution
 
 Consumers that need those should use a dedicated SSH crate alongside this one. A native SCP1 client was briefly added and then reverted before it was ever released (#52, reverted by #53) for exactly this reason; issues #47 and #51 were closed as not planned on the same grounds. The round trip is visible in `git log` between v0.13.2 and the next release — it was a deliberate reversal, not an accident.
+
+## What's New in v0.14.3
+
+Bug-fix release (#61). `rustnetconf-cli` and `rustnetconf-yang` are unchanged. No API changes — every function touched is private — so a drop-in patch upgrade from 0.14.2.
+
+- **Fixed: a cancelled commit no longer misclassifies the next unrelated failure.** `Session` tracked "a commit is in flight" in a `pending_commit` field, set before the send and cleared after it. Drop that future at its `.await` — a `tokio::time::timeout`, a `select!` — and the reset never ran, so the flag stayed set for the life of the session. The next unrelated transport EOF, during a `get-config` or anything else, was then reported as `RpcError::CommitUnknown`.
+
+  That is the flag's purpose inverted. It exists so a genuinely indeterminate commit is not mistaken for a clean I/O failure; the leak made a clean I/O failure look like an indeterminate commit, which can send a caller hunting for a commit that never happened or stop it retrying something perfectly safe to retry.
+
+- **The fix removes state rather than guarding it.** "This is a commit" describes one call, not the session, so it is now an `is_commit` parameter threaded through the private `send_rpc_raw` → `read_rpc_reply` → `read_message` chain, and the field is gone. Cancellation-safety follows by construction: the fact lives in the call frame and dies with any future that is dropped. Commit paths call a new private `send_rpc_commit()`; the other 20 `send_rpc` call sites are untouched.
+
+  An RAII guard was considered and rejected — holding `&mut self.pending_commit` across `self.send_rpc(&mut self)` does not borrow-check, so it would have forced the flag into `Rc<Cell<bool>>`/`Arc<AtomicBool>`, adding an allocation and indirection to every session to fix an error path.
+
+- **Regression test.** `test_cancelled_commit_does_not_poison_later_eof` cancels a commit mid-await against a transport that parks, then asserts a following non-commit EOF is reported as a transport error. It was verified to **fail** against the 0.14.2 implementation, returning `CommitUnknown`, so it guards the fix rather than passing vacuously. A `StallingMockTransport` was added for it, because the existing mock reads synchronously and can never be interrupted mid-await.
 
 ## What's New in v0.14.2
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -77,8 +77,6 @@ pub struct Session {
     read_buffer: Vec<u8>,
     /// The negotiated NETCONF version.
     version: Option<NetconfVersion>,
-    /// True while a `<commit>` RPC has been sent but the reply hasn't arrived.
-    pending_commit: bool,
     /// Vendor-specific behavior profile. Set during establish() via auto-detection,
     /// or overridden by the user via Client::vendor() / Client::vendor_profile().
     vendor_profile: Arc<dyn VendorProfile>,
@@ -122,7 +120,6 @@ impl Session {
             state: SessionState::Connected,
             read_buffer: Vec::new(),
             version: None,
-            pending_commit: false,
             vendor_profile: Arc::new(crate::vendor::generic::GenericVendor),
             facts: Facts::default(),
             keepalive_interval: None,
@@ -180,7 +177,7 @@ impl Session {
         self.transport.write_all(&framed).await?;
 
         // Read device hello
-        let device_hello = self.read_message().await?;
+        let device_hello = self.read_message(false).await?;
         let mut caps =
             capability::parse_device_hello(&device_hello).map_err(ProtocolError::HelloFailed)?;
 
@@ -383,7 +380,7 @@ impl Session {
     pub async fn probe(&mut self) -> bool {
         let msg_id = self.next_message_id();
         let xml = operations::get_xml(&msg_id, Some(""));
-        match self.send_rpc_raw(&xml, &msg_id).await {
+        match self.send_rpc_raw(&xml, &msg_id, false).await {
             Ok(_) => true,
             Err(err) => {
                 tracing::warn!(%err, "session probe failed — marking session dead");
@@ -422,7 +419,27 @@ impl Session {
     /// [`send_rpc_raw`].
     async fn send_rpc(&mut self, xml: &str, message_id: &str) -> Result<RpcReply, NetconfError> {
         self.keepalive_check().await?;
-        self.send_rpc_raw(xml, message_id).await
+        self.send_rpc_raw(xml, message_id, false).await
+    }
+
+    /// Send a commit RPC with keepalive check.
+    ///
+    /// Like [`send_rpc`], but marks the call as a commit operation. If the
+    /// transport returns EOF while awaiting the reply, this returns
+    /// [`RpcError::CommitUnknown`] instead of a generic transport error,
+    /// signaling that the device may have applied the commit before the
+    /// connection dropped.
+    ///
+    /// Threading `is_commit` as an argument (rather than storing it on the
+    /// session) makes this method cancellation-safe: a dropped future cannot
+    /// leave stale state behind that would affect subsequent, unrelated RPCs.
+    async fn send_rpc_commit(
+        &mut self,
+        xml: &str,
+        message_id: &str,
+    ) -> Result<RpcReply, NetconfError> {
+        self.keepalive_check().await?;
+        self.send_rpc_raw(xml, message_id, true).await
     }
 
     /// Send an RPC without keepalive check.
@@ -434,10 +451,13 @@ impl Session {
     /// When `rpc_timeout` is configured, the entire read loop is bounded by
     /// [`tokio::time::timeout()`]. If the device does not produce a matching
     /// reply within the deadline, `RpcError::Timeout` is returned.
+    ///
+    /// `is_commit`: whether this is a commit RPC; passed through to the read path.
     async fn send_rpc_raw(
         &mut self,
         xml: &str,
         message_id: &str,
+        is_commit: bool,
     ) -> Result<RpcReply, NetconfError> {
         self.ensure_established()?;
 
@@ -447,10 +467,12 @@ impl Session {
         self.transport.write_all(&framed).await?;
 
         match self.rpc_timeout {
-            Some(timeout) => tokio::time::timeout(timeout, self.read_rpc_reply(message_id))
-                .await
-                .map_err(|_| crate::error::RpcError::Timeout(timeout))?,
-            None => self.read_rpc_reply(message_id).await,
+            Some(timeout) => {
+                tokio::time::timeout(timeout, self.read_rpc_reply(message_id, is_commit))
+                    .await
+                    .map_err(|_| crate::error::RpcError::Timeout(timeout))?
+            }
+            None => self.read_rpc_reply(message_id, is_commit).await,
         }
     }
 
@@ -458,10 +480,16 @@ impl Session {
     ///
     /// Extracted from `send_rpc_raw` so that `tokio::time::timeout` can
     /// wrap the entire read loop.
-    async fn read_rpc_reply(&mut self, message_id: &str) -> Result<RpcReply, NetconfError> {
+    ///
+    /// `is_commit`: whether this is a commit RPC; passed through to `read_message`.
+    async fn read_rpc_reply(
+        &mut self,
+        message_id: &str,
+        is_commit: bool,
+    ) -> Result<RpcReply, NetconfError> {
         let mut drain_attempt = 0;
         loop {
-            let response = self.read_message().await?;
+            let response = self.read_message(is_commit).await?;
 
             // Demux: if a notification arrives during RPC exchange, buffer it
             if notification::classify_message(&response) == Some(MessageKind::Notification) {
@@ -524,7 +552,11 @@ impl Session {
     }
 
     /// Read one complete framed message from the transport.
-    async fn read_message(&mut self) -> Result<String, NetconfError> {
+    ///
+    /// `is_commit`: whether this read is for a commit RPC. If `true`, a transport
+    /// EOF is reported as `RpcError::CommitUnknown` because the device may have
+    /// applied the commit before the connection dropped.
+    async fn read_message(&mut self, is_commit: bool) -> Result<String, NetconfError> {
         let mut temp_buf = vec![0u8; READ_BUF_SIZE];
 
         loop {
@@ -549,8 +581,7 @@ impl Session {
             // Read more data from transport
             let bytes_read = self.transport.read(&mut temp_buf).await?;
             if bytes_read == 0 {
-                if self.pending_commit {
-                    self.pending_commit = false;
+                if is_commit {
                     return Err(crate::error::RpcError::CommitUnknown.into());
                 }
                 return Err(TransportError::Io(std::io::Error::new(
@@ -728,7 +759,7 @@ impl Session {
         // 5. Build the RPC envelope and send via send_rpc_raw (bypasses keepalive re-check)
         let msg_id = self.next_message_id();
         let xml = Self::wrap_rpc_envelope(&msg_id, rpc_content);
-        self.send_rpc_raw(&xml, &msg_id).await
+        self.send_rpc_raw(&xml, &msg_id, false).await
     }
 
     /// Internal helper: wrap a validated fragment in the `<rpc>` envelope.
@@ -895,11 +926,7 @@ impl Session {
         let msg_id = self.next_message_id();
         let xml = operations::commit_xml(&msg_id);
 
-        self.pending_commit = true;
-        let result = self.send_rpc(&xml, &msg_id).await;
-        self.pending_commit = false;
-
-        result?;
+        self.send_rpc_commit(&xml, &msg_id).await?;
         // Clear dirty flag on success
         self.candidate_dirty = false;
         Ok(())
@@ -981,12 +1008,11 @@ impl Session {
     /// Clears the candidate-dirty flag only on success, so a failed commit that
     /// may have partially applied still leaves the flag set for cleanup on close.
     ///
-    /// The send is bracketed by `pending_commit` so that a transport EOF while
-    /// awaiting the reply surfaces as [`RpcError::CommitUnknown`] rather than a
-    /// generic I/O error. The device may have applied the commit before the
-    /// connection dropped, and a caller that mistakes that for a clean failure
-    /// may retry a commit that already took effect. `commit()` and
-    /// `confirmed_commit()` already did this; `commit_configuration()` did not.
+    /// Uses [`send_rpc_commit`] so that a transport EOF while awaiting the reply
+    /// surfaces as [`RpcError::CommitUnknown`] rather than a generic I/O error.
+    /// The device may have applied the commit before the connection dropped, and
+    /// a caller that mistakes that for a clean failure may retry a commit that
+    /// already took effect. `commit()` and `confirmed_commit()` do the same.
     async fn dispatch_commit_configuration(
         &mut self,
         log: Option<&str>,
@@ -997,11 +1023,7 @@ impl Session {
             None => operations::commit_configuration_xml(&msg_id),
         };
 
-        self.pending_commit = true;
-        let result = self.send_rpc(&xml, &msg_id).await;
-        self.pending_commit = false;
-
-        result?;
+        self.send_rpc_commit(&xml, &msg_id).await?;
         // Clear dirty flag on success
         self.candidate_dirty = false;
         Ok(())
@@ -1151,11 +1173,7 @@ impl Session {
         let msg_id = self.next_message_id();
         let xml = operations::confirmed_commit_xml(&msg_id, confirm_timeout);
 
-        self.pending_commit = true;
-        let result = self.send_rpc(&xml, &msg_id).await;
-        self.pending_commit = false;
-
-        result?;
+        self.send_rpc_commit(&xml, &msg_id).await?;
         // Clear dirty flag on success
         self.candidate_dirty = false;
         Ok(())
@@ -1368,7 +1386,7 @@ impl Session {
 
         // Read from transport until we get a notification or EOF
         loop {
-            let response = match self.read_message().await {
+            let response = match self.read_message(false).await {
                 Ok(msg) => msg,
                 Err(NetconfError::Transport(TransportError::Io(ref e)))
                     if e.kind() == std::io::ErrorKind::UnexpectedEof =>
@@ -1426,7 +1444,7 @@ impl Session {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::transport::mock::MockTransport;
+    use crate::transport::mock::{MockTransport, StallingMockTransport};
 
     /// Build a mock device hello response with EOM framing.
     fn mock_device_hello() -> Vec<u8> {
@@ -1503,6 +1521,45 @@ mod tests {
         }
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn test_cancelled_commit_does_not_poison_later_eof() {
+        // The #61 regression. A commit whose future is dropped mid-await must not
+        // leave "a commit is in flight" behind, or the NEXT unrelated EOF gets
+        // misreported as CommitUnknown — the flag's purpose inverted.
+        //
+        // This is why the fact is a parameter rather than a field: it lives on the
+        // call frame and dies with the cancelled future. Against the old
+        // field-based implementation this test fails, because the reset after the
+        // await never ran.
+        let transport = StallingMockTransport::new(mock_junos_hello());
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        // The transport parks on this read, so the timeout cancels the commit
+        // future exactly at its .await.
+        let cancelled = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            session.commit_configuration(),
+        )
+        .await;
+        assert!(
+            cancelled.is_err(),
+            "commit should have been cancelled by the timeout"
+        );
+
+        // A different, non-commit operation now hits EOF. It must be reported as
+        // what it is — a dropped connection — not as an indeterminate commit.
+        let result = session.get_config(Datastore::Running, None).await;
+        match result {
+            Err(NetconfError::Rpc(crate::error::RpcError::CommitUnknown)) => panic!(
+                "a cancelled commit poisoned a later unrelated EOF: got CommitUnknown \
+                 for a get-config, which is the #61 bug"
+            ),
+            Err(_) => {}
+            Ok(_) => panic!("expected the get-config to fail against a closed transport"),
+        }
+    }
+
     #[tokio::test]
     async fn test_non_commit_disconnect_is_transport_error() {
         // Mock transport: serves the hello, then EOF during get-config
@@ -1527,12 +1584,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_successful_commit_clears_pending_flag() {
-        // Mock transport: hello + lock reply + commit reply
+    async fn test_successful_commit_then_eof_is_transport_error() {
+        // After a successful commit, a subsequent non-commit RPC that hits EOF
+        // should return a transport error, NOT CommitUnknown. This ensures that
+        // the commit-tracking state does not leak across calls.
         let mut response_data = mock_device_hello();
         response_data.extend_from_slice(&mock_ok_reply("1")); // lock
         response_data.extend_from_slice(&mock_ok_reply("2")); // commit
         response_data.extend_from_slice(&mock_ok_reply("3")); // unlock
+                                                              // No reply for the final get-config — EOF
 
         let transport = MockTransport::new(response_data);
         let mut session = Session::new(Box::new(transport));
@@ -1543,17 +1603,76 @@ mod tests {
             .await
             .expect("lock failed");
         session.commit().await.expect("commit failed");
-
-        // pending_commit should be false after successful commit
-        assert!(
-            !session.pending_commit,
-            "pending_commit should be cleared after success"
-        );
-
         session
             .unlock(Datastore::Candidate)
             .await
             .expect("unlock failed");
+
+        // get-config should return a transport error, NOT CommitUnknown
+        let result = session.get_config(Datastore::Running, None).await;
+        match result {
+            Err(NetconfError::Transport(_)) => {
+                // Expected — generic transport error for non-commit operations
+            }
+            Err(NetconfError::Rpc(crate::error::RpcError::CommitUnknown)) => {
+                panic!(
+                    "CommitUnknown should not leak to a non-commit RPC after a successful commit"
+                );
+            }
+            other => panic!("expected TransportError, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_commit_eof_then_non_commit_eof_reports_correctly() {
+        // NOT the #61 regression test — see
+        // test_cancelled_commit_does_not_poison_later_eof for that one. This
+        // case passed under the old field-based implementation too, because the
+        // EOF branch cleared the flag on its way out. It is kept as a guard on
+        // the ordinary path: a commit that reports CommitUnknown must not change
+        // how the next unrelated failure is classified.
+        //
+        // This test verifies that after a commit hits EOF (returning CommitUnknown),
+        // a subsequent non-commit operation that also hits EOF correctly returns
+        // a transport error, not CommitUnknown.
+        let mut response_data = mock_device_hello();
+        response_data.extend_from_slice(&mock_ok_reply("1")); // lock
+                                                              // No commit reply — message-id "2" will hit EOF
+                                                              // No get-config reply — message-id "3" will also hit EOF
+
+        let transport = MockTransport::new(response_data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        session
+            .lock(Datastore::Candidate)
+            .await
+            .expect("lock failed");
+
+        // Commit hits EOF — should return CommitUnknown
+        let commit_result = session.commit().await;
+        match commit_result {
+            Err(NetconfError::Rpc(crate::error::RpcError::CommitUnknown)) => {
+                // Expected
+            }
+            other => panic!("expected CommitUnknown, got: {other:?}"),
+        }
+
+        // Now a non-commit operation hits EOF — should return TransportError, NOT CommitUnknown.
+        // With the old field-based approach and a mid-await cancellation, pending_commit
+        // could have been left set, poisoning this call.
+        let result = session.get_config(Datastore::Running, None).await;
+        match result {
+            Err(NetconfError::Transport(_)) => {
+                // Expected — generic transport error for non-commit operations
+            }
+            Err(NetconfError::Rpc(crate::error::RpcError::CommitUnknown)) => {
+                panic!(
+                    "CommitUnknown should not leak to a non-commit RPC after a commit that returned CommitUnknown"
+                );
+            }
+            other => panic!("expected TransportError, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -68,6 +68,67 @@ pub mod mock {
         }
     }
 
+    /// Mock transport that stalls once before reporting EOF.
+    ///
+    /// `MockTransport` reads synchronously and so can never be interrupted
+    /// mid-await, which makes it impossible to test cancellation. This variant
+    /// parks forever on the first read that would otherwise return EOF, so a
+    /// caller wrapping the operation in `tokio::time::timeout` genuinely drops
+    /// the future at its `.await`. Every read after that returns EOF normally,
+    /// so a follow-up operation can observe how the session behaves once a
+    /// cancelled call is behind it.
+    pub struct StallingMockTransport {
+        read_data: Vec<u8>,
+        read_pos: usize,
+        stalled_once: bool,
+        written: Arc<Mutex<Vec<u8>>>,
+        pub closed: bool,
+    }
+
+    impl StallingMockTransport {
+        /// Create a stalling mock with the given canned response data.
+        pub fn new(read_data: Vec<u8>) -> Self {
+            Self {
+                read_data,
+                read_pos: 0,
+                stalled_once: false,
+                written: Arc::new(Mutex::new(Vec::new())),
+                closed: false,
+            }
+        }
+    }
+
+    #[async_trait]
+    impl Transport for StallingMockTransport {
+        async fn write_all(&mut self, data: &[u8]) -> Result<(), TransportError> {
+            self.written.lock().unwrap().extend_from_slice(data);
+            Ok(())
+        }
+
+        async fn read(&mut self, buf: &mut [u8]) -> Result<usize, TransportError> {
+            let remaining = &self.read_data[self.read_pos..];
+            if remaining.is_empty() {
+                // Park once so the caller's timeout can cancel us here. The flag
+                // is set *before* the await, so the cancellation that drops this
+                // future still leaves the stall spent.
+                if !self.stalled_once {
+                    self.stalled_once = true;
+                    tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+                }
+                return Ok(0);
+            }
+            let to_read = std::cmp::min(buf.len(), remaining.len());
+            buf[..to_read].copy_from_slice(&remaining[..to_read]);
+            self.read_pos += to_read;
+            Ok(to_read)
+        }
+
+        async fn close(&mut self) -> Result<(), TransportError> {
+            self.closed = true;
+            Ok(())
+        }
+    }
+
     #[async_trait]
     impl Transport for MockTransport {
         async fn write_all(&mut self, data: &[u8]) -> Result<(), TransportError> {


### PR DESCRIPTION
Closes #61. Releases 0.14.3.

## The bug

`Session` tracked "a commit is in flight" in a `pending_commit` field, set before the send and cleared after it:

```rust
self.pending_commit = true;
let result = self.send_rpc(&xml, &msg_id).await;
self.pending_commit = false;
```

Drop that future at its `.await` — `tokio::time::timeout`, `select!`, any cancellation — and the reset never runs. The flag stays set for the life of the session, and the next unrelated transport EOF (a `get-config`, anything) is reported as `RpcError::CommitUnknown`.

**That is the flag's purpose inverted.** It exists so a genuinely indeterminate commit is not mistaken for a clean I/O failure. The leak makes a clean I/O failure look like an indeterminate commit — which can send a caller hunting for a commit that never happened, or stop it retrying something perfectly safe to retry.

It matters in practice because wrapping RPCs in `tokio::time::timeout` is ordinary consumer behaviour — rustez does it on **every** RPC by convention.

## The fix removes state rather than guarding it

"This is a commit" describes one call, not the session. It is now an `is_commit` parameter threaded through the private `send_rpc_raw` → `read_rpc_reply` → `read_message` chain, and the field is deleted.

Cancellation-safety follows **by construction**: the fact lives in the call frame and dies with any future that is dropped. There is no state left to leak.

The three commit paths call a new private `send_rpc_commit()`. `send_rpc` keeps its signature, so its 20 call sites are untouched. Every function whose signature changed is private — **no API change**.

### Alternatives considered

- **RAII guard** — rejected. Holding `&mut self.pending_commit` across `self.send_rpc(&mut self)` does not borrow-check, so it would force the flag into `Rc<Cell<bool>>`/`Arc<AtomicBool>`: an allocation and indirection on every session, to fix an error path.
- **Message-id tracking** — rejected as a fix for *this*. It solves a different problem (a late reply arriving on a later read) and does not fix cancellation on its own, since a dropped future still leaves the id set. It could layer on top later.

## The regression test is verified, not assumed

`test_cancelled_commit_does_not_poison_later_eof` cancels a commit mid-await, then asserts the following non-commit EOF is a transport error.

It was run against the 0.14.2 implementation in a separate worktree and **fails** there:

```
test session::tests::test_cancelled_commit_does_not_poison_later_eof ... FAILED
a cancelled commit poisoned a later unrelated EOF: got CommitUnknown
for a get-config, which is the #61 bug
```

It needs a new `StallingMockTransport`, which parks once before reporting EOF. The existing `MockTransport` reads synchronously and can never be interrupted mid-await — which is precisely why no cancellation test existed before.

**One test is explicitly labelled as NOT guarding #61.** A commit-EOF-then-non-commit-EOF case passes under the old implementation too, because the old EOF branch cleared the flag on its way out. It is kept as a guard on the ordinary path, with a comment saying so, rather than left to look like coverage it does not provide.

The pre-existing test asserting `!session.pending_commit` is replaced by a behavioural equivalent, since the field no longer exists.

## Verification

- `cargo build` / `test` / `clippy --workspace --all-targets --all-features -- -D warnings` → clean
- 385 lib tests plus the integration suites pass
- `cargo fmt --all -- --check` → clean
- `cargo deny check advisories bans sources licenses` → all ok

🤖 Generated with [Claude Code](https://claude.com/claude-code)