### PR TITLE
deps(quick-xml): migrate to 0.42

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,9 +1559,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ tokio = { version = "1", features = ["full"] }
 russh = { version = "0.62", default-features = false, features = ["flate2", "aws-lc-rs"] }
 aws-lc-rs = { version = "1", default-features = false, features = ["aws-lc-sys"] }
 base64ct = { version = "1", features = ["std"] }
-quick-xml = "0.41"
+quick-xml = "0.42"
 thiserror = "2"
 tracing = "0.1"
 async-trait = "0.1"

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1206,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
 dependencies = [
  "memchr",
 ]

--- a/rustnetconf-cli/Cargo.toml
+++ b/rustnetconf-cli/Cargo.toml
@@ -19,7 +19,7 @@ colored = "3"
 toml = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-quick-xml = "0.41"
+quick-xml = "0.42"
 tokio = { version = "1", features = ["full"] }
 dialoguer = "0.11"
 zeroize = "1"

--- a/rustnetconf-cli/src/diff/tree.rs
+++ b/rustnetconf-cli/src/diff/tree.rs
@@ -54,14 +54,15 @@ fn resolve_entity_ref(entity: &quick_xml::events::BytesRef<'_>) -> Option<String
     if let Ok(Some(ch)) = entity.resolve_char_ref() {
         return Some(ch.to_string());
     }
-    let name = entity.decode().ok()?;
+    // 0.42 decodes at the reader, so the name is already `str`.
+    let name: &str = entity;
     // `resolve_xml_entity`, not `resolve_predefined_entity` — the same hazard
     // the library crate's copy of this helper documents, missed here when that
     // one was fixed. `resolve_predefined_entity` is dispatched on quick-xml's
     // `escape-html` feature, and Cargo unifies features across the whole
     // graph, so any unrelated dependency enabling it would make `netconf diff`
     // resolve HTML5 entities the device never sent.
-    quick_xml::escape::resolve_xml_entity(&name).map(|s| s.to_string())
+    quick_xml::escape::resolve_xml_entity(name).map(|s| s.to_string())
 }
 
 /// Parse an XML string into a simplified tree.
