### PR TITLE
chore(release): bump rustnetconf-cli 0.3.6 and rustnetconf-yang 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,7 +1859,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-cli"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap",
  "colored",
@@ -1876,7 +1876,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-yang"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "quick-xml",
  "rustnetconf",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
 > **Latest release — [v0.15.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.15.0)** (smaller error types — one breaking change).
-> On crates.io: `rustnetconf` 0.15.0 · `rustnetconf-cli` 0.3.5 · `rustnetconf-yang` 0.1.5.
+> On crates.io: `rustnetconf` 0.15.0 · `rustnetconf-cli` 0.3.6 · `rustnetconf-yang` 0.1.6.
 > See [What's New in v0.15.0](#whats-new-in-v0150) below.
 
 ## Workspace
@@ -50,7 +50,7 @@ Consumers that need those should use a dedicated SSH crate alongside this one. A
 
 ## What's New in v0.15.0
 
-Breaking change (#66). One variant changes shape; nothing else in the public API moves. `rustnetconf-cli` and `rustnetconf-yang` have no source changes and only carry the new dependency requirement.
+Breaking change (#66). One variant changes shape; nothing else in the public API moves. `rustnetconf-cli` (0.3.6) and `rustnetconf-yang` (0.1.6) have no source changes and bump only to carry the new `rustnetconf = "0.15"` requirement, exactly as they did at 0.14.0.
 
 - **`RpcError::ServerError` now carries a boxed struct.** Its 7 RFC 6241 §4.3 fields moved into a new public `RpcServerError`, and the variant became `ServerError(Box<RpcServerError>)`. The fields are unchanged, still public, and still all present — only where they live moved.
 

--- a/rustnetconf-cli/Cargo.toml
+++ b/rustnetconf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-cli"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "Terraform-like CLI for declarative NETCONF network config management"

--- a/rustnetconf-yang/Cargo.toml
+++ b/rustnetconf-yang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-yang"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "YANG model code generation for rustnetconf — compile-time config validation"


### PR DESCRIPTION
Follow-up to #68, required before 0.15.0 can be published.

## The gap

#68 moved both sibling crates' requirement to `rustnetconf = "0.15"` but left their own versions unchanged:

| crate | version in repo after #68 | published on crates.io | published requirement |
|---|---|---|---|
| `rustnetconf-cli` | 0.3.5 | **0.3.5** | `^0.14` |
| `rustnetconf-yang` | 0.1.5 | **0.1.5** | `^0.14` |

Those versions are already taken, so the new `"0.15"` requirement could never be uploaded — the repo would sit permanently ahead of the registry.

## The fix

Exactly what the 0.13 → 0.14 bump did in `517162b`:

```
rustnetconf-cli:  0.3.4 -> 0.3.5   dep "0.13" -> "0.14"
rustnetconf-yang: 0.1.4 -> 0.1.5   dep "0.13" -> "0.14"
```

So here: **cli 0.3.5 → 0.3.6**, **yang 0.1.5 → 0.1.6**. Neither has source changes; both bump solely to carry the new requirement. README release header and the v0.15.0 section corrected to name them.

## Verification

| gate | result |
|---|---|
| `cargo test --workspace --all-features` | 398 + 105 + 15 doc-tests, 0 failed |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| `cargo publish --dry-run -p rustnetconf` | packages and verifies 0.15.0 |
| `codex exec review --commit 963969e` | no findings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)