### PR TITLE
security(audit): drop the stale RUSTSEC-2023-0071 suppression

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,24 +5,15 @@
 # include a rationale and a review date so it does not become invisible.
 
 [advisories]
-ignore = [
-    # RUSTSEC-2023-0071 — Marvin Attack timing side-channel in `rsa`.
-    #
-    # Reachability: `rsa 0.10.0-rc.16` is pulled in through
-    #   russh -> internal-russh-forked-ssh-key -> rsa.
-    # The dependency exists unconditionally inside the forked ssh-key
-    # crate; russh has no opt-out feature for it. Upstream `cargo audit`
-    # reports "No fixed upgrade is available!"
-    #
-    # Exposure: only matters when an RSA SSH key is used. The library
-    # default and CLI templates do not generate or use RSA keys, and
-    # rustnetconf supports ed25519/ECDSA paths through SSH agent and
-    # key_file auth.
-    #
-    # Mitigation: README/security documentation recommends Ed25519 or
-    # ECDSA SSH keys until a fixed upstream release lands.
-    #
-    # Review date: 2026-08-01 (re-check russh + ssh-key for a fixed rsa
-    # release; remove this ignore once upstream resolves it).
-    "RUSTSEC-2023-0071",
-]
+# No advisories are currently suppressed.
+#
+# RUSTSEC-2023-0071 (Marvin Attack, `rsa`) was ignored here until russh 0.62.
+# It is gone from the graph, not merely tolerated: russh gates `rsa` behind a
+# non-default feature and we build with `default-features = false`, so
+# `grep '^name = "rsa"' Cargo.lock` and `cargo tree -i rsa` both come up empty.
+#
+# Deliberately not left in place "just in case". A suppression for an advisory
+# that cannot fire is a loaded gun: were a future bump to pull `rsa` back in,
+# cargo-audit would stay green and nobody would notice. Removing it means a
+# reintroduction is loud.
+ignore = []

--- a/README.md
+++ b/README.md
@@ -703,8 +703,6 @@ SKIP_INTEGRATION=1 cargo test             # Skip tests requiring a device
 
 ### Known Issues
 
-- **RSA timing sidechannel (RUSTSEC-2023-0071)** — The `rsa` crate (transitive dependency via `russh → internal-russh-forked-ssh-key → rsa`) has a known timing sidechannel that could theoretically allow RSA key recovery. No upstream fix is available. **Mitigation:** Use Ed25519 or ECDSA keys instead of RSA for SSH authentication.
-
 - **Debug logs may contain file paths** — When SSH key file loading fails, the key file path is included in `tracing::debug!` output. This is not exposed at info/warn/error levels. **Mitigation:** Disable debug-level logging in production, or filter `rustnetconf::transport` logs.
 
 ### Security Features
@@ -723,18 +721,28 @@ SKIP_INTEGRATION=1 cargo test             # Skip tests requiring a device
 
 ### Known advisories
 
-- **RUSTSEC-2023-0071** (Marvin Attack, `rsa` crate timing side-channel)
-  is present in the dependency graph via
-  `russh → internal-russh-forked-ssh-key → rsa 0.10.0-rc.16`. No fixed
-  upstream release is available yet. The advisory is risk-accepted with
-  rationale in `.cargo/audit.toml` and CI re-checks on every run. It only
-  matters when an **RSA** SSH key is used for authentication — Ed25519
-  and ECDSA paths are unaffected. Use the mitigation in the next section.
+None currently suppressed — `.cargo/audit.toml` has an empty `ignore` list,
+and `cargo audit` plus `cargo deny` run on every CI build.
+
+**RUSTSEC-2023-0071** (Marvin Attack, `rsa` timing side-channel) was carried
+here until russh 0.62. It is now *absent from the graph*, not tolerated within
+it: russh gates `rsa` behind a non-default feature and this crate builds with
+`default-features = false`, so both of these come up empty:
+
+```bash
+grep '^name = "rsa"' Cargo.lock
+cargo tree --workspace --all-features -i rsa
+```
+
+The suppression was removed rather than left in place, so that a future
+dependency bump reintroducing `rsa` fails the audit loudly instead of passing
+under an ignore nobody re-reads.
 
 ### Security Best Practices
 
-- Use Ed25519 SSH keys (not RSA) for device authentication (also mitigates
-  RUSTSEC-2023-0071 above)
+- Use Ed25519 SSH keys (not RSA) for device authentication — smaller, faster,
+  constant-time by construction, and not exposed to the RSA timing
+  side-channel class of bug in the first place
 - Set `host_key_verification(HostKeyVerification::Fingerprint(...))` or `HostKeyVerification::KnownHosts(path)` in production — the default is `RejectAll` (fail closed), so the connection will refuse to complete until you choose a policy. For the CLI, set either `host_key_fingerprint = "SHA256:..."` or `known_hosts_path = "/path/to/known_hosts"` per device in `inventory.toml` (or `known_hosts_path` under `[defaults]` for fleet-wide pinning). See `examples/known_hosts.rs` for the `ssh-keyscan` workflow.
 - Set `.rpc_timeout(Duration::from_secs(30))` to prevent hanging on unresponsive devices
 - Prefer SSH agent auth over inline passwords


### PR DESCRIPTION
Closes #78.

`.cargo/audit.toml` ignored RUSTSEC-2023-0071 (Marvin Attack, timing side-channel in `rsa`). **The advisory can no longer fire** — russh 0.62 gates `rsa` behind a non-default feature and this crate builds with `default-features = false`, so the crate is absent from the graph entirely:

```
$ grep '^name = "rsa"' Cargo.lock
(no match)
$ cargo tree --workspace --all-features -i rsa
error: package ID specification `rsa` did not match any packages
```

`cargo audit` passes with the ignore list emptied — that is what proves the advisory is unreachable rather than merely unlisted.

## Why remove rather than leave it

A suppression for an advisory that cannot fire is not neutral. If a later bump pulled `rsa` back in — enabling `russh/rsa` for a device needing RSA host keys, say — the audit would stay green and nobody would find out. An empty `ignore` makes reintroduction loud.

The stored rationale had gone stale on its own terms too: it described the path as `russh → internal-russh-forked-ssh-key → rsa` and asserted russh "has no opt-out feature for it". russh 0.62 uses upstream `ssh-key` and does have one.

## Documentation

The README carried the same claim in three places — **Known Issues**, **Known advisories**, and a best-practice bullet justified by the advisory. The Ed25519 recommendation stays, rejustified on its own merits. The **RNC-SEC-002** audit-history entry is deliberately untouched: it records what was true at that audit.

## Verification

- `cargo audit` — passes with `ignore = []`
- `cargo deny check` — advisories ok, bans ok, licenses ok, sources ok
- 486 tests pass, clippy `-D warnings` clean, fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)