### PR TITLE
fix(error)!: box RpcError::ServerError so the error types clear result_large_err

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -141,7 +141,8 @@ NetconfError
 ├── Framing(FramingError)
 │   ├── Invalid, Incomplete, Mismatch (firmware bug detection)
 ├── Rpc(RpcError)
-│   ├── ServerError{7 fields}, Timeout, CommitUnknown, ParseError, MessageIdMismatch
+│   ├── ServerError(Box<RpcServerError>)  — the 7 RFC 6241 §4.3 fields, boxed
+│   ├── Timeout, CommitUnknown, ParseError, MessageIdMismatch
 └── Protocol(ProtocolError)
     ├── CapabilityMissing, SessionClosed, HelloFailed, Xml
 ```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,7 +1838,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.14.5"
+version = "0.15.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "rustnetconf"
-version = "0.14.5"
+version = "0.15.0"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.14.3](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.14.3)** (cancellation-safe commit classification).
-> On crates.io: `rustnetconf` 0.14.3 · `rustnetconf-cli` 0.3.5 · `rustnetconf-yang` 0.1.5.
-> See [What's New in v0.14.3](#whats-new-in-v0143) below.
+> **Latest release — [v0.15.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.15.0)** (smaller error types — one breaking change).
+> On crates.io: `rustnetconf` 0.15.0 · `rustnetconf-cli` 0.3.5 · `rustnetconf-yang` 0.1.5.
+> See [What's New in v0.15.0](#whats-new-in-v0150) below.
 
 ## Workspace
 
@@ -47,6 +47,30 @@ SSH is present as a *transport for NETCONF*, not as a general-purpose capability
 - Remote shell or command execution
 
 Consumers that need those should use a dedicated SSH crate alongside this one. A native SCP1 client was briefly added and then reverted before it was ever released (#52, reverted by #53) for exactly this reason; issues #47 and #51 were closed as not planned on the same grounds. The round trip is visible in `git log` between v0.13.2 and the next release — it was a deliberate reversal, not an accident.
+
+## What's New in v0.15.0
+
+Breaking change (#66). One variant changes shape; nothing else in the public API moves. `rustnetconf-cli` and `rustnetconf-yang` have no source changes and only carry the new dependency requirement.
+
+- **`RpcError::ServerError` now carries a boxed struct.** Its 7 RFC 6241 §4.3 fields moved into a new public `RpcServerError`, and the variant became `ServerError(Box<RpcServerError>)`. The fields are unchanged, still public, and still all present — only where they live moved.
+
+  ```rust
+  // before
+  Err(NetconfError::Rpc(RpcError::ServerError { tag, message, .. })) => ...
+
+  // after
+  Err(NetconfError::Rpc(RpcError::ServerError(e))) => ... // e.tag, e.message
+  ```
+
+  Construction gets `From<RpcServerError>` for both `RpcError` and `NetconfError`, so `rpc_server_error.into()` boxes for you. `Display` output is byte-for-byte what it was — code matching on the error *string* is unaffected.
+
+- **Why: the error types were exactly 128 bytes.** `NetconfError` and `RpcError` both measured 128, which is precisely clippy's `result_large_err` threshold, so every fallible function in the public surface tripped the lint — 71 sites once the suppression was lifted. `ServerError` was the whole of it: `message` plus three `Option<String>` is 96 bytes before `ErrorTag`'s own 24. Boxing that one variant takes `RpcError` 128 → 48 and `NetconfError` 128 → 72, and the ceiling becomes `TransportError::HostKeyMismatch` at 72.
+
+  Every `Result<T, NetconfError>` in the crate was moving 128 bytes on the success path too, since a `Result` is as wide as its larger arm.
+
+- **The suppression is gone, not relocated.** `#![allow(clippy::result_large_err)]` in `src/lib.rs` and two local allows in `src/session.rs` were removed; `cargo clippy --workspace --all-targets --all-features -- -D warnings` passes clean without them. A new test asserts each error enum stays under 128 bytes, so a future inline `String` field fails the suite rather than quietly re-arming the lint.
+
+- **The toolchain is now pinned.** `rust-toolchain.toml` pins 1.98.0, matching every sibling crate. CI installed `stable` unpinned, which is why a clippy release turned the gate red with no change on this side.
 
 ## What's New in v0.14.3
 

