### PR TITLE
fix(rpc): accept the <ok/> sibling Junos sends with <commit-results>

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,14 @@
 //! See [ARCHITECTURE.md](https://github.com/fastrevmd-lab/rustnetconf/blob/main/ARCHITECTURE.md)
 //! for full design details.
 
+// `NetconfError` and `RpcError` are 128 bytes, exactly clippy's
+// `result_large_err` threshold, so every fallible public function trips the
+// lint (72 sites across client.rs, session.rs, and pool/mod.rs). Both types
+// are public API of a published crate, so shrinking them means boxing a
+// variant, which is a breaking change and does not belong in a patch release.
+// Tracked in #66; remove this allow when the error types shrink.
+#![allow(clippy::result_large_err)]
+
 pub mod capability;
 pub mod client;
 pub mod error;

--- a/src/rpc/reply/mod.rs
+++ b/src/rpc/reply/mod.rs
@@ -488,6 +488,144 @@ mod tests {
     }
 
     #[test]
+    fn parses_standalone_commit_check_with_ok_sibling() {
+        // Captured off the wire from a standalone single-RE SRX345 running
+        // Junos 21.2R3-S6.11. Unlike the chassis-cluster form, this reply is
+        // well-formed: <commit-results> is closed, and <ok/> follows it as a
+        // sibling. RFC 6241 does not allow both, but Junos sends both.
+        let xml =
+            include_str!("../../../tests/fixtures/commit_check/standalone_validate_success.xml");
+        let result = parse_rpc_reply(xml, "101").unwrap();
+        assert!(
+            matches!(result, RpcReply::Ok | RpcReply::OkWithWarnings(_)),
+            "standalone commit-check should parse as Ok, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn ok_sibling_after_a_closed_direct_payload_is_not_a_conflict() {
+        // The same shape with content in the payload, to pin that the verdict
+        // survives regardless of what <commit-results> carries.
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="7">
+<commit-results>
+<routing-engine><name>re0</name><commit-check-success/></routing-engine>
+</commit-results>
+<ok/>
+</rpc-reply>"#;
+        assert!(matches!(parse_rpc_reply(xml, "7"), Ok(RpcReply::Ok)));
+    }
+
+    #[test]
+    fn ok_sibling_does_not_mask_a_device_error() {
+        // A hard rpc-error must still win over the tolerated <ok/> sibling,
+        // so a failed check is never reported as a passing one.
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="8">
+<commit-results>
+</commit-results>
+<rpc-error>
+<error-type>protocol</error-type>
+<error-tag>operation-failed</error-tag>
+<error-severity>error</error-severity>
+<error-message>configuration check-out failed</error-message>
+</rpc-error>
+<ok/>
+</rpc-reply>"#;
+        match parse_rpc_reply(xml, "8") {
+            Err(RpcError::ServerError { message, .. }) => {
+                assert_eq!(message, "configuration check-out failed");
+            }
+            other => panic!("expected ServerError, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unrelated_direct_payload_with_ok_is_not_silently_discarded() {
+        // An op-command payload followed by <ok/> must not resolve to Ok:
+        // that would hand the caller an empty string and lose the response.
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="4">
+<software-information><host-name>srx345</host-name></software-information>
+<ok/>
+</rpc-reply>"#;
+        assert!(matches!(
+            parse_rpc_reply(xml, "4"),
+            Err(RpcError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn commit_results_plus_another_sibling_then_ok_still_conflicts() {
+        // Direct siblings aggregate into one payload
+        // (public_direct_payload_aggregates_siblings_contract). The <ok/>
+        // exception is for a reply whose only direct root is
+        // <commit-results>; once a second root joins it, resolving to Ok
+        // would drop the aggregate.
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="10">
+<commit-results/>
+<software-information><host-name>srx345</host-name></software-information>
+<ok/>
+</rpc-reply>"#;
+        assert!(matches!(
+            parse_rpc_reply(xml, "10"),
+            Err(RpcError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn commit_results_after_another_sibling_then_ok_still_conflicts() {
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="11">
+<software-information><host-name>srx345</host-name></software-information>
+<commit-results/>
+<ok/>
+</rpc-reply>"#;
+        assert!(matches!(
+            parse_rpc_reply(xml, "11"),
+            Err(RpcError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn duplicate_ok_after_commit_results_still_conflicts() {
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="5">
+<commit-results>
+</commit-results>
+<ok/>
+<ok/>
+</rpc-reply>"#;
+        assert!(matches!(
+            parse_rpc_reply(xml, "5"),
+            Err(RpcError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn direct_sibling_after_the_tolerated_ok_still_conflicts() {
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="6">
+<commit-results>
+</commit-results>
+<ok/>
+<software-information><host-name>srx345</host-name></software-information>
+</rpc-reply>"#;
+        assert!(matches!(
+            parse_rpc_reply(xml, "6"),
+            Err(RpcError::ParseError(_))
+        ));
+    }
+
+    #[test]
+    fn two_data_payloads_still_conflict() {
+        // The tolerance is scoped to a direct payload followed by <ok/>. A
+        // genuinely ambiguous reply must still be rejected.
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="9">
+<data><a/></data>
+<ok/>
+</rpc-reply>"#;
+        assert!(matches!(
+            parse_rpc_reply(xml, "9"),
+            Err(RpcError::ParseError(_))
+        ));
+    }
+
+    #[test]
     fn test_repair_two_node_unclosed_routing_engine() {
         // Synthetic two-node cluster with two consecutive unclosed routing-engine blocks.
         let xml = r#"<nc:rpc-reply xmlns:junos="http://xml.juniper.net/junos/25.4R1.12/junos" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">

--- a/src/rpc/reply/parser.rs
+++ b/src/rpc/reply/parser.rs
@@ -110,6 +110,9 @@ struct ReplyParser<'a> {
     message_id: Option<String>,
     payload: PayloadState,
     protocol_ok: bool,
+    /// Whether the direct payload's root element is Junos `<commit-results>`,
+    /// the one shape allowed to be followed by a sibling `<ok/>`.
+    direct_root_is_commit_results: bool,
     current_error: Option<ErrorState>,
     errors: Vec<RpcErrorInfo>,
     deferred_payload_error: Option<&'static str>,
@@ -126,6 +129,7 @@ impl<'a> ReplyParser<'a> {
             message_id: None,
             payload: PayloadState::None,
             protocol_ok: false,
+            direct_root_is_commit_results: false,
             current_error: None,
             errors: Vec::new(),
             deferred_payload_error: None,
@@ -343,6 +347,13 @@ impl ReplyParser<'_> {
         }
     }
 
+    /// Whether `tag` is the Junos `<commit-results>` element, in either the
+    /// NETCONF namespace or none.
+    fn is_commit_results(&self, tag: &BytesStart<'_>) -> bool {
+        let qualified_name = tag.name();
+        self.netconf_local_name(qualified_name.as_ref()) == Some(b"commit-results")
+    }
+
     fn in_open_direct_payload(&self) -> bool {
         matches!(
             self.payload,
@@ -524,16 +535,27 @@ impl ReplyParser<'_> {
 
     fn open_direct(&mut self, tag: &BytesStart<'_>) -> Result<(), RpcError> {
         let parent_namespaces = self.parent_namespaces();
+        let is_commit_results = self.is_commit_results(tag);
+        if self.protocol_ok {
+            self.defer_payload_conflict("direct payload conflicts with an existing payload");
+            self.ignored_payload = Some(IgnoredPayload::Direct { depth: 1 });
+            return Ok(());
+        }
         match &mut self.payload {
             PayloadState::None => {
                 let mut capture = FragmentCapture::with_namespaces(parent_namespaces);
                 capture.start(tag)?;
                 self.payload = PayloadState::Direct { capture, depth: 1 };
+                self.direct_root_is_commit_results = is_commit_results;
                 Ok(())
             }
             PayloadState::Direct { capture, depth } if *depth == 0 => {
+                // A second direct root joins the aggregate, so the payload is
+                // no longer a lone <commit-results> and the <ok/> exception
+                // must not apply.
                 capture.start(tag)?;
                 *depth = 1;
+                self.direct_root_is_commit_results = false;
                 Ok(())
             }
             _ => {
@@ -546,14 +568,25 @@ impl ReplyParser<'_> {
 
     fn capture_direct_empty(&mut self, tag: &BytesStart<'_>) -> Result<(), RpcError> {
         let parent_namespaces = self.parent_namespaces();
+        let is_commit_results = self.is_commit_results(tag);
+        if self.protocol_ok {
+            self.defer_payload_conflict("direct payload conflicts with an existing payload");
+            return Ok(());
+        }
         match &mut self.payload {
             PayloadState::None => {
                 let mut capture = FragmentCapture::with_namespaces(parent_namespaces);
                 capture.empty(tag)?;
                 self.payload = PayloadState::Direct { capture, depth: 0 };
+                self.direct_root_is_commit_results = is_commit_results;
                 Ok(())
             }
-            PayloadState::Direct { capture, depth } if *depth == 0 => capture.empty(tag),
+            PayloadState::Direct { capture, depth } if *depth == 0 => {
+                // See open_direct: a second direct root ends the exception.
+                capture.empty(tag)?;
+                self.direct_root_is_commit_results = false;
+                Ok(())
+            }
             _ => {
                 self.defer_payload_conflict("direct payload conflicts with an existing payload");
                 Ok(())
@@ -641,6 +674,24 @@ impl ReplyParser<'_> {
         match self.payload {
             PayloadState::None => {
                 self.payload = PayloadState::Ok;
+                Ok(())
+            }
+            // Junos answers a commit-check with `<commit-results>` and a
+            // sibling `<ok/>`, which RFC 6241 does not allow together. On a
+            // chassis cluster the element is left unclosed, so `handle_empty`
+            // already tolerates it through `in_open_direct_payload`. A
+            // standalone device closes it correctly and reaches here instead;
+            // the well-formed reply must not fare worse than the malformed
+            // one. The `<ok/>` carries the verdict, so record it.
+            //
+            // Scoped to exactly one `<ok/>` after a closed `<commit-results>`.
+            // Any other direct payload keeps the conflict: resolving to `Ok`
+            // would hand the caller an empty string and silently drop a
+            // response body it asked for.
+            PayloadState::Direct { depth: 0, .. }
+                if self.direct_root_is_commit_results && !self.protocol_ok =>
+            {
+                self.protocol_ok = true;
                 Ok(())
             }
             _ => {

--- a/tests/fixtures/commit_check/standalone_validate_success.xml
+++ b/tests/fixtures/commit_check/standalone_validate_success.xml
@@ -1,0 +1,5 @@
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/21.2R0/junos" message-id="101">
+<commit-results>
+</commit-results>
+<ok/>
+</rpc-reply>


### PR DESCRIPTION
Fixes the parse failure behind fastrevmd-lab/rustjunosmcp#358.

## The reply

Captured off the wire from the lab's one physical SRX345 (Junos 21.2R3-S6.11, standalone, single RE), answering `<validate><source><candidate/></source></validate>`:

```xml
<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="101">
<commit-results>
</commit-results>
<ok/>
</rpc-reply>
```

RFC 6241 does not allow a payload and `<ok/>` together. `set_ok` deferred a payload conflict, so the reply failed with `<ok/> conflicts with an existing payload` and the verdict was lost even though the check had **succeeded**.

Downstream this made the *governed* write path unusable on that device while the ungoverned one worked: `apply_junos_change_set` runs commit-check internally and refused, while `load_and_commit_config` committed the same text happily.

## Why the cluster form already worked

On a chassis cluster Junos leaves `<routing-engine>` **unclosed**, so the payload is still open when `<ok/>` arrives and `handle_empty` routes it through `in_open_direct_payload` to set `protocol_ok`. That tolerance is keyed on `depth > 0`, so it covered only the *malformed* shape. A device that closes the element correctly fared worse than one that does not.

## The change

Tolerate exactly one `<ok/>` after a **lone, closed `<commit-results>`**, recording the verdict in `protocol_ok`.

The scope is deliberately narrow. An earlier draft accepted `<ok/>` after any closed direct payload, which turned `<software-information>…</software-information><ok/>` into `RpcReply::Ok` — handing the caller an empty string and silently dropping a response body it had asked for. Trading a loud parse error for silent data loss is the wrong trade.

Every boundary is pinned by a test:

| Reply | Result |
|---|---|
| `<commit-results/>` + `<ok/>` | `Ok` |
| any other direct payload + `<ok/>` | conflict |
| `<commit-results/>` + another sibling + `<ok/>` | conflict — sibling aggregation is a public contract |
| another sibling + `<commit-results/>` + `<ok/>` | conflict |
| `<commit-results/>` + `<ok/>` + `<ok/>` | conflict |
| `<commit-results/>` + `<ok/>` + a direct sibling | conflict |
| `<data>` + `<ok/>` | conflict |
| `<commit-results/>` + `<rpc-error>` + `<ok/>` | the error wins |

That last row matters most: a failed check is never reported as a passing one.

## Verification

- 480 workspace tests pass; clippy warning count unchanged from `main` (75, all pre-existing `Err`-variant-size notes in `client.rs`).
- Fixture is the captured bytes, not a hand-written approximation.
- Reviewed by the codex gate three times. The first two passes each found a real over-broad case — the general-payload data loss and then the sibling-aggregation hole — and both are now closed and pinned by the tests above.

Ships as 0.14.4 so `rustjunosmcp` can pick it up on its `rustnetconf = "0.14"` pin.