@@ -90,7 +91,7 @@ fn parse_xml_tree(xml: &str) -> Result<Vec<XmlNode>, String> {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref tag)) => {
                 flush_text(&mut pending_text, &mut stack);
-                let name = String::from_utf8_lossy(tag.local_name().as_ref()).to_string();
+                let name = tag.local_name().as_ref().to_string();
                 stack.push((name, Vec::new()));
             }
             Ok(Event::End(_)) => {
@@ -105,7 +106,7 @@ fn parse_xml_tree(xml: &str) -> Result<Vec<XmlNode>, String> {
                 }
             }
             Ok(Event::Text(ref text)) => {
-                pending_text.push_str(&text.decode().unwrap_or_default());
+                pending_text.push_str(text);
             }
             Ok(Event::GeneralRef(ref entity)) => {
                 if let Some(resolved) = resolve_entity_ref(entity) {
@@ -113,11 +114,11 @@ fn parse_xml_tree(xml: &str) -> Result<Vec<XmlNode>, String> {
                 }
             }
             Ok(Event::CData(ref cdata)) => {
-                pending_text.push_str(&cdata.decode().unwrap_or_default());
+                pending_text.push_str(cdata);
             }
             Ok(Event::Empty(ref tag)) => {
                 flush_text(&mut pending_text, &mut stack);
-                let name = String::from_utf8_lossy(tag.local_name().as_ref()).to_string();
+                let name = tag.local_name().as_ref().to_string();
                 let node = XmlNode::Element {
                     name,
                     children: Vec::new(),

--- a/rustnetconf-yang/Cargo.toml
+++ b/rustnetconf-yang/Cargo.toml
@@ -20,7 +20,7 @@ bundled = ["yang2/bundled"]
 [dependencies]
 rustnetconf = { version = "0.16", path = ".." }
 serde = { version = "1", features = ["derive"] }
-quick-xml = "0.41"
+quick-xml = "0.42"
 thiserror = "2"
 
 [dev-dependencies]

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -232,17 +232,16 @@ pub fn parse_device_hello(xml: &str) -> Result<Capabilities, String> {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref tag)) | Ok(Event::Empty(ref tag)) => {
                 let local_name = tag.local_name();
-                if local_name.as_ref() == b"capability" {
+                if local_name.as_ref() == "capability" {
                     in_capability = true;
                     text_buf.clear();
-                } else if local_name.as_ref() == b"session-id" {
+                } else if local_name.as_ref() == "session-id" {
                     in_session_id = true;
                     text_buf.clear();
                 }
             }
             Ok(Event::Text(ref text)) if in_capability || in_session_id => {
-                let value = text.decode().map_err(|e| e.to_string())?;
-                text_buf.push_str(&value);
+                text_buf.push_str(text);
             }
             Ok(Event::GeneralRef(ref entity)) if in_capability || in_session_id => {
                 if let Some(resolved) = resolve_entity_ref(entity) {
@@ -250,19 +249,18 @@ pub fn parse_device_hello(xml: &str) -> Result<Capabilities, String> {
                 }
             }
             Ok(Event::CData(ref cdata)) if in_capability || in_session_id => {
-                let value = cdata.decode().map_err(|e| e.to_string())?;
-                text_buf.push_str(&value);
+                text_buf.push_str(cdata);
             }
             Ok(Event::End(ref tag)) => {
                 let local_name = tag.local_name();
-                if local_name.as_ref() == b"capability" {
+                if local_name.as_ref() == "capability" {
                     in_capability = false;
                     let trimmed = text_buf.trim();
                     if !trimmed.is_empty() {
                         capabilities.insert(trimmed.to_string());
                     }
                     text_buf.clear();
-                } else if local_name.as_ref() == b"session-id" {
+                } else if local_name.as_ref() == "session-id" {
                     in_session_id = false;
                     session_id = text_buf.trim().parse().ok();
                     text_buf.clear();

--- a/src/notification.rs
+++ b/src/notification.rs
@@ -39,8 +39,8 @@ pub fn classify_message(xml: &str) -> Option<MessageKind> {
             Ok(Event::Start(ref tag)) | Ok(Event::Empty(ref tag)) => {
                 let local_name = tag.local_name();
                 return match local_name.as_ref() {
-                    b"rpc-reply" => Some(MessageKind::RpcReply),
-                    b"notification" => Some(MessageKind::Notification),
+                    "rpc-reply" => Some(MessageKind::RpcReply),
+                    "notification" => Some(MessageKind::Notification),
                     _ => None,
                 };
             }
@@ -73,16 +73,13 @@ pub fn parse_notification(xml: &str) -> Result<Notification, RpcError> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref tag)) => {
-                if tag.local_name().as_ref() == b"eventTime" {
+                if tag.local_name().as_ref() == "eventTime" {
                     in_event_time = true;
                     time_buf = None;
                 }
             }
             Ok(Event::Text(ref text)) if in_event_time => {
-                let t = text
-                    .decode()
-                    .map_err(|e| RpcError::ParseError(format!("failed to parse eventTime: {e}")))?;
-                time_buf.get_or_insert_with(String::new).push_str(&t);
+                time_buf.get_or_insert_with(String::new).push_str(text);
             }
             Ok(Event::GeneralRef(ref entity)) if in_event_time => {
                 if let Some(resolved) = resolve_entity_ref(entity) {
@@ -90,13 +87,10 @@ pub fn parse_notification(xml: &str) -> Result<Notification, RpcError> {
                 }
             }
             Ok(Event::CData(ref cdata)) if in_event_time => {
-                let t = cdata
-                    .decode()
-                    .map_err(|e| RpcError::ParseError(format!("failed to parse eventTime: {e}")))?;
-                time_buf.get_or_insert_with(String::new).push_str(&t);
+                time_buf.get_or_insert_with(String::new).push_str(cdata);
             }
             Ok(Event::End(ref tag)) => {
-                if tag.local_name().as_ref() == b"eventTime" {
+                if tag.local_name().as_ref() == "eventTime" {
                     in_event_time = false;
                     if let Some(t) = time_buf.take() {
                         event_time = Some(t.trim().to_string());
@@ -145,15 +139,15 @@ fn extract_event_content(xml: &str) -> String {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref tag)) => {
-                if tag.local_name().as_ref() == b"notification" {
+                if tag.local_name().as_ref() == "notification" {
                     in_notification = true;
                 }
             }
             Ok(Event::End(ref tag)) => {
                 let local = tag.local_name();
-                if local.as_ref() == b"eventTime" && in_notification {
+                if local.as_ref() == "eventTime" && in_notification {
                     event_time_end_offset = Some(reader.buffer_position() as usize);
-                } else if local.as_ref() == b"notification" && in_notification {
+                } else if local.as_ref() == "notification" && in_notification {
                     if let Some(start) = event_time_end_offset {
                         // Find the closing </...notification> tag start in the raw string
                         let pos = reader.buffer_position() as usize;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -153,9 +153,7 @@ pub fn validate_xml_fragment(xml: &str) -> Result<(), ProtocolError> {
             // slips through Text/CDATA and produces a document a strict parser
             // rejects. Same validator/parser disagreement, different axis.
             Ok(Event::Text(ref t)) => {
-                let decoded = t.decode().map_err(|e| {
-                    ProtocolError::Xml(format!("XML fragment text is not decodable: {e}"))
-                })?;
+                let decoded: &str = t;
                 if !decoded
                     .chars()
                     .all(crate::rpc::reply::lexical::is_valid_xml_char)
@@ -174,9 +172,7 @@ pub fn validate_xml_fragment(xml: &str) -> Result<(), ProtocolError> {
                 }
             }
             Ok(Event::CData(ref c)) => {
-                let decoded = c.decode().map_err(|e| {
-                    ProtocolError::Xml(format!("XML fragment CDATA is not decodable: {e}"))
-                })?;
+                let decoded: &str = c;
                 if !decoded
                     .chars()
                     .all(crate::rpc::reply::lexical::is_valid_xml_char)
@@ -199,9 +195,7 @@ pub fn validate_xml_fragment(xml: &str) -> Result<(), ProtocolError> {
             // not end with `-`. quick-xml accepts `<!-->` and `<---->`; a
             // conforming parser rejects both.
             Ok(Event::Comment(ref c)) => {
-                let body = std::str::from_utf8(c.as_ref()).map_err(|_| {
-                    ProtocolError::Xml("XML fragment has a non-UTF-8 comment".to_string())
-                })?;
+                let body: &str = c.as_ref();
                 if body.contains("--") || body.ends_with('-') {
                     return Err(ProtocolError::Xml(
                         "XML fragment has a malformed comment: `--` may not appear \
@@ -223,10 +217,12 @@ pub fn validate_xml_fragment(xml: &str) -> Result<(), ProtocolError> {
             // A processing instruction's target must be a Name, and may not be
             // `xml` in any case (XML 1.0 §2.6). quick-xml validates neither.
             Ok(Event::PI(ref pi)) => {
-                let raw = pi.as_ref();
+                let raw: &str = pi.as_ref();
+                // ASCII whitespace only, exactly as the byte scan did. Not
+                // `char::is_whitespace`, which is Unicode-aware and would split
+                // the target on characters XML does not treat as whitespace.
                 let target_end = raw
-                    .iter()
-                    .position(|b| b.is_ascii_whitespace())
+                    .find(|c: char| c.is_ascii_whitespace())
                     .unwrap_or(raw.len());
                 let target = &raw[..target_end];
                 // `Name`, not `NCName`. XML 1.0 §2.6 defines
@@ -238,19 +234,14 @@ pub fn validate_xml_fragment(xml: &str) -> Result<(), ProtocolError> {
                 // first by requiring NCName, then by reusing `validate_name`,
                 // which enforces QName and so still refused `<?a:b:c?>`.
                 validate_pi_target(target)?;
-                if target.eq_ignore_ascii_case(b"xml") {
+                if target.eq_ignore_ascii_case("xml") {
                     return Err(ProtocolError::Xml(
                         "XML fragment has a processing instruction targeting `xml`, \
                          which is reserved"
                             .to_string(),
                     ));
                 }
-                let body = std::str::from_utf8(raw).map_err(|_| {
-                    ProtocolError::Xml(
-                        "XML fragment has a non-UTF-8 processing instruction".to_string(),
-                    )
-                })?;
-                if !body
+                if !raw
                     .chars()
                     .all(crate::rpc::reply::lexical::is_valid_xml_char)
                 {
@@ -276,7 +267,7 @@ pub fn validate_xml_fragment(xml: &str) -> Result<(), ProtocolError> {
                         }
                     }
                     None => {
-                        let name = entity.decode().unwrap_or_default();
+                        let name: &str = entity;
                         let preview: String = name.chars().take(32).collect();
                         return Err(ProtocolError::Xml(format!(
                             "XML fragment references an undefined entity `&{preview};`; \
@@ -398,10 +389,7 @@ fn is_name_char(c: char) -> bool {
 /// processing-instruction target is only required to be a `Name`, so
 /// `<?a:b:c?>`, `<?:a?>` and `<?a:?>` are all legal and a conforming parser
 /// accepts them.
-fn validate_pi_target(raw: &[u8]) -> Result<(), ProtocolError> {
-    let name = std::str::from_utf8(raw).map_err(|_| {
-        ProtocolError::Xml("XML fragment has a non-UTF-8 processing-instruction target".to_string())
-    })?;
+fn validate_pi_target(name: &str) -> Result<(), ProtocolError> {
     let mut chars = name.chars();
     let ok = match chars.next() {
         None => false,
@@ -442,8 +430,9 @@ fn validate_attributes(tag: &quick_xml::events::BytesStart<'_>) -> Result<(), Pr
     // XML requires whitespace before every attribute. quick-xml's iterator
     // happily yields both of `<a b="1"c="2"/>`, so the separator has to be
     // checked against the raw bytes: after a closing quote, only whitespace or
-    // the end of the tag may follow.
-    let raw = tag.attributes_raw();
+    // the end of the tag may follow. 0.42 hands this back as `str`; the rule is
+    // about ASCII quote and whitespace bytes, so it stays a byte scan.
+    let raw = tag.attributes_raw().as_bytes();
     let mut quote: Option<u8> = None;
     for (i, &byte) in raw.iter().enumerate() {
         match quote {
@@ -475,16 +464,14 @@ fn validate_attributes(tag: &quick_xml::events::BytesStart<'_>) -> Result<(), Pr
         // `xmlns:p=""` is not. roxmltree 0.20 accepts it, so the strict
         // validator cannot catch it either — but the attribute iteration
         // needed to see it already happens here.
-        if attribute.key.as_ref().starts_with(b"xmlns:") && attribute.value.is_empty() {
+        if attribute.key.as_ref().starts_with("xmlns:") && attribute.value.is_empty() {
             return Err(ProtocolError::Xml(
                 "XML fragment undeclares a prefixed namespace; only the default \
                  namespace may be set to an empty URI"
                     .to_string(),
             ));
         }
-        let value = std::str::from_utf8(attribute.value.as_ref()).map_err(|_| {
-            ProtocolError::Xml("XML fragment has a non-UTF-8 attribute value".to_string())
-        })?;
+        let value: &str = attribute.value.as_ref();
         if !value
             .chars()
             .all(crate::rpc::reply::lexical::is_valid_xml_char)
@@ -577,11 +564,12 @@ fn validate_attribute_references(value: &str) -> Result<(), ProtocolError> {
 ///
 /// Only the prefix is reserved: `<xmlns/>` is a valid element name, and
 /// roxmltree accepts it.
-fn validate_element_name(raw: &[u8]) -> Result<(), ProtocolError> {
-    validate_name(raw)?;
-    let mut parts = raw.split(|byte| *byte == b':');
+fn validate_element_name(name: &str) -> Result<(), ProtocolError> {
+    validate_name(name)?;
+    // `:` is ASCII, so this split is the same operation it was over bytes.
+    let mut parts = name.split(':');
     if let (Some(prefix), Some(_)) = (parts.next(), parts.next()) {
-        if prefix == b"xmlns" {
+        if prefix == "xmlns" {
             return Err(ProtocolError::Xml(
                 "XML fragment has an element using the reserved `xmlns` prefix;                  it may only introduce namespace declarations"
                     .to_string(),
@@ -591,9 +579,7 @@ fn validate_element_name(raw: &[u8]) -> Result<(), ProtocolError> {
     Ok(())
 }
 
-fn validate_name(raw: &[u8]) -> Result<(), ProtocolError> {
-    let name = std::str::from_utf8(raw)
-        .map_err(|_| ProtocolError::Xml("XML fragment has a non-UTF-8 element name".to_string()))?;
+fn validate_name(name: &str) -> Result<(), ProtocolError> {
     // NETCONF is namespace-based throughout, so the relevant standard is
     // QName, not the raw Name production. `:` is a legal NameStartChar, which
     // makes `<:/>` a valid Name and an invalid QName — a namespace-aware parser

--- a/src/rpc/operations.rs
+++ b/src/rpc/operations.rs
@@ -574,14 +574,13 @@ pub(crate) fn parse_partial_lock_reply(payload: &str) -> Result<PartialLock, Net
                     "partial-lock reply has an invalid attribute: {e}"
                 )))
             })?;
-            let key = attr.key.as_ref();
-            let prefix = if key == b"xmlns" {
+            let key: &str = attr.key.as_ref();
+            // 0.42 decodes at the reader, so a prefix that is not valid UTF-8
+            // fails the read rather than arriving here to be skipped.
+            let prefix = if key == "xmlns" {
                 None
-            } else if let Some(p) = key.strip_prefix(b"xmlns:") {
-                match std::str::from_utf8(p) {
-                    Ok(p) => Some(p.to_string()),
-                    Err(_) => continue,
-                }
+            } else if let Some(p) = key.strip_prefix("xmlns:") {
+                Some(p.to_string())
             } else {
                 continue;
             };
@@ -596,12 +595,10 @@ pub(crate) fn parse_partial_lock_reply(payload: &str) -> Result<PartialLock, Net
     }
 
     /// Resolve an element's namespace against the declarations in scope.
-    fn resolve_ns(raw_name: &[u8], scopes: &[Vec<(Option<String>, String)>]) -> Option<String> {
-        let prefix = raw_name
-            .iter()
-            .position(|b| *b == b':')
-            .and_then(|i| std::str::from_utf8(&raw_name[..i]).ok())
-            .map(|s| s.to_string());
+    fn resolve_ns(raw_name: &str, scopes: &[Vec<(Option<String>, String)>]) -> Option<String> {
+        // `:` is ASCII, so splitting on the first one is the same operation it
+        // was over bytes — no char boundary can fall inside it.
+        let prefix = raw_name.find(':').map(|i| raw_name[..i].to_string());
         // `xml` is bound implicitly and never appears in a declaration, so it
         // must be resolved here; otherwise <xml:lock-id> looks unqualified and
         // would be wrongly accepted.
@@ -663,8 +660,8 @@ pub(crate) fn parse_partial_lock_reply(payload: &str) -> Result<PartialLock, Net
                 };
                 current = if in_scope {
                     match e.local_name().as_ref() {
-                        b"lock-id" => Some("lock-id"),
-                        b"locked-node" => Some("locked-node"),
+                        "lock-id" => Some("lock-id"),
+                        "locked-node" => Some("locked-node"),
                         _ => None,
                     }
                 } else {
@@ -683,20 +680,10 @@ pub(crate) fn parse_partial_lock_reply(payload: &str) -> Result<PartialLock, Net
             }
             Ok(Event::Empty(_)) => {}
             Ok(Event::Text(ref text)) if current.is_some() => {
-                let decoded = text.decode().map_err(|e| {
-                    NetconfError::Protocol(ProtocolError::Xml(format!(
-                        "partial-lock reply text is not decodable: {e}"
-                    )))
-                })?;
-                text_buf.push_str(&decoded);
+                text_buf.push_str(text);
             }
             Ok(Event::CData(ref cdata)) if current.is_some() => {
-                let decoded = cdata.decode().map_err(|e| {
-                    NetconfError::Protocol(ProtocolError::Xml(format!(
-                        "partial-lock reply CDATA is not decodable: {e}"
-                    )))
-                })?;
-                text_buf.push_str(&decoded);
+                text_buf.push_str(cdata);
             }
             Ok(Event::GeneralRef(ref entity)) if current.is_some() => {
                 if let Some(resolved) = crate::xml_entity::resolve_entity_ref(entity) {

--- a/src/rpc/reply/capture.rs
+++ b/src/rpc/reply/capture.rs
@@ -50,8 +50,7 @@ impl FragmentCapture {
             ));
         }
         let binding = tag.name();
-        let name = str::from_utf8(binding.as_ref())
-            .map_err(|error| parse_error(format!("invalid end-tag name: {error}")))?;
+        let name = binding.as_ref();
         self.xml.push_str("</");
         self.xml.push_str(name);
         self.xml.push('>');
@@ -61,32 +60,29 @@ impl FragmentCapture {
 
     pub(super) fn text(&mut self, text: &BytesText<'_>) -> Result<(), RpcError> {
         validate_text_lexical(text.as_ref())?;
-        let decoded = text
-            .xml10_content()
-            .map_err(|error| parse_error(format!("invalid text encoding: {error}")))?;
+        let decoded = text.xml10_content();
         validate_xml_chars(&decoded, "text content")?;
         self.xml.push_str(&escape_xml_text(&decoded));
         Ok(())
     }
 
     pub(super) fn cdata(&mut self, cdata: &BytesCData<'_>) -> Result<(), RpcError> {
-        let decoded = cdata
-            .xml10_content()
-            .map_err(|error| parse_error(format!("invalid CDATA encoding: {error}")))?;
+        let decoded = cdata.xml10_content();
         validate_xml_chars(&decoded, "CDATA content")?;
         self.xml.push_str(&escape_xml_text(&decoded));
         Ok(())
     }
 
     pub(super) fn entity(&mut self, entity: &BytesRef<'_>) -> Result<(), RpcError> {
-        let decoded = entity
-            .decode()
-            .map_err(|error| parse_error(format!("invalid entity encoding: {error}")))?;
+        // quick-xml 0.42 decodes at the reader, so the event already holds
+        // `str`; there is no per-event decode step and no encoding error to
+        // surface here any more.
+        let decoded: &str = entity;
         crate::xml_entity::resolve_entity_ref(entity)
             .filter(|value| value.chars().all(is_valid_xml_char))
             .ok_or_else(|| parse_error("invalid entity reference".to_string()))?;
         self.xml.push('&');
-        self.xml.push_str(&decoded);
+        self.xml.push_str(decoded);
         self.xml.push(';');
         Ok(())
     }
@@ -97,15 +93,13 @@ impl FragmentCapture {
 
     fn write_start_like(&mut self, tag: &BytesStart<'_>, empty: bool) -> Result<(), RpcError> {
         let binding = tag.name();
-        let name = str::from_utf8(binding.as_ref())
-            .map_err(|error| parse_error(format!("invalid start-tag name: {error}")))?;
+        let name = binding.as_ref();
         let mut attributes = Vec::new();
         let mut explicit_namespaces = HashSet::new();
         for attribute in tag.attributes().with_checks(true) {
             let attribute = attribute
                 .map_err(|error| parse_error(format!("invalid XML attribute: {error}")))?;
-            let key = str::from_utf8(attribute.key.as_ref())
-                .map_err(|error| parse_error(format!("invalid attribute name: {error}")))?;
+            let key = attribute.key.as_ref();
             let value = decode_attribute(attribute.value.as_ref(), "captured XML attribute value")?;
             if let Some(prefix) = namespace_prefix(key)? {
                 explicit_namespaces.insert(prefix.to_string());
@@ -173,8 +167,7 @@ pub(super) fn namespace_declarations(tag: &BytesStart<'_>) -> Result<NamespaceBi
     for attribute in tag.attributes().with_checks(true) {
         let attribute =
             attribute.map_err(|error| parse_error(format!("invalid XML attribute: {error}")))?;
-        let key = str::from_utf8(attribute.key.as_ref())
-            .map_err(|error| parse_error(format!("invalid attribute name: {error}")))?;
+        let key = attribute.key.as_ref();
         let Some(prefix) = namespace_prefix(key)? else {
             continue;
         };
@@ -187,9 +180,9 @@ pub(super) fn namespace_declarations(tag: &BytesStart<'_>) -> Result<NamespaceBi
     Ok(declarations)
 }
 
-pub(super) fn validate_qname(raw: &[u8]) -> Result<ValidatedQName<'_>, RpcError> {
-    let name =
-        str::from_utf8(raw).map_err(|_| parse_error("invalid QName encoding".to_string()))?;
+pub(super) fn validate_qname(name: &str) -> Result<ValidatedQName<'_>, RpcError> {
+    // quick-xml 0.42 decodes at the reader, so names arrive as `str` and the
+    // UTF-8 check that used to guard this is unreachable rather than removed.
     let mut parts = name.split(':');
     let first = parts
         .next()
@@ -213,8 +206,8 @@ pub(super) fn validate_qname(raw: &[u8]) -> Result<ValidatedQName<'_>, RpcError>
     Ok(ValidatedQName { prefix, local })
 }
 
-pub(super) fn is_namespace_declaration(attribute_name: &[u8]) -> bool {
-    attribute_name == b"xmlns" || attribute_name.starts_with(b"xmlns:")
+pub(super) fn is_namespace_declaration(attribute_name: &str) -> bool {
+    attribute_name == "xmlns" || attribute_name.starts_with("xmlns:")
 }
 
 fn namespace_prefix(attribute_name: &str) -> Result<Option<&str>, RpcError> {

--- a/src/rpc/reply/lexical.rs
+++ b/src/rpc/reply/lexical.rs
@@ -50,7 +50,10 @@ fn validate_attribute_separators(tag: &BytesStart<'_>) -> Result<(), RpcError> {
     }
 }
 
-fn ordinary_attribute_separators_are_valid(raw: &[u8]) -> bool {
+fn ordinary_attribute_separators_are_valid(raw: &str) -> bool {
+    // The lexical rules below are byte rules; only the boundary moved to
+    // `str` when quick-xml started decoding at the reader.
+    let raw = raw.as_bytes();
     let mut cursor = 0usize;
     loop {
         let separator_start = cursor;
@@ -99,7 +102,10 @@ fn ordinary_attribute_separators_are_valid(raw: &[u8]) -> bool {
     }
 }
 
-pub(super) fn validate_text_lexical(raw: &[u8]) -> Result<(), RpcError> {
+pub(super) fn validate_text_lexical(raw: &str) -> Result<(), RpcError> {
+    // The lexical rules below are byte rules; only the boundary moved to
+    // `str` when quick-xml started decoding at the reader.
+    let raw = raw.as_bytes();
     if raw.windows(3).any(|window| window == b"]]>") {
         Err(parse_error(
             "character data contains forbidden CDATA terminator",
@@ -109,31 +115,28 @@ pub(super) fn validate_text_lexical(raw: &[u8]) -> Result<(), RpcError> {
     }
 }
 
-fn validate_comment(raw: &[u8]) -> Result<(), RpcError> {
-    if raw.windows(2).any(|window| window == b"--") || raw.ends_with(b"-") {
+fn validate_comment(raw: &str) -> Result<(), RpcError> {
+    if raw.contains("--") || raw.ends_with('-') {
         return Err(parse_error("invalid XML comment syntax"));
     }
-    let decoded = str::from_utf8(raw).map_err(|_| parse_error("invalid comment encoding"))?;
-    validate_xml_chars(decoded, "comment")
+    validate_xml_chars(raw, "comment")
 }
 
 fn validate_processing_instruction(
     instruction: &quick_xml::events::BytesPI<'_>,
 ) -> Result<(), RpcError> {
     let target = instruction.target();
-    if !is_valid_ncname_bytes(target) || target.eq_ignore_ascii_case(b"xml") {
+    if !is_valid_ncname_bytes(target.as_bytes()) || target.eq_ignore_ascii_case("xml") {
         return Err(parse_error("invalid processing instruction target"));
     }
-    let decoded = str::from_utf8(instruction.as_ref())
-        .map_err(|_| parse_error("invalid processing instruction encoding"))?;
+    let decoded = instruction.as_ref();
     validate_xml_chars(decoded, "processing instruction")
 }
 
 fn validate_declaration(declaration: &BytesDecl<'_>) -> Result<(), RpcError> {
-    let raw = str::from_utf8(declaration.as_ref())
-        .map_err(|_| parse_error("invalid XML declaration encoding"))?;
+    let raw = declaration.as_ref();
     validate_xml_chars(raw, "XML declaration")?;
-    if !declaration_attributes_are_separated(raw.as_bytes()) {
+    if !declaration_attributes_are_separated(raw) {
         return Err(parse_error("invalid XML declaration syntax"));
     }
 
@@ -143,9 +146,9 @@ fn validate_declaration(declaration: &BytesDecl<'_>) -> Result<(), RpcError> {
     for attribute in declaration.attributes().with_checks(true) {
         let attribute = attribute.map_err(|_| parse_error("invalid XML declaration syntax"))?;
         let (rank, valid_value) = match attribute.key.as_ref() {
-            b"version" => (0, attribute.value.as_ref() == b"1.0"),
-            b"encoding" => (1, valid_encoding_name(attribute.value.as_ref())),
-            b"standalone" => (2, matches!(attribute.value.as_ref(), b"yes" | b"no")),
+            "version" => (0, attribute.value.as_ref() == "1.0"),
+            "encoding" => (1, valid_encoding_name(attribute.value.as_ref())),
+            "standalone" => (2, matches!(attribute.value.as_ref(), "yes" | "no")),
             _ => return Err(parse_error("invalid XML declaration syntax")),
         };
         if (count == 0 && rank != 0) || previous_rank.is_some_and(|previous| previous >= rank) {
@@ -163,7 +166,10 @@ fn validate_declaration(declaration: &BytesDecl<'_>) -> Result<(), RpcError> {
     Ok(())
 }
 
-fn declaration_attributes_are_separated(raw: &[u8]) -> bool {
+fn declaration_attributes_are_separated(raw: &str) -> bool {
+    // The lexical rules below are byte rules; only the boundary moved to
+    // `str` when quick-xml started decoding at the reader.
+    let raw = raw.as_bytes();
     if !raw.starts_with(b"xml") {
         return false;
     }
@@ -226,7 +232,10 @@ pub(super) fn contains_only_xml_space(value: &str) -> bool {
     value.bytes().all(is_xml_space)
 }
 
-fn valid_encoding_name(value: &[u8]) -> bool {
+fn valid_encoding_name(value: &str) -> bool {
+    // The lexical rules below are byte rules; only the boundary moved to
+    // `str` when quick-xml started decoding at the reader.
+    let value = value.as_bytes();
     value.first().is_some_and(u8::is_ascii_alphabetic)
         && value[1..]
             .iter()
@@ -296,9 +305,8 @@ pub(super) fn validate_xml_chars(value: &str, field: &'static str) -> Result<(),
     }
 }
 
-pub(crate) fn decode_attribute(raw: &[u8], field: &'static str) -> Result<String, RpcError> {
+pub(crate) fn decode_attribute(raw: &str, field: &'static str) -> Result<String, RpcError> {
     validate_attribute_lexical(raw)?;
-    let raw = str::from_utf8(raw).map_err(|_| parse_error(format!("invalid {field} encoding")))?;
     let normalized = normalize_literal_attribute_whitespace(raw);
     let decoded = quick_xml::escape::unescape(&normalized)
         .map(|value| value.into_owned())
@@ -332,7 +340,9 @@ fn normalize_literal_attribute_whitespace(raw: &str) -> Cow<'_, str> {
     Cow::Owned(normalized)
 }
 
-fn validate_attribute_lexical(raw: &[u8]) -> Result<(), RpcError> {
+fn validate_attribute_lexical(raw: &str) -> Result<(), RpcError> {
+    // quick-xml 0.42 decodes at the reader; only the boundary moved to `str`.
+    let raw = raw.as_bytes();
     if raw.contains(&b'<') {
         return Err(parse_error("attribute value contains raw '<'"));
     }
@@ -349,12 +359,12 @@ mod tests {
 
     #[test]
     fn normalizes_literal_attribute_whitespace_before_expanding_references() {
-        let literal = decode_attribute(b"left\tmiddle\nright\rend\r\ntail", "test attribute value")
+        let literal = decode_attribute("left\tmiddle\nright\rend\r\ntail", "test attribute value")
             .expect("literal XML whitespace is valid");
         assert_eq!(literal, "left middle right end tail");
 
         let referenced =
-            decode_attribute(b"left&#x9;middle&#xA;right&#xD;end", "test attribute value")
+            decode_attribute("left&#x9;middle&#xA;right&#xD;end", "test attribute value")
                 .expect("referenced XML whitespace is valid");
         assert_eq!(referenced, "left\tmiddle\nright\rend");
     }
@@ -362,7 +372,7 @@ mod tests {
     #[test]
     fn attribute_normalization_preserves_entities_quotes_and_unicode() {
         let decoded = decode_attribute(
-            "caf\u{e9} &amp; &quot;quoted&quot; &apos;single&apos;".as_bytes(),
+            "caf\u{e9} &amp; &quot;quoted&quot; &apos;single&apos;",
             "test attribute value",
         )
         .expect("ordinary attribute content is valid");

--- a/src/rpc/reply/parser.rs
+++ b/src/rpc/reply/parser.rs
@@ -59,26 +59,26 @@ enum ErrorField {
 }
 
 impl ErrorField {
-    fn from_name(name: &[u8]) -> Option<Self> {
+    fn from_name(name: &str) -> Option<Self> {
         match name {
-            b"error-type" => Some(Self::Type),
-            b"error-tag" => Some(Self::Tag),
-            b"error-severity" => Some(Self::Severity),
-            b"error-app-tag" => Some(Self::AppTag),
-            b"error-path" => Some(Self::Path),
-            b"error-message" => Some(Self::Message),
+            "error-type" => Some(Self::Type),
+            "error-tag" => Some(Self::Tag),
+            "error-severity" => Some(Self::Severity),
+            "error-app-tag" => Some(Self::AppTag),
+            "error-path" => Some(Self::Path),
+            "error-message" => Some(Self::Message),
             _ => None,
         }
     }
 
-    fn xml_name(self) -> &'static [u8] {
+    fn xml_name(self) -> &'static str {
         match self {
-            Self::Type => b"error-type",
-            Self::Tag => b"error-tag",
-            Self::Severity => b"error-severity",
-            Self::AppTag => b"error-app-tag",
-            Self::Path => b"error-path",
-            Self::Message => b"error-message",
+            Self::Type => "error-type",
+            Self::Tag => "error-tag",
+            Self::Severity => "error-severity",
+            Self::AppTag => "error-app-tag",
+            Self::Path => "error-path",
+            Self::Message => "error-message",
         }
     }
 }
@@ -192,20 +192,20 @@ impl ReplyParser<'_> {
         }
         if self.current_error.is_none()
             && self.in_open_direct_payload()
-            && protocol_name == Some(b"rpc-reply")
+            && protocol_name == Some("rpc-reply")
         {
             return Err(parse_error("nested <rpc-reply> is not allowed"));
         }
         if self.current_error.is_none()
             && self.in_open_direct_payload()
-            && protocol_name == Some(b"rpc-error")
+            && protocol_name == Some("rpc-error")
         {
             self.current_error = Some(ErrorState::default());
             return Ok(());
         }
         if self.current_error.is_none()
             && self.in_open_direct_payload()
-            && protocol_name == Some(b"ok")
+            && protocol_name == Some("ok")
         {
             return Err(parse_error("<ok> must be an empty element"));
         }
@@ -217,16 +217,16 @@ impl ReplyParser<'_> {
         }
 
         match (self.envelope, protocol_name) {
-            (EnvelopeState::Before, Some(b"rpc-reply")) => self.open_reply(tag),
-            (EnvelopeState::Inside, Some(b"rpc-reply")) => {
+            (EnvelopeState::Before, Some("rpc-reply")) => self.open_reply(tag),
+            (EnvelopeState::Inside, Some("rpc-reply")) => {
                 Err(parse_error("nested <rpc-reply> is not allowed"))
             }
-            (EnvelopeState::Inside, Some(b"data")) => self.open_data(),
-            (EnvelopeState::Inside, Some(b"rpc-error")) => {
+            (EnvelopeState::Inside, Some("data")) => self.open_data(),
+            (EnvelopeState::Inside, Some("rpc-error")) => {
                 self.current_error = Some(ErrorState::default());
                 Ok(())
             }
-            (EnvelopeState::Inside, Some(b"ok")) => {
+            (EnvelopeState::Inside, Some("ok")) => {
                 Err(parse_error("<ok> must be an empty element"))
             }
             (EnvelopeState::Inside, _) => self.open_direct(tag),
@@ -256,20 +256,20 @@ impl ReplyParser<'_> {
         }
         if self.current_error.is_none()
             && self.in_open_direct_payload()
-            && protocol_name == Some(b"rpc-reply")
+            && protocol_name == Some("rpc-reply")
         {
             return Err(parse_error("nested <rpc-reply> is not allowed"));
         }
         if self.current_error.is_none()
             && self.in_open_direct_payload()
-            && protocol_name == Some(b"ok")
+            && protocol_name == Some("ok")
         {
             self.protocol_ok = true;
             return Ok(());
         }
         if self.current_error.is_none()
             && self.in_open_direct_payload()
-            && protocol_name == Some(b"rpc-error")
+            && protocol_name == Some("rpc-error")
         {
             return RpcErrorBuilder::default().finish().map(|_| ());
         }
@@ -281,14 +281,14 @@ impl ReplyParser<'_> {
         }
 
         match (self.envelope, protocol_name) {
-            (EnvelopeState::Before, Some(b"rpc-reply")) => {
+            (EnvelopeState::Before, Some("rpc-reply")) => {
                 self.open_reply(tag)?;
                 self.envelope = EnvelopeState::After;
                 Ok(())
             }
-            (EnvelopeState::Inside, Some(b"ok")) => self.set_ok(),
-            (EnvelopeState::Inside, Some(b"data")) => self.set_empty_data(),
-            (EnvelopeState::Inside, Some(b"rpc-error" | b"rpc-reply")) => {
+            (EnvelopeState::Inside, Some("ok")) => self.set_ok(),
+            (EnvelopeState::Inside, Some("data")) => self.set_empty_data(),
+            (EnvelopeState::Inside, Some("rpc-error" | "rpc-reply")) => {
                 Err(parse_error("invalid empty NETCONF reply element"))
             }
             (EnvelopeState::Inside, _) => self.capture_direct_empty(tag),
@@ -299,18 +299,14 @@ impl ReplyParser<'_> {
 
     fn text(&mut self, text: &BytesText<'_>) -> Result<(), RpcError> {
         if self.ignored_payload.is_some() && self.current_error.is_none() {
-            let decoded = text
-                .xml10_content()
-                .map_err(|error| parse_error(format!("invalid text encoding: {error}")))?;
+            let decoded = text.xml10_content();
             validate_xml_chars(&decoded, "ignored text content")?;
             return Ok(());
         }
         if self.capture_text(text)? {
             return Ok(());
         }
-        let decoded = text
-            .xml10_content()
-            .map_err(|error| parse_error(format!("invalid text encoding: {error}")))?;
+        let decoded = text.xml10_content();
         validate_xml_chars(&decoded, "text content")?;
         if contains_only_xml_space(&decoded) {
             Ok(())
@@ -321,9 +317,7 @@ impl ReplyParser<'_> {
 
     fn cdata(&mut self, cdata: &BytesCData<'_>) -> Result<(), RpcError> {
         if self.ignored_payload.is_some() && self.current_error.is_none() {
-            let decoded = cdata
-                .xml10_content()
-                .map_err(|error| parse_error(format!("invalid CDATA encoding: {error}")))?;
+            let decoded = cdata.xml10_content();
             validate_xml_chars(&decoded, "ignored CDATA content")?;
             return Ok(());
         }
@@ -351,7 +345,7 @@ impl ReplyParser<'_> {
     /// NETCONF namespace or none.
     fn is_commit_results(&self, tag: &BytesStart<'_>) -> bool {
         let qualified_name = tag.name();
-        self.netconf_local_name(qualified_name.as_ref()) == Some(b"commit-results")
+        self.netconf_local_name(qualified_name.as_ref()) == Some("commit-results")
     }
 
     fn in_open_direct_payload(&self) -> bool {
@@ -397,7 +391,7 @@ impl ReplyParser<'_> {
         let qualified_name = tag.name();
         let protocol_name = self
             .netconf_local_name(qualified_name.as_ref())
-            .map(<[u8]>::to_vec);
+            .map(str::to_string);
         if let Some(error) = self.current_error.as_mut() {
             if let Some(capture) = error.info_capture.as_mut() {
                 capture.empty(tag)?;
@@ -439,9 +433,7 @@ impl ReplyParser<'_> {
                 return Ok(true);
             }
             if error.field.is_some() {
-                let decoded = text
-                    .xml10_content()
-                    .map_err(|cause| parse_error(format!("invalid text encoding: {cause}")))?;
+                let decoded = text.xml10_content();
                 validate_xml_chars(&decoded, "rpc-error text field")?;
                 error.field_text.push_str(&decoded);
                 return Ok(true);
@@ -473,9 +465,7 @@ impl ReplyParser<'_> {
                 return Ok(true);
             }
             if error.field.is_some() {
-                let decoded = cdata
-                    .xml10_content()
-                    .map_err(|cause| parse_error(format!("invalid CDATA encoding: {cause}")))?;
+                let decoded = cdata.xml10_content();
                 validate_xml_chars(&decoded, "rpc-error text field")?;
                 error.field_text.push_str(&decoded);
                 return Ok(true);
@@ -602,7 +592,7 @@ impl ReplyParser<'_> {
             .current_error
             .as_mut()
             .expect("error_start requires current_error");
-        if name == Some(b"error-info") {
+        if name == Some("error-info") {
             if error.info_seen {
                 return Err(parse_error("duplicate error-info"));
             }
@@ -630,7 +620,7 @@ impl ReplyParser<'_> {
             .current_error
             .as_mut()
             .expect("error_empty requires current_error");
-        if name == Some(b"error-info") {
+        if name == Some("error-info") {
             if error.info_seen {
                 return Err(parse_error("duplicate error-info"));
             }
@@ -654,7 +644,7 @@ impl ReplyParser<'_> {
         for attribute in tag.attributes().with_checks(true) {
             let attribute = attribute
                 .map_err(|error| parse_error(format!("invalid XML attribute: {error}")))?;
-            if attribute.key.as_ref() == b"message-id" {
+            if attribute.key.as_ref() == "message-id" {
                 if message_id.is_some() {
                     return Err(parse_error("duplicate message-id attribute"));
                 }
@@ -760,7 +750,7 @@ impl ReplyParser<'_> {
                         error.info_depth -= 1;
                         return Ok(());
                     }
-                    if name != Some(b"error-info") {
+                    if name != Some("error-info") {
                         return Err(parse_error("unexpected end inside error-info"));
                     }
                     let info = error
@@ -783,7 +773,7 @@ impl ReplyParser<'_> {
                 }
             }
 
-            if name == Some(b"rpc-error") {
+            if name == Some("rpc-error") {
                 let error = self
                     .current_error
                     .take()
@@ -816,7 +806,7 @@ impl ReplyParser<'_> {
                     *depth -= 1;
                     return Ok(());
                 }
-                if name == Some(b"data") {
+                if name == Some("data") {
                     *closed = true;
                     return Ok(());
                 }
@@ -830,7 +820,7 @@ impl ReplyParser<'_> {
             _ => {}
         }
 
-        if name != Some(b"rpc-reply") {
+        if name != Some("rpc-reply") {
             return Err(parse_error("unexpected end directly inside rpc-reply"));
         }
         if self.envelope != EnvelopeState::Inside {
@@ -906,14 +896,14 @@ impl ReplyParser<'_> {
                 *depth += 1;
                 Ok(())
             }
-            Some(IgnoredPayload::Direct { .. }) if name == Some(b"rpc-reply") => {
+            Some(IgnoredPayload::Direct { .. }) if name == Some("rpc-reply") => {
                 Err(parse_error("nested <rpc-reply> is not allowed"))
             }
-            Some(IgnoredPayload::Direct { .. }) if name == Some(b"rpc-error") => {
+            Some(IgnoredPayload::Direct { .. }) if name == Some("rpc-error") => {
                 self.current_error = Some(ErrorState::default());
                 Ok(())
             }
-            Some(IgnoredPayload::Direct { .. }) if name == Some(b"ok") => {
+            Some(IgnoredPayload::Direct { .. }) if name == Some("ok") => {
                 Err(parse_error("<ok> must be an empty element"))
             }
             Some(IgnoredPayload::Direct { ref mut depth }) => {
@@ -929,13 +919,13 @@ impl ReplyParser<'_> {
         let name = self.netconf_local_name(qualified_name.as_ref());
         match self.ignored_payload {
             Some(IgnoredPayload::Data { .. }) => Ok(()),
-            Some(IgnoredPayload::Direct { .. }) if name == Some(b"rpc-reply") => {
+            Some(IgnoredPayload::Direct { .. }) if name == Some("rpc-reply") => {
                 Err(parse_error("nested <rpc-reply> is not allowed"))
             }
-            Some(IgnoredPayload::Direct { .. }) if name == Some(b"rpc-error") => {
+            Some(IgnoredPayload::Direct { .. }) if name == Some("rpc-error") => {
                 RpcErrorBuilder::default().finish().map(|_| ())
             }
-            Some(IgnoredPayload::Direct { .. }) if name == Some(b"ok") => {
+            Some(IgnoredPayload::Direct { .. }) if name == Some("ok") => {
                 self.protocol_ok = true;
                 Ok(())
             }
@@ -950,29 +940,29 @@ impl ReplyParser<'_> {
         }
     }
 
-    fn netconf_local_name<'a>(&self, qualified_name: &'a [u8]) -> Option<&'a [u8]> {
+    fn netconf_local_name<'a>(&self, qualified_name: &'a str) -> Option<&'a str> {
         let name = self.expanded_element_name(qualified_name).ok()?;
         match name.namespace {
-            None => Some(name.local.as_bytes()),
-            Some(NETCONF_NAMESPACE) => Some(name.local.as_bytes()),
+            None => Some(name.local),
+            Some(NETCONF_NAMESPACE) => Some(name.local),
             _ => None,
         }
     }
 
-    fn validate_element_name(&self, qualified_name: &[u8]) -> Result<(), RpcError> {
+    fn validate_element_name(&self, qualified_name: &str) -> Result<(), RpcError> {
         self.expanded_element_name(qualified_name).map(|_| ())
     }
 
     fn expanded_element_name<'name, 'namespace>(
         &'namespace self,
-        qualified_name: &'name [u8],
+        qualified_name: &'name str,
     ) -> Result<ExpandedName<'name, 'namespace>, RpcError> {
         self.expanded_name(validate_qname(qualified_name)?, true)
     }
 
     fn expanded_attribute_name<'name, 'namespace>(
         &'namespace self,
-        qualified_name: &'name [u8],
+        qualified_name: &'name str,
     ) -> Result<ExpandedName<'name, 'namespace>, RpcError> {
         self.expanded_name(validate_qname(qualified_name)?, false)
     }
@@ -1088,7 +1078,7 @@ impl RpcErrorBuilder {
             ErrorField::Message => self.message.is_some(),
         };
         if duplicate {
-            let name = String::from_utf8_lossy(field.xml_name());
+            let name = field.xml_name();
             return Err(parse_error(format!("duplicate rpc-error {name}")));
         }
 
@@ -1175,7 +1165,7 @@ mod tests {
     use super::*;
     use crate::rpc::validate_xml_fragment;
 
-    fn reparse_attribute(fragment: &str, element: &[u8], key: &[u8]) -> String {
+    fn reparse_attribute(fragment: &str, element: &str, key: &str) -> String {
         let mut reader = Reader::from_str(fragment);
         loop {
             match reader.read_event().expect("captured fragment must reparse") {
@@ -3068,9 +3058,9 @@ mod tests {
         let info = server_error.info.expect("expected captured error-info");
 
         for (path, fragment, element) in [
-            ("data", data.as_str(), b"item".as_slice()),
-            ("direct", direct.as_str(), b"output".as_slice()),
-            ("error-info", info.as_str(), b"detail".as_slice()),
+            ("data", data.as_str(), "item"),
+            ("direct", direct.as_str(), "output"),
+            ("error-info", info.as_str(), "detail"),
         ] {
             assert!(fragment.contains(serialized), "{path}: {fragment}");
             assert!(
@@ -3078,7 +3068,7 @@ mod tests {
                 "{path}: serialized literal controls"
             );
             assert_eq!(
-                reparse_attribute(fragment, element, b"probe"),
+                reparse_attribute(fragment, element, "probe"),
                 expected,
                 "{path}: reparsing changed the semantic value"
             );
@@ -3090,7 +3080,7 @@ mod tests {
             "ordinary attributes changed: {data}"
         );
         assert_eq!(
-            reparse_attribute(&data, b"item", b"ordinary"),
+            reparse_attribute(&data, "item", "ordinary"),
             "caf\u{e9} & \"quoted\""
         );
     }
@@ -3109,7 +3099,7 @@ mod tests {
         assert!(!data.contains("&#xA;"));
         assert!(!data.contains("&#xD;"));
         assert_eq!(
-            reparse_attribute(&data, b"item", b"probe"),
+            reparse_attribute(&data, "item", "probe"),
             "left middle right end tail"
         );
     }
@@ -3131,15 +3121,15 @@ mod tests {
         );
         assert!(data.contains("xmlns:r=\"urn:literal space end\""), "{data}");
         assert_eq!(
-            reparse_attribute(&data, b"p:item", b"xmlns:p"),
+            reparse_attribute(&data, "p:item", "xmlns:p"),
             "urn:parent\tscope"
         );
         assert_eq!(
-            reparse_attribute(&data, b"p:item", b"xmlns:q"),
+            reparse_attribute(&data, "p:item", "xmlns:q"),
             "urn:explicit\nscope"
         );
         assert_eq!(
-            reparse_attribute(&data, b"p:item", b"xmlns:r"),
+            reparse_attribute(&data, "p:item", "xmlns:r"),
             "urn:literal space end"
         );
         validate_xml_fragment(&data).expect("captured namespace scope stays well formed");

--- a/src/rpc/reply/repair.rs
+++ b/src/rpc/reply/repair.rs
@@ -19,9 +19,9 @@ enum DocumentRootState {
 
 #[derive(Debug)]
 struct OpenElement {
-    qname: Vec<u8>,
-    local: Vec<u8>,
-    protocol_local: Option<Vec<u8>>,
+    qname: String,
+    local: String,
+    protocol_local: Option<String>,
     namespaces: NamespaceBindings,
     multi_re_path: MultiRePathElement,
     routing_engine_supported: bool,
@@ -30,14 +30,14 @@ struct OpenElement {
 
 impl OpenElement {
     fn ordinary(
-        qname: &[u8],
+        qname: &str,
         namespaces: NamespaceBindings,
         multi_re_path: MultiRePathElement,
     ) -> Self {
         Self {
-            qname: qname.to_vec(),
-            local: local_name(qname).to_vec(),
-            protocol_local: netconf_local_name(qname, &namespaces).map(<[u8]>::to_vec),
+            qname: qname.to_string(),
+            local: local_name(qname).to_string(),
+            protocol_local: netconf_local_name(qname, &namespaces).map(str::to_string),
             namespaces,
             multi_re_path,
             routing_engine_supported: false,
@@ -45,11 +45,11 @@ impl OpenElement {
         }
     }
 
-    fn routing_engine(qname: &[u8], supported: bool, namespaces: NamespaceBindings) -> Self {
+    fn routing_engine(qname: &str, supported: bool, namespaces: NamespaceBindings) -> Self {
         Self {
-            qname: qname.to_vec(),
-            local: b"routing-engine".to_vec(),
-            protocol_local: netconf_local_name(qname, &namespaces).map(<[u8]>::to_vec),
+            qname: qname.to_string(),
+            local: "routing-engine".to_string(),
+            protocol_local: netconf_local_name(qname, &namespaces).map(str::to_string),
             namespaces,
             multi_re_path: MultiRePathElement::Other,
             routing_engine_supported: supported,
@@ -58,20 +58,20 @@ impl OpenElement {
     }
 
     fn repairable(&self) -> bool {
-        self.local == b"routing-engine"
+        self.local == "routing-engine"
             && self.routing_engine_supported
             && self.routing_engine_has_marker
     }
 }
 
-fn local_name(qname: &[u8]) -> &[u8] {
-    qname.rsplit(|byte| *byte == b':').next().unwrap_or(qname)
+fn local_name(qname: &str) -> &str {
+    qname.rsplit(':').next().unwrap_or(qname)
 }
 
 fn netconf_local_name<'a>(
-    qualified_name: &'a [u8],
+    qualified_name: &'a str,
     namespaces: &NamespaceBindings,
-) -> Option<&'a [u8]> {
+) -> Option<&'a str> {
     let (namespace, local) = expanded_name(qualified_name, namespaces)?;
     match namespace {
         None => Some(local),
@@ -81,9 +81,9 @@ fn netconf_local_name<'a>(
 }
 
 fn juniper_local_name<'a>(
-    qualified_name: &'a [u8],
+    qualified_name: &'a str,
     namespaces: &NamespaceBindings,
-) -> Option<&'a [u8]> {
+) -> Option<&'a str> {
     let (namespace, local) = expanded_name(qualified_name, namespaces)?;
     match namespace {
         None => Some(local),
@@ -93,18 +93,20 @@ fn juniper_local_name<'a>(
 }
 
 fn expanded_name<'name, 'namespace>(
-    qualified_name: &'name [u8],
+    qualified_name: &'name str,
     namespaces: &'namespace NamespaceBindings,
-) -> Option<(Option<&'namespace str>, &'name [u8])> {
-    let mut parts = qualified_name.split(|byte| *byte == b':');
+) -> Option<(Option<&'namespace str>, &'name str)> {
+    // Splitting on an ASCII colon is the same operation over `str` as it was
+    // over bytes: no char boundary can fall inside a single-byte codepoint.
+    let mut parts = qualified_name.split(':');
     let first = parts.next()?;
     let second = parts.next();
     if parts.next().is_some() {
         return None;
     }
     let (namespace, local) = if let Some(local) = second {
-        let prefix = std::str::from_utf8(first).ok()?;
-        (Some(namespaces.get(prefix)?.as_str()), local)
+        // The prefix no longer needs a UTF-8 check — the reader made one.
+        (Some(namespaces.get(first)?.as_str()), local)
     } else {
         (namespaces.get("").map(String::as_str), first)
     };
@@ -197,7 +199,7 @@ fn namespaces_for(
 
 fn supported_routing_engine_parent(stack: &[OpenElement]) -> bool {
     stack.last().is_some_and(|element| {
-        (stack.len() == 1 && element.protocol_local.as_deref() == Some(b"rpc-reply"))
+        (stack.len() == 1 && element.protocol_local.as_deref() == Some("rpc-reply"))
             || matches!(
                 element.multi_re_path,
                 MultiRePathElement::Results | MultiRePathElement::Item
@@ -208,13 +210,13 @@ fn supported_routing_engine_parent(stack: &[OpenElement]) -> bool {
 fn mark_commit_check_result(stack: &mut [OpenElement]) {
     let Some(index) = stack
         .iter_mut()
-        .rposition(|element| element.local == b"routing-engine")
+        .rposition(|element| element.local == "routing-engine")
     else {
         return;
     };
     if stack[index + 1..]
         .iter()
-        .any(|element| element.protocol_local.as_deref() == Some(b"data"))
+        .any(|element| element.protocol_local.as_deref() == Some("data"))
     {
         return;
     }
@@ -226,8 +228,11 @@ fn close_repairable(writer: &mut Writer<Vec<u8>>, stack: &mut Vec<OpenElement>) 
     if !top.repairable() {
         return None;
     }
-    let qname = std::str::from_utf8(&top.qname).ok()?;
-    writer.write_event(Event::End(BytesEnd::new(qname))).ok()?;
+    // Was a `from_utf8(...).ok()?` — the reader has already guaranteed UTF-8,
+    // so that arm could only ever have discarded a repair silently.
+    writer
+        .write_event(Event::End(BytesEnd::new(&top.qname)))
+        .ok()?;
     stack.pop();
     Some(())
 }
@@ -242,16 +247,16 @@ fn handle_start(
     let local = local_name(qname.as_ref());
     let namespaces = namespaces_for(&tag, stack)?;
 
-    if juniper_local_name(qname.as_ref(), &namespaces) == Some(b"commit-check-success")
-        || netconf_local_name(qname.as_ref(), &namespaces) == Some(b"rpc-error")
+    if juniper_local_name(qname.as_ref(), &namespaces) == Some("commit-check-success")
+        || netconf_local_name(qname.as_ref(), &namespaces) == Some("rpc-error")
     {
         mark_commit_check_result(stack);
     }
 
-    if local == b"routing-engine" {
+    if local == "routing-engine" {
         if stack
             .last()
-            .is_some_and(|element| element.local == b"routing-engine")
+            .is_some_and(|element| element.local == "routing-engine")
         {
             close_repairable(writer, stack)?;
             *repaired_any = true;
@@ -264,14 +269,14 @@ fn handle_start(
         ));
     } else {
         let vendor_local = juniper_local_name(qname.as_ref(), &namespaces);
-        let multi_re_path = if vendor_local == Some(b"multi-routing-engine-results")
+        let multi_re_path = if vendor_local == Some("multi-routing-engine-results")
             && stack.len() == 1
             && stack
                 .last()
-                .is_some_and(|element| element.protocol_local.as_deref() == Some(b"rpc-reply"))
+                .is_some_and(|element| element.protocol_local.as_deref() == Some("rpc-reply"))
         {
             MultiRePathElement::Results
-        } else if vendor_local == Some(b"multi-routing-engine-item")
+        } else if vendor_local == Some("multi-routing-engine-item")
             && stack
                 .last()
                 .is_some_and(|element| element.multi_re_path == MultiRePathElement::Results)
@@ -302,7 +307,7 @@ fn begin_document_root(
         return None;
     }
     let namespaces = namespaces_for(tag, stack)?;
-    if netconf_local_name(tag.name().as_ref(), &namespaces) != Some(b"rpc-reply") {
+    if netconf_local_name(tag.name().as_ref(), &namespaces) != Some("rpc-reply") {
         return None;
     }
     *root_state = DocumentRootState::Inside;
@@ -312,10 +317,9 @@ fn begin_document_root(
 fn event_allowed_outside_root(event: &Event<'_>, root_state: DocumentRootState) -> bool {
     root_state == DocumentRootState::Inside
         || match event {
-            Event::Text(text) => text
-                .as_ref()
-                .iter()
-                .all(|byte| matches!(byte, b' ' | b'\t' | b'\r' | b'\n')),
+            // XML's four whitespace characters, not `char::is_whitespace`,
+            // which is Unicode-aware and would accept NBSP outside the root.
+            Event::Text(text) => text.chars().all(|c| matches!(c, ' ' | '\t' | '\r' | '\n')),
             Event::CData(_) | Event::GeneralRef(_) | Event::DocType(_) => false,
             _ => true,
         }
@@ -348,8 +352,8 @@ pub(super) fn repair_cluster_commit_check(xml: &str) -> Option<String> {
                 }
                 let namespaces = namespaces_for(&tag, &stack)?;
                 let qname = tag.name();
-                if juniper_local_name(qname.as_ref(), &namespaces) == Some(b"commit-check-success")
-                    || netconf_local_name(qname.as_ref(), &namespaces) == Some(b"rpc-error")
+                if juniper_local_name(qname.as_ref(), &namespaces) == Some("commit-check-success")
+                    || netconf_local_name(qname.as_ref(), &namespaces) == Some("rpc-error")
                 {
                     mark_commit_check_result(&mut stack);
                 }
@@ -361,10 +365,10 @@ pub(super) fn repair_cluster_commit_check(xml: &str) -> Option<String> {
 
                 while stack
                     .last()
-                    .is_some_and(|element| element.local.as_slice() != end_local)
+                    .is_some_and(|element| element.local != end_local)
                 {
                     let parent_matches =
-                        stack.len() >= 2 && stack[stack.len() - 2].local.as_slice() == end_local;
+                        stack.len() >= 2 && stack[stack.len() - 2].local == end_local;
                     if !parent_matches {
                         return None;
                     }
@@ -373,13 +377,13 @@ pub(super) fn repair_cluster_commit_check(xml: &str) -> Option<String> {
                 }
 
                 let open = stack.pop()?;
-                if open.local.as_slice() != end_local {
+                if open.local != end_local {
                     return None;
                 }
                 writer.write_event(Event::End(tag.into_owned())).ok()?;
                 if stack.is_empty() {
                     if root_state != DocumentRootState::Inside
-                        || open.protocol_local.as_deref() != Some(b"rpc-reply")
+                        || open.protocol_local.as_deref() != Some("rpc-reply")
                     {
                         return None;
                     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -2179,16 +2179,15 @@ fn parse_session_id_from_info(info: &str) -> Option<u32> {
             match reader.read_event_into(&mut buf) {
                 Ok(Event::Start(ref tag)) => {
                     let local = tag.local_name();
-                    let name = std::str::from_utf8(local.as_ref()).unwrap_or("");
+                    let name: &str = local.as_ref();
                     if name == "session-id" {
                         in_session_id = true;
                         id_buf.clear();
                     }
                 }
                 Ok(Event::Text(ref text)) if in_session_id => {
-                    if let Ok(value) = text.decode() {
-                        id_buf.push_str(&value);
-                    }
+                    let value: &str = text;
+                    id_buf.push_str(value);
                 }
                 Ok(Event::GeneralRef(ref entity)) if in_session_id => {
                     if let Some(resolved) = resolve_entity_ref(entity) {
@@ -2196,9 +2195,8 @@ fn parse_session_id_from_info(info: &str) -> Option<u32> {
                     }
                 }
                 Ok(Event::CData(ref cdata)) if in_session_id => {
-                    if let Ok(value) = cdata.decode() {
-                        id_buf.push_str(&value);
-                    }
+                    let value: &str = cdata;
+                    id_buf.push_str(value);
                 }
                 Ok(Event::End(_)) => {
                     if in_session_id {

--- a/src/xml_entity.rs
+++ b/src/xml_entity.rs
@@ -18,7 +18,8 @@ pub(crate) fn resolve_entity_ref(entity: &BytesRef<'_>) -> Option<String> {
     if let Ok(Some(ch)) = entity.resolve_char_ref() {
         return Some(ch.to_string());
     }
-    let name = entity.decode().ok()?;
+    // 0.42 decodes at the reader, so the name is already `str`.
+    let name: &str = entity;
     // `resolve_xml_entity`, not `resolve_predefined_entity`. The latter is
     // feature-dispatched: with quick-xml's `escape-html` enabled it resolves
     // HTML5 names instead, and Cargo unifies features across the whole graph —
@@ -26,5 +27,5 @@ pub(crate) fn resolve_entity_ref(entity: &BytesRef<'_>) -> Option<String> {
     // accept `&nbsp;`. A NETCONF RPC carries no DTD, so HTML5 entities are
     // undefined there and the device would receive malformed XML. Validation
     // semantics must not depend on what a downstream crate happens to enable.
-    quick_xml::escape::resolve_xml_entity(&name).map(|s| s.to_string())
+    quick_xml::escape::resolve_xml_entity(name).map(|s| s.to_string())
 }


### PR DESCRIPTION
> **Updated 2026-08-29.** This PR opened as an incomplete draft (~49 compile errors). The migration is now complete, rebased onto `main` @ v0.16.1, squashed to one commit, and validated on a live device against a control. The original draft description is preserved at the bottom.

quick-xml 0.42 decodes at the reader, so events hand back `str` rather than `[u8]`. That removes most of the decode / `from_utf8_lossy` layer this crate carried, and the migration is mostly deletion: **239 insertions against 277 deletions** across the parser, the reply capture and repair paths, notification, capability, session, and the CLI's diff tree.

**quick-xml is fully internal.** No public signature, error variant, or trait exposes it, so 0.42 is not an API break and the follow-up release can honestly be a patch (0.16.2). Verified by reading every public item rather than assuming.

## What the migration decided, where a choice existed

- **Kept as byte scans** — the attribute-separator check and the PI-target split. Both use `is_ascii_whitespace`, never `char::is_whitespace`, which is Unicode-aware and would split on characters XML does not treat as whitespace.

- **Moved to `str`** — splitting on `:` in `expanded_name`/`resolve_ns`, where no char boundary can fall inside a single-byte codepoint, and the whitespace-outside-root test, written as the four XML whitespace characters explicitly rather than as a class.

- **`OpenElement` moved `Vec<u8>` → `String`** — the last byte holdout. Its helpers had already moved, so every comparison was crossing a boundary for nothing.

- **Five UTF-8 branches deleted, not retyped** — the reader guarantees UTF-8 now, and three of the five silently skipped or discarded input on failure. Error paths that could not be reached and would have been wrong if they were.

The CLI's `resolve_entity_ref` keeps `resolve_xml_entity`; 0.42 only changes how the name is obtained, since the entity is already `str`. The `escape-html` feature-unification hazard that fix exists for (#96) is unchanged by the version bump, and the comment recording it stays.

`fuzz/` is an independent workspace and needs its own lockfile moved, or `--locked` builds break.

## Verification

The draft below said this could not be trusted on a green suite. It is not being asked to be.

- 654 tests, clippy and fmt clean workspace-wide with `-D warnings`, `cargo build --locked` in `fuzz/`
- `reply_parser_is_total` — **6.06M** fuzz executions on the migrated parser, no crashes
- `fragment_embeds_cleanly` — **8.1M** on main, **5.5M** on this branch, no crashes
- `codex exec review --commit 2563da3` — no findings

### Live device, against a control

Run on a real vSRX (Junos **24.4R1.9**), baseline first so a failure could be attributed to the migration rather than to the device or the harness:

| | `integration_vsrx` | `integration_vendor_pool` |
|---|---|---|
| baseline (`main` @ v0.16.1) | 23 passed, 16.4s | 9 passed ×2 |
| this branch | 23 passed, 14.2s | 9 passed ×2 |

Every run used `RUSTNETCONF_TEST_VSRX_REQUIRED=1` (added in #97), so a run that never reached the device would have **failed** rather than reporting a pass it did not earn. Elapsed time corroborates: a skipped run finishes in `0.00s`.

The control earned its keep — the first pool run failed on the *baseline*, and the cause was the device's `system services netconf ssh rate-limit 32` (`netconf-ssh ... exceeded counts/min (limit 32/min)` in the device log), not the migration.

## Follow-up

Release 0.16.2 (`rustnetconf` only) as a separate PR after this merges, matching the #96 → #97 pattern.

---

<details>
<summary>Original draft description (2026-08-27, incomplete)</summary>

**Draft. Does not compile — roughly 49 errors remain.** Pushed so the mechanical work is not lost.

0.42 moves decoding to the reader: `LocalName` and event bodies become `str` instead of `[u8]`, `decode()` and the `Result` on `xml10_content()` disappear, `unescape()` returns `Cow` rather than `Result`.

**Done:** byte-literal name comparisons and match arms, `decode()` sites, redundant `from_utf8` calls, the lexical validators' boundary, most of the namespace-resolution core. Started at 89 errors.

**Left:** `rpc/reply/{parser,repair,capture,lexical}.rs` — the namespace and lexical core. Those remaining decisions are not type mechanics; each is a judgement about whether a rule was a byte rule that happens to be expressible on `str`, or a byte rule that must stay one.

### Why this stopped rather than pushed through

A wrong answer in this layer produces a parser that compiles, passes the suite, and mis-parses device output. [rustjunosmcp#358](https://github.com/fastrevmd-lab/rustjunosmcp/issues/358) did exactly that — 480 tests, a clean review gate, a published tag, then a different error on the device.

This cannot be trusted on a green suite. It needs vsrx-ci validation before it merges.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)