--- a/README.md
+++ b/README.md
@@ -72,6 +72,28 @@ Breaking change (#66). One variant changes shape; nothing else in the public API
 
 - **The toolchain is now pinned.** `rust-toolchain.toml` pins 1.98.0, matching every sibling crate. CI installed `stable` unpinned, which is why a clippy release turned the gate red with no change on this side.
 
+## What's New in v0.14.5
+
+Bug-fix release (#67). `rustnetconf-cli` and `rustnetconf-yang` are unchanged. No API changes — a drop-in patch upgrade from 0.14.4.
+
+- **Fixed: a benign Junos warning no longer sinks the whole load.** Deleting a statement that is not present on an SRX345 returns an `<rpc-error>` carrying only severity and message — RFC 6241 makes `error-type` and `error-tag` mandatory, and Junos omits both. `RpcErrorBuilder::finish` rejected the reply with "rpc-error is missing error-type", so a warning failed the load and took `commit_check_config` and `apply_junos_change_set` with it — the same tools 0.14.4 had just unblocked on the same device.
+
+- **The tolerance is keyed on severity.** A missing `error-type`/`error-tag` is accepted only when severity is `warning`: a warning carries no verdict, so an absent classification costs nothing, while an `error`-severity `rpc-error` still has to say what it is rather than be reported under an invented tag. `RpcErrorInfo` already modelled `error_type` as `Option`, so the struct did not change; a missing tag becomes `ErrorTag::Other("unspecified")`.
+
+  Severity is read but not consumed before the type and tag checks, so the strict path still reports error-type, then error-tag, then error-severity in that order — an empty `<rpc-error/>` fails exactly as it always did.
+
+## What's New in v0.14.4
+
+Bug-fix release (#65). `rustnetconf-cli` and `rustnetconf-yang` are unchanged. No API changes — a drop-in patch upgrade from 0.14.3.
+
+- **Fixed: a standalone SRX's commit-check verdict was lost.** A single-RE SRX345 answers a commit-check with a closed `<commit-results>` followed by a sibling `<ok/>`. RFC 6241 does not allow a payload and `<ok/>` together, so the reply failed to parse with "`<ok/>` conflicts with an existing payload" and the verdict was discarded even though the check had passed. This made the governed write path unusable on the lab's physical SRX345 while the ungoverned one worked ([rustjunosmcp#358](https://github.com/fastrevmd-lab/rustjunosmcp/issues/358)).
+
+  The chassis-cluster form of the same reply already parsed, because there Junos leaves `<routing-engine>` unclosed — the payload is still open when `<ok/>` arrives. That existing tolerance was keyed on depth > 0, so it covered only the malformed shape: a device that closed the element correctly fared *worse* than one that did not.
+
+- **The scope is deliberately narrow.** Exactly one `<ok/>` after a closed `<commit-results>` is tolerated. An earlier draft accepted `<ok/>` after any closed direct payload, which turned `<software-information>…</software-information><ok/>` into `RpcReply::Ok` — handing the caller an empty string and silently dropping a body it had asked for. Trading a loud parse error for silent data loss is the wrong trade, so every other direct payload keeps the conflict, as do a duplicate `<ok/>` and any direct sibling following the tolerated one. A hard `<rpc-error>` still wins, so a failed check is never reported as passing. All four boundaries are pinned by tests, against a fixture captured off the wire from the SRX345 on Junos 21.2R3-S6.11.
+
+- **Also: `clippy::result_large_err` suppressed.** Stable 1.98.0 turned it into a red gate on main. Suppression was the right scope for a patch release carrying a production bugfix; the lint is fixed properly in 0.15.0 (#66).
+
 ## What's New in v0.14.3
 
 Bug-fix release (#61). `rustnetconf-cli` and `rustnetconf-yang` are unchanged. No API changes — every function touched is private — so a drop-in patch upgrade from 0.14.2.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Pinned so a new stable clippy cannot turn CI red without a deliberate bump
+# here first. Every sibling crate in the fleet pins the same way; this repo was
+# the one that did not, which is how the 1.98 `result_large_err` change (#66)
+# landed as a surprise.
+[toolchain]
+channel = "1.98.0"
+components = ["clippy", "rustfmt"]

--- a/rustnetconf-cli/Cargo.toml
+++ b/rustnetconf-cli/Cargo.toml
@@ -13,7 +13,7 @@ name = "netconf"
 path = "src/main.rs"
 
 [dependencies]
-rustnetconf = { version = "0.14", path = ".." }
+rustnetconf = { version = "0.15", path = ".." }
 clap = { version = "4", features = ["derive"] }
 colored = "3"
 toml = "0.8"

--- a/rustnetconf-yang/Cargo.toml
+++ b/rustnetconf-yang/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming"]
 generated = []
 
 [dependencies]
-rustnetconf = { version = "0.14", path = ".." }
+rustnetconf = { version = "0.15", path = ".." }
 serde = { version = "1", features = ["derive"] }
 quick-xml = "0.41"
 thiserror = "2"

--- a/src/error.rs
+++ b/src/error.rs
@@ -116,28 +116,44 @@ pub enum FramingError {
     Mismatch { advertised: String, actual: String },
 }
 
+/// The parsed contents of a device's `<rpc-error>` response — all 7 fields
+/// defined by RFC 6241 §4.3.
+///
+/// Carried behind a [`Box`] in [`RpcError::ServerError`] so that the error
+/// enums stay small: at 128 bytes inline this struct made every
+/// `Result<T, NetconfError>` in the crate a large-`Err` return.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RpcServerError {
+    /// The conceptual layer where the error occurred.
+    pub error_type: Option<RpcErrorType>,
+    /// The error condition tag.
+    pub tag: ErrorTag,
+    /// Error severity.
+    pub severity: Option<ErrorSeverity>,
+    /// Vendor-specific or implementation-specific error tag.
+    pub app_tag: Option<String>,
+    /// XPath expression identifying the element in error.
+    pub path: Option<String>,
+    /// Human-readable error message.
+    pub message: String,
+    /// Additional error information (raw XML).
+    pub info: Option<String>,
+}
+
+impl std::fmt::Display for RpcServerError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "server error: [{:?}] {}", self.tag, self.message)
+    }
+}
+
 /// RPC layer errors — the device responded with `<rpc-error>`.
 #[derive(Debug, Error)]
 pub enum RpcError {
     /// Device returned a structured `<rpc-error>` response.
-    /// All 7 RFC 6241 §4.3 fields are parsed and available.
-    #[error("server error: [{tag:?}] {message}")]
-    ServerError {
-        /// The conceptual layer where the error occurred.
-        error_type: Option<RpcErrorType>,
-        /// The error condition tag.
-        tag: ErrorTag,
-        /// Error severity.
-        severity: Option<ErrorSeverity>,
-        /// Vendor-specific or implementation-specific error tag.
-        app_tag: Option<String>,
-        /// XPath expression identifying the element in error.
-        path: Option<String>,
-        /// Human-readable error message.
-        message: String,
-        /// Additional error information (raw XML).
-        info: Option<String>,
-    },
+    /// All 7 RFC 6241 §4.3 fields are parsed and available on
+    /// [`RpcServerError`].
+    #[error("{0}")]
+    ServerError(Box<RpcServerError>),
 
     /// RPC response was not received within the deadline.
     #[error("RPC timeout after {0:?}")]
@@ -156,6 +172,20 @@ pub enum RpcError {
     /// Response message-id does not match the request.
     #[error("message-id mismatch: expected {expected}, got {actual}")]
     MessageIdMismatch { expected: String, actual: String },
+}
+
+impl From<RpcServerError> for RpcError {
+    /// Box the payload into [`RpcError::ServerError`].
+    fn from(err: RpcServerError) -> Self {
+        RpcError::ServerError(Box::new(err))
+    }
+}
+
+impl From<RpcServerError> for NetconfError {
+    /// Box the payload into [`RpcError::ServerError`] and wrap it.
+    fn from(err: RpcServerError) -> Self {
+        NetconfError::Rpc(err.into())
+    }
 }
 
 /// Protocol layer errors (capability negotiation, session state).
@@ -213,6 +243,55 @@ mod tests {
         assert!(s.contains("device-a.lab"), "got {s:?}");
         assert!(s.contains("830"), "got {s:?}");
         assert!(s.contains("/etc/jmcp/known_hosts"), "got {s:?}");
+    }
+
+    /// Guards the fix for #66. `RpcError::ServerError` carried its 7 fields
+    /// inline at 128 bytes, which put both error enums exactly on clippy's
+    /// `result_large_err` threshold and lit the lint at 71 call sites.
+    /// Boxing the payload dropped them well under; these bounds keep a new
+    /// inline `String` field from silently pushing them back over.
+    #[test]
+    fn error_enums_stay_well_under_the_large_err_threshold() {
+        use std::mem::size_of;
+
+        const CLIPPY_LARGE_ERR_THRESHOLD: usize = 128;
+
+        for (name, size) in [
+            ("NetconfError", size_of::<NetconfError>()),
+            ("RpcError", size_of::<RpcError>()),
+            ("TransportError", size_of::<TransportError>()),
+            ("FramingError", size_of::<FramingError>()),
+            ("ProtocolError", size_of::<ProtocolError>()),
+        ] {
+            assert!(
+                size < CLIPPY_LARGE_ERR_THRESHOLD,
+                "{name} is {size} bytes, at or over clippy's \
+                 result_large_err threshold of {CLIPPY_LARGE_ERR_THRESHOLD} — \
+                 box the variant that grew rather than re-adding the allow"
+            );
+        }
+    }
+
+    #[test]
+    fn server_error_display_matches_the_pre_boxing_format() {
+        let err: RpcError = RpcServerError {
+            error_type: Some(RpcErrorType::Application),
+            tag: ErrorTag::InvalidValue,
+            severity: Some(ErrorSeverity::Error),
+            app_tag: None,
+            path: None,
+            message: "invalid interface name".into(),
+            info: None,
+        }
+        .into();
+        assert_eq!(
+            err.to_string(),
+            "server error: [InvalidValue] invalid interface name"
+        );
+        assert_eq!(
+            NetconfError::from(err).to_string(),
+            "RPC error: server error: [InvalidValue] invalid interface name"
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,14 +35,6 @@
 //! See [ARCHITECTURE.md](https://github.com/fastrevmd-lab/rustnetconf/blob/main/ARCHITECTURE.md)
 //! for full design details.
 
-// `NetconfError` and `RpcError` are 128 bytes, exactly clippy's
-// `result_large_err` threshold, so every fallible public function trips the
-// lint (72 sites across client.rs, session.rs, and pool/mod.rs). Both types
-// are public API of a published crate, so shrinking them means boxing a
-// variant, which is a breaking change and does not belong in a patch release.
-// Tracked in #66; remove this allow when the error types shrink.
-#![allow(clippy::result_large_err)]
-
 pub mod capability;
 pub mod client;
 pub mod error;
@@ -60,7 +52,7 @@ pub(crate) mod xml_entity;
 
 // Re-export the primary public API types
 pub use client::{Client, ClientBuilder, EditConfigBuilder};
-pub use error::NetconfError;
+pub use error::{NetconfError, RpcServerError};
 pub use facts::Facts;
 pub use notification::Notification;
 pub use rpc::RpcErrorInfo;

--- a/src/rpc/reply/mod.rs
+++ b/src/rpc/reply/mod.rs
@@ -102,12 +102,10 @@ mod tests {
 </rpc-reply>"#;
         let err = parse_rpc_reply(xml, "3").unwrap_err();
         match err {
-            RpcError::ServerError {
-                tag, message, path, ..
-            } => {
-                assert_eq!(tag, ErrorTag::InvalidValue);
-                assert_eq!(message, "invalid interface name");
-                assert!(path.unwrap().contains("ge-0/0/0"));
+            RpcError::ServerError(ref server_error) => {
+                assert_eq!(server_error.tag, ErrorTag::InvalidValue);
+                assert_eq!(server_error.message, "invalid interface name");
+                assert!(server_error.path.as_deref().unwrap().contains("ge-0/0/0"));
             }
             _ => panic!("expected ServerError, got {err:?}"),
         }
@@ -135,12 +133,10 @@ mod tests {
 </rpc-reply>"#;
         let err = parse_rpc_reply(xml, "5").unwrap_err();
         match err {
-            RpcError::ServerError {
-                tag, info, message, ..
-            } => {
-                assert_eq!(tag, ErrorTag::LockDenied);
-                assert!(message.contains("Lock failed"));
-                assert!(info.unwrap().contains("42"));
+            RpcError::ServerError(server_error) => {
+                assert_eq!(server_error.tag, ErrorTag::LockDenied);
+                assert!(server_error.message.contains("Lock failed"));
+                assert!(server_error.info.unwrap().contains("42"));
             }
             _ => panic!("expected ServerError"),
         }
@@ -251,9 +247,9 @@ mod tests {
 </rpc-reply>"#;
         let err = parse_rpc_reply(xml, "12").unwrap_err();
         match err {
-            RpcError::ServerError { tag, message, .. } => {
-                assert_eq!(tag, ErrorTag::InvalidValue);
-                assert_eq!(message, "real error");
+            RpcError::ServerError(ref server_error) => {
+                assert_eq!(server_error.tag, ErrorTag::InvalidValue);
+                assert_eq!(server_error.message, "real error");
             }
             _ => panic!("expected ServerError for hard error, got {err:?}"),
         }
@@ -322,8 +318,8 @@ mod tests {
 </rpc-reply>"#;
         let err = parse_rpc_reply(xml, "5").unwrap_err();
         match err {
-            RpcError::ServerError { message, .. } => {
-                assert_eq!(message, "syntax error before <get> & after");
+            RpcError::ServerError(server_error) => {
+                assert_eq!(server_error.message, "syntax error before <get> & after");
             }
             other => panic!("expected ServerError, got {other:?}"),
         }
@@ -363,9 +359,8 @@ mod tests {
 </rpc-reply>"#;
         let err = parse_rpc_reply(xml, "7").unwrap_err();
         match err {
-            RpcError::ServerError {
-                info: Some(info), ..
-            } => {
+            RpcError::ServerError(server_error) if server_error.info.is_some() => {
+                let info = server_error.info.expect("info checked above");
                 validate_xml_fragment(&info).expect("error-info must stay well-formed");
                 let decoded = quick_xml::escape::unescape(&info).expect("must unescape");
                 assert!(
@@ -429,8 +424,8 @@ mod tests {
 </rpc-reply>"#;
         let err = parse_rpc_reply(xml, "10").unwrap_err();
         match err {
-            RpcError::ServerError { message, .. } => {
-                assert_eq!(message, "bad & input");
+            RpcError::ServerError(server_error) => {
+                assert_eq!(server_error.message, "bad & input");
             }
             other => panic!("expected ServerError, got {other:?}"),
         }
@@ -531,8 +526,8 @@ mod tests {
 <ok/>
 </rpc-reply>"#;
         match parse_rpc_reply(xml, "8") {
-            Err(RpcError::ServerError { message, .. }) => {
-                assert_eq!(message, "configuration check-out failed");
+            Err(RpcError::ServerError(server_error)) => {
+                assert_eq!(server_error.message, "configuration check-out failed");
             }
             other => panic!("expected ServerError, got {other:?}"),
         }
@@ -695,11 +690,14 @@ mod tests {
 </nc:rpc-reply>"#;
         let err = parse_rpc_reply(xml, "101").unwrap_err();
         match err {
-            RpcError::ServerError { tag, message, .. } => {
-                assert_eq!(tag, ErrorTag::OperationFailed);
+            RpcError::ServerError(ref server_error) => {
+                assert_eq!(server_error.tag, ErrorTag::OperationFailed);
                 assert!(
-                    message.contains("configuration check-out failed"),
-                    "error message should be preserved, got: {message}"
+                    server_error
+                        .message
+                        .contains("configuration check-out failed"),
+                    "error message should be preserved, got: {}",
+                    server_error.message
                 );
             }
             other => panic!("expected ServerError, got {other:?}"),

--- a/src/rpc/reply/parser.rs
+++ b/src/rpc/reply/parser.rs
@@ -6,7 +6,7 @@ use super::lexical::{
     contains_only_xml_space, decode_attribute, validate_xml_chars, DocumentLexicalState,
 };
 use super::{RpcErrorInfo, RpcReply};
-use crate::error::RpcError;
+use crate::error::{RpcError, RpcServerError};
 use crate::types::{ErrorSeverity, ErrorTag, RpcErrorType};
 use quick_xml::events::{BytesCData, BytesEnd, BytesRef, BytesStart, BytesText, Event};
 use quick_xml::Reader;
@@ -1023,7 +1023,7 @@ impl ReplyParser<'_> {
             .partition(|error| error.severity != Some(ErrorSeverity::Warning));
 
         if let Some(error) = hard_errors.into_iter().next() {
-            return Err(RpcError::ServerError {
+            return Err(RpcError::ServerError(Box::new(RpcServerError {
                 error_type: error.error_type,
                 tag: error.tag,
                 severity: error.severity,
@@ -1031,7 +1031,7 @@ impl ReplyParser<'_> {
                 path: error.path,
                 message: error.message,
                 info: error.info,
-            });
+            })));
         }
 
         if let Some(message) = self.deferred_payload_error {
@@ -1304,11 +1304,8 @@ mod tests {
         for xml in cases {
             assert!(matches!(
                 parse_strict(&xml, "1"),
-                Err(RpcError::ServerError {
-                    tag: ErrorTag::InvalidValue,
-                    message,
-                    ..
-                }) if message == "hard failure"
+                Err(RpcError::ServerError(e))
+                    if e.tag == ErrorTag::InvalidValue && e.message == "hard failure"
             ));
         }
 
@@ -1478,7 +1475,7 @@ mod tests {
           </nc:rpc-error></nc:rpc-reply>"#;
         assert!(matches!(
             parse_strict(error, "1"),
-            Err(RpcError::ServerError { info: Some(_), .. })
+            Err(RpcError::ServerError(e)) if e.info.is_some()
         ));
     }
 
@@ -2109,10 +2106,8 @@ mod tests {
         </rpc-error></rpc-reply>"#;
         assert!(matches!(
             parse_strict(vendor, "1"),
-            Err(RpcError::ServerError {
-                tag: ErrorTag::Other(tag),
-                ..
-            }) if tag == "vendor-failure"
+            Err(RpcError::ServerError(e))
+                if matches!(&e.tag, ErrorTag::Other(tag) if tag == "vendor-failure")
         ));
     }
 
@@ -2187,12 +2182,12 @@ mod tests {
         </rpc-error></rpc-reply>"#;
 
         let error = parse_strict(xml, "1").expect_err("hard error");
-        let RpcError::ServerError {
-            info: Some(info), ..
-        } = error
-        else {
+        let RpcError::ServerError(server_error) = error else {
             panic!("expected ServerError with error-info");
         };
+        let info = server_error
+            .info
+            .expect("expected ServerError with error-info");
         assert!(info.contains("xmlns:v=\"urn:vendor\""));
         assert!(info.contains("v:source=\"candidate\""));
         assert!(info.contains("x &amp; y"));
@@ -2249,12 +2244,14 @@ mod tests {
             <error-info xmlns:e="urn:error-detail"><e:detail/></error-info>
           </rpc-error>
         </rpc-reply>"#;
-        let RpcError::ServerError {
-            info: Some(info), ..
-        } = parse_strict(error, "ns-error").expect_err("hard error")
+        let RpcError::ServerError(server_error) =
+            parse_strict(error, "ns-error").expect_err("hard error")
         else {
             panic!("expected ServerError with error-info");
         };
+        let info = server_error
+            .info
+            .expect("expected ServerError with error-info");
         assert!(info.contains("xmlns:e=\"urn:error-detail\""));
         validate_xml_fragment(&info).expect("error-info keeps inherited namespace");
     }
@@ -2372,12 +2369,12 @@ mod tests {
           <error-severity>error</error-severity>
           <error-info><x><![CDATA[once < & >]]></x></error-info>
         </rpc-error></rpc-reply>"#;
-        let RpcError::ServerError {
-            info: Some(info), ..
-        } = parse_strict(error_xml, "cdata-error").expect_err("hard error")
+        let RpcError::ServerError(server_error) =
+            parse_strict(error_xml, "cdata-error").expect_err("hard error")
         else {
             panic!("expected ServerError with info");
         };
+        let info = server_error.info.expect("expected ServerError with info");
         assert_eq!(info.matches("once &lt; &amp; &gt;").count(), 1);
     }
 
@@ -2413,12 +2410,12 @@ mod tests {
              <error-info>{children}</error-info>\
              </rpc-error></rpc-reply>"
         );
-        let RpcError::ServerError {
-            info: Some(info), ..
-        } = parse_strict(&error_xml, "error-eol").expect_err("hard rpc-error")
+        let RpcError::ServerError(server_error) =
+            parse_strict(&error_xml, "error-eol").expect_err("hard rpc-error")
         else {
             panic!("expected error-info fragment");
         };
+        let info = server_error.info.expect("expected error-info fragment");
 
         for (path, fragment) in [("data", data), ("direct", direct), ("error-info", info)] {
             assert!(fragment.contains(&expected_text), "{path}: {fragment:?}");
@@ -2442,11 +2439,12 @@ mod tests {
              <error-message>{literal}&#xD;&#xA;&amp;😀</error-message>\
              </rpc-error></rpc-reply>"
         );
-        let RpcError::ServerError { message, .. } =
+        let RpcError::ServerError(server_error) =
             parse_strict(&text_xml, "text-eol").expect_err("hard rpc-error")
         else {
             panic!("expected server error");
         };
+        let message = server_error.message;
         assert_eq!(message, "a\nb\nc\nd\r\n&😀");
 
         let cdata_xml = format!(
@@ -2457,11 +2455,12 @@ mod tests {
              <error-message><![CDATA[{literal}&😀]]></error-message>\
              </rpc-error></rpc-reply>"
         );
-        let RpcError::ServerError { message, .. } =
+        let RpcError::ServerError(server_error) =
             parse_strict(&cdata_xml, "cdata-eol").expect_err("hard rpc-error")
         else {
             panic!("expected server error");
         };
+        let message = server_error.message;
         assert_eq!(message, "a\nb\nc\nd&😀");
     }
 
@@ -2474,9 +2473,10 @@ mod tests {
         </rpc-error></rpc-reply>"#;
 
         let error = parse_strict(xml, "1").expect_err("hard error");
-        let RpcError::ServerError { message, .. } = error else {
+        let RpcError::ServerError(server_error) = error else {
             panic!("expected ServerError");
         };
+        let message = server_error.message;
         assert!(message.is_empty());
     }
 
@@ -3060,12 +3060,12 @@ mod tests {
              <error-info><detail probe=\"{references}\"/></error-info>\
              </rpc-error></rpc-reply>"
         );
-        let RpcError::ServerError {
-            info: Some(info), ..
-        } = parse_strict(&error_xml, "error").expect_err("hard rpc-error")
+        let RpcError::ServerError(server_error) =
+            parse_strict(&error_xml, "error").expect_err("hard rpc-error")
         else {
             panic!("expected captured error-info");
         };
+        let info = server_error.info.expect("expected captured error-info");
 
         for (path, fragment, element) in [
             ("data", data.as_str(), b"item".as_slice()),

--- a/src/session.rs
+++ b/src/session.rs
@@ -606,7 +606,6 @@ impl Session {
     }
 
     /// Ensure the session is established before sending RPCs.
-    #[allow(clippy::result_large_err)]
     fn ensure_established(&self) -> Result<(), NetconfError> {
         match self.state {
             SessionState::Established => Ok(()),
@@ -619,7 +618,6 @@ impl Session {
     }
 
     /// Ensure the device supports a capability, or return an error.
-    #[allow(clippy::result_large_err)]
     fn require_capability(&self, uri: &str, operation: &str) -> Result<(), NetconfError> {
         if !self.supports(uri) {
             return Err(ProtocolError::CapabilityMissing(format!(
@@ -1202,13 +1200,12 @@ impl Session {
     ) -> Result<Option<u32>, NetconfError> {
         match self.lock(target).await {
             Ok(()) => Ok(None),
-            Err(NetconfError::Rpc(crate::error::RpcError::ServerError {
-                ref tag,
-                ref info,
-                ..
-            })) if *tag == crate::types::ErrorTag::LockDenied => {
+            Err(NetconfError::Rpc(crate::error::RpcError::ServerError(ref server_error)))
+                if server_error.tag == crate::types::ErrorTag::LockDenied =>
+            {
                 // Try to extract session-id from error-info
-                let stale_session_id = info
+                let stale_session_id = server_error
+                    .info
                     .as_ref()
                     .and_then(|info_xml| parse_session_id_from_info(info_xml));
 
@@ -1226,7 +1223,7 @@ impl Session {
                 // Couldn't parse session-id — return the original error
                 Err(ProtocolError::CapabilityMissing(format!(
                     "lock denied but could not extract stale session-id from error-info: {:?}",
-                    info
+                    server_error.info
                 ))
                 .into())
             }

--- a/tests/rpc_reply_contract.rs
+++ b/tests/rpc_reply_contract.rs
@@ -110,9 +110,9 @@ fn public_hard_error_contract() {
 
     let error = parse_rpc_reply(xml, "44").expect_err("hard error must fail");
     match error {
-        RpcError::ServerError { tag, message, .. } => {
-            assert_eq!(tag, ErrorTag::InvalidValue);
-            assert_eq!(message, "invalid interface");
+        RpcError::ServerError(ref server_error) => {
+            assert_eq!(server_error.tag, ErrorTag::InvalidValue);
+            assert_eq!(server_error.message, "invalid interface");
         }
         other => panic!("expected ServerError, got {other:?}"),
     }


### PR DESCRIPTION
Closes #66.

## What

`NetconfError` and `RpcError` both measured exactly **128 bytes** — precisely clippy's `result_large_err` threshold — so every fallible function in the public surface tripped the lint. Lifting the suppression showed **71 sites**.

`RpcError::ServerError` was the whole of it: `message` plus three `Option<String>` is 96 bytes before `ErrorTag`'s own 24. Its seven RFC 6241 §4.3 fields move into a new public `RpcServerError`, and the variant becomes `ServerError(Box<RpcServerError>)`.

Measured on the real types, before and after:

| type | before | after |
|---|---|---|
| `NetconfError` | 128 | **72** |
| `RpcError` | 128 | **48** |

The new ceiling is `TransportError::HostKeyMismatch` at 72. Every `Result<T, NetconfError>` in the crate was also moving 128 bytes on the *success* path, since a `Result` is as wide as its larger arm.

## Breaking change

`RpcError::ServerError` is now a tuple variant carrying `Box<RpcServerError>` rather than a struct variant. The fields are unchanged and still public — only where they live moved.

```rust
// before
Err(NetconfError::Rpc(RpcError::ServerError { tag, message, .. })) => ...

// after
Err(NetconfError::Rpc(RpcError::ServerError(e))) => ... // e.tag, e.message
```

Two things soften it:

- **`Display` is byte-for-byte identical.** A test pins the output of both `RpcError` and `NetconfError`, so callers matching on the error *string* are unaffected.
- **`From<RpcServerError>` is provided** for both `RpcError` and `NetconfError`, so construction is `.into()` rather than a hand-rolled `Box::new`.

Version goes to **0.15.0**; `rustnetconf-cli` and `rustnetconf-yang` have no source changes and only carry the new `rustnetconf = "0.15"` requirement.

Downstream `rustjunosmcp` pins `rustnetconf = "0.14"`, so it will not pull this until it chooses to. When it does, ~6 match arms need the tuple form (`junos_transaction.rs:1028`, `candidate_transaction.rs:485`).

## The suppression is removed, not relocated

`#![allow(clippy::result_large_err)]` in `src/lib.rs` and both local allows in `src/session.rs` are gone. A new test asserts each error enum stays under 128 bytes, so a future inline `String` field fails the suite rather than quietly re-arming the lint.

## Toolchain pinned

`rust-toolchain.toml` now pins 1.98.0, matching every sibling crate in the fleet. CI installed `stable` unpinned, which is how this clippy change landed as a surprise red gate with no change on this side. Pinning alone would not have avoided it — stable *is* 1.98.0 — but it makes the next one a deliberate bump instead of a surprise.

## Verification

All on the pinned 1.98.0:

| gate | result |
|---|---|
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean, exit 0, no allows |
| `cargo test --workspace --all-features` | 398 + 105 + 15 doc-tests, 0 failed |
| `cargo fmt --all --check` | clean |
| `cargo doc --no-deps --all-features` | clean |
| `codex exec review` on both commits | no findings |

## Second commit

`782a2c0` is docs-only: the README release header sat on v0.14.3 while the crate shipped 0.14.4 and 0.14.5, so two releases carrying production SRX345 fixes had no "What's New" entry. Both are backfilled from their tags and commit messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)