### PR TITLE
fix(rpc): accept a warning rpc-error that omits error-type and error-tag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/src/rpc/reply/mod.rs
+++ b/src/rpc/reply/mod.rs
@@ -539,6 +539,42 @@ mod tests {
     }
 
     #[test]
+    fn load_warning_without_error_type_or_tag_parses() {
+        // Captured off the wire from the SRX345. Deleting a statement that is
+        // not present returns a *warning* rpc-error carrying only severity and
+        // message — RFC 6241 makes error-type and error-tag mandatory, and
+        // Junos omits both. Requiring them turned a benign warning into
+        // "rpc-error is missing error-type" and failed the whole load.
+        let xml = include_str!("../../../tests/fixtures/commit_check/standalone_load_warning.xml");
+        match parse_rpc_reply(xml, "101").expect("warning must not fail the reply") {
+            RpcReply::OkWithWarnings(warnings) => {
+                assert_eq!(warnings.len(), 1);
+                assert_eq!(warnings[0].severity, Some(ErrorSeverity::Warning));
+                assert!(warnings[0].message.contains("statement not found"));
+                assert_eq!(warnings[0].error_type, None);
+            }
+            other => panic!("expected OkWithWarnings, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_hard_error_still_requires_error_type_and_tag() {
+        // The tolerance above is scoped to warnings. An error-severity
+        // rpc-error missing its type must still be rejected rather than
+        // silently reported with an invented tag.
+        let xml = r#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="12">
+<rpc-error>
+<error-severity>error</error-severity>
+<error-message>configuration check-out failed</error-message>
+</rpc-error>
+</rpc-reply>"#;
+        assert!(matches!(
+            parse_rpc_reply(xml, "12"),
+            Err(RpcError::ParseError(_))
+        ));
+    }
+
+    #[test]
     fn unrelated_direct_payload_with_ok_is_not_silently_discarded() {
         // An op-command payload followed by <ok/> must not resolve to Ok:
         // that would hand the caller an empty string and lose the response.

--- a/src/rpc/reply/parser.rs
+++ b/src/rpc/reply/parser.rs
@@ -1128,18 +1128,40 @@ impl RpcErrorBuilder {
     }
 
     fn finish(self) -> Result<RpcErrorInfo, RpcError> {
+        // RFC 6241 makes error-type and error-tag mandatory. Junos omits both
+        // on warnings — deleting an absent statement returns nothing but
+        // `<error-severity>warning</error-severity>` and "statement not
+        // found". Requiring them turned that benign warning into a hard parse
+        // failure that sank the entire load.
+        //
+        // Scoped to warnings on purpose. A warning carries no verdict, so a
+        // missing classification costs nothing; an error-severity rpc-error
+        // still must say what it is, rather than be reported under an invented
+        // tag.
+        //
+        // Severity is read but not consumed here, so the strict path keeps
+        // reporting error-type, then error-tag, then error-severity in that
+        // order — an empty <rpc-error/> fails exactly as it always did.
+        let lenient = self.severity == Some(ErrorSeverity::Warning);
+        let error_type = match self.error_type {
+            Some(error_type) => Some(error_type),
+            None if lenient => None,
+            None => return Err(parse_error("rpc-error is missing error-type")),
+        };
+        let tag = match self.tag {
+            Some(tag) => tag,
+            None if lenient => ErrorTag::Other("unspecified".to_owned()),
+            None => return Err(parse_error("rpc-error is missing error-tag")),
+        };
+
+        let severity = self
+            .severity
+            .ok_or_else(|| parse_error("rpc-error is missing error-severity"))?;
+
         Ok(RpcErrorInfo {
-            error_type: Some(
-                self.error_type
-                    .ok_or_else(|| parse_error("rpc-error is missing error-type"))?,
-            ),
-            tag: self
-                .tag
-                .ok_or_else(|| parse_error("rpc-error is missing error-tag"))?,
-            severity: Some(
-                self.severity
-                    .ok_or_else(|| parse_error("rpc-error is missing error-severity"))?,
-            ),
+            error_type,
+            tag,
+            severity: Some(severity),
             app_tag: self.app_tag,
             path: self.path,
             message: self.message.unwrap_or_default(),

--- a/tests/fixtures/commit_check/standalone_load_warning.xml
+++ b/tests/fixtures/commit_check/standalone_load_warning.xml
@@ -1,0 +1,11 @@
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" xmlns:junos="http://xml.juniper.net/junos/21.2R0/junos" message-id="101">
+<load-configuration-results>
+<rpc-error>
+<error-severity>warning</error-severity>
+<error-message>
+statement not found
+</error-message>
+</rpc-error>
+<ok/>
+</load-configuration-results>
+</rpc-reply>


### PR DESCRIPTION
Found by deploying 0.14.4 and testing fastrevmd-lab/rustjunosmcp#358 against the real SRX345. The `<ok/>`-sibling fix worked — and immediately exposed a **second, distinct** parse gap on the same device.

## The reply

Deleting a statement that is not present, captured off the wire:

```xml
<rpc-reply message-id="101">
<load-configuration-results>
<rpc-error>
<error-severity>warning</error-severity>
<error-message>
statement not found
</error-message>
</rpc-error>
<ok/>
</load-configuration-results>
</rpc-reply>
```

RFC 6241 makes `error-type` and `error-tag` mandatory. **Junos omits both on warnings.** `RpcErrorBuilder::finish` rejected the reply with `rpc-error is missing error-type`, so a benign warning sank the entire load — and with it `commit_check_config` and `apply_junos_change_set`, the very tools 0.14.4 had just unblocked on this device.

This is not SRX345-specific: any delete of an absent statement, on any Junos device, produces this shape.

## The change

Tolerate a missing `error-type` and `error-tag` **only when severity is `warning`**.

A warning carries no verdict, so an absent classification costs nothing. An **error**-severity `rpc-error` still has to say what it is, rather than be reported under an invented tag — pinned by `a_hard_error_still_requires_error_type_and_tag`.

`RpcErrorInfo` already models `error_type` as `Option<RpcErrorType>`, so the struct did not change; the builder was simply stricter than the type it built. A missing tag becomes `ErrorTag::Other("unspecified")`, the variant already reserved for vendor-specific and unrecognized tags.

## Error ordering is deliberately unchanged

Severity is read but **not consumed** before the type and tag checks, so the strict path still reports `error-type`, then `error-tag`, then `error-severity` in that order. An empty `<rpc-error/>` fails exactly as it always did.

An earlier draft checked severity first and changed that message to "missing error-severity" — still a correct rejection, but it broke `direct_wrapper_protocol_elements_validate_start_and_empty_forms`, which pins the existing contract. The restructure keeps every existing message identical.

## Verification

- 126 reply tests and the full workspace suite pass; clippy clean with `-D warnings --all-features`.
- Fixture is the captured device bytes.
- Ships as 0.14.5.