### PR TITLE
docs: correct README accuracy claims, and enforce the unsafe one

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,12 @@
 members = [".", "rustnetconf-yang", "rustnetconf-cli"]
 resolver = "2"
 
+# Declared here rather than as a crate-root attribute so it covers *every*
+# target in each package - build scripts, examples and integration tests are
+# separate crates, and `#![forbid(unsafe_code)]` in lib.rs does not reach them.
+[workspace.lints.rust]
+unsafe_code = "forbid"
+
 [package]
 name = "rustnetconf"
 version = "0.15.0"
@@ -35,3 +41,6 @@ webpki-roots = { version = "0.26", optional = true }
 tokio-test = "0.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ match result {
 | `get` | §7.7 | Done |
 | `get-config` | §7.1 | Done |
 | `edit-config` | §7.2 | Done |
-| `lock` / `unlock` | §7.4-7.5 | Done |
+| `lock` / `unlock` | §7.5-7.6 | Done |
 | `close-session` | §7.8 | Done |
 | `kill-session` | §7.9 | Done |
 | `commit` | §8.4 | Done |
@@ -623,7 +623,9 @@ match result {
 
 ## Testing
 
-197 tests across the workspace:
+504 tests across the workspace, the count CI runs
+(`cargo test --workspace --all-features`) — 489 in unit and integration
+harnesses plus 15 doc-tests:
 - **Unit tests** — framing, RPC serialization, capability parsing, vendor profiles, diff engine, inventory parsing, IPv6 address parsing, XML fragment validation, capability normalization
 - **Mock transport tests** — session state machine, CommitUnknown detection, lock recovery
 - **Integration tests** — 32 tests against a live Juniper vSRX including full edit-config round trips, vendor auto-detection, connection pooling, and concurrent sessions
@@ -717,7 +719,7 @@ SKIP_INTEGRATION=1 cargo test             # Skip tests requiring a device
 - **RPC timeout** — Configurable via `.rpc_timeout()` to prevent indefinite blocking on unresponsive devices.
 - **CLI input validation** — Device names are validated to prevent path traversal; state files are written with `0600` permissions on Unix.
 - **Typed error hierarchy** — Structured error types (`ChannelClosed`, `SessionExpired`, `MessageIdMismatch`) enable precise error handling without string matching.
-- **No unsafe code** — The entire codebase uses safe Rust.
+- **No unsafe code, enforced across every target** — declared as `unsafe_code = "forbid"` in `[workspace.lints.rust]`, which each package opts into. This is deliberate rather than a crate-root `#![forbid(unsafe_code)]`: build scripts, examples and integration tests compile as separate crates, so an inner attribute would not reach them. Verified by injecting an `unsafe` block into `build.rs`, a test target and an example, each of which now fails to compile. The one place that previously needed `unsafe` was two tests setting `HOME` via `std::env::set_var`, which the 2024 edition makes unsafe; the tilde expansion they covered was split into a pure function taking the home directory as an argument.
 
 ### Known advisories
 
@@ -758,8 +760,10 @@ To report a security vulnerability, please open an issue on GitHub.
 | Crate | Version | Purpose |
 |-------|---------|---------|
 | `async-trait` | 0.1 | Async trait support |
-| `quick-xml` | 0.37 | XML parsing (NETCONF RPC encode/decode) |
-| `russh` | 0.60 | SSH transport (pure Rust, no libssh2) |
+| `aws-lc-rs` | 1 | SHA-256 fingerprints and HMAC for `known_hosts` |
+| `base64ct` | 1 | Constant-time base64 for key blobs |
+| `quick-xml` | 0.41 | XML parsing (NETCONF RPC encode/decode) |
+| `russh` | 0.62 | SSH transport (pure Rust, no libssh2) |
 | `thiserror` | 2 | Error derive macros |
 | `tokio` | 1 | Async runtime |
 | `tracing` | 0.1 | Structured logging/tracing |

--- a/rustnetconf-cli/Cargo.toml
+++ b/rustnetconf-cli/Cargo.toml
@@ -26,3 +26,6 @@ zeroize = "1"
 
 [dev-dependencies]
 tempfile = "3"
+
+[lints]
+workspace = true

--- a/rustnetconf-yang/Cargo.toml
+++ b/rustnetconf-yang/Cargo.toml
@@ -28,3 +28,6 @@ serde_json = "1"
 
 [build-dependencies]
 yang2 = "0.18"
+
+[lints]
+workspace = true

--- a/src/ssh_config.rs
+++ b/src/ssh_config.rs
@@ -322,14 +322,24 @@ pub fn parse_proxy_jump(value: &str) -> Vec<JumpHostConfig> {
 /// doesn't start with `~`. Falls back to leaving the path untouched if
 /// `$HOME` is unset.
 fn expand_tilde(path: &str) -> String {
+    expand_tilde_with(path, std::env::var("HOME").ok().as_deref())
+}
+
+/// `expand_tilde` with the home directory supplied rather than read from the
+/// environment.
+///
+/// Split out so the expansion rules can be tested directly. The alternative —
+/// having tests set `HOME` around each assertion — needs `unsafe` under the
+/// 2024 edition and is not thread-safe against a parallel test runner.
+fn expand_tilde_with(path: &str, home: Option<&str>) -> String {
+    let Some(home) = home else {
+        return path.to_string();
+    };
     if let Some(rest) = path.strip_prefix("~/") {
-        if let Ok(home) = std::env::var("HOME") {
-            return format!("{home}/{rest}");
-        }
-    } else if path == "~" {
-        if let Ok(home) = std::env::var("HOME") {
-            return home;
-        }
+        return format!("{home}/{rest}");
+    }
+    if path == "~" {
+        return home.to_string();
     }
     path.to_string()
 }
@@ -862,23 +872,23 @@ mod tests {
 
     #[test]
     fn expand_tilde_with_home() {
-        // Save & restore HOME to make this hermetic.
-        let prev = std::env::var("HOME").ok();
-        // SAFETY: tests run single-threaded by default; we restore HOME below.
-        unsafe {
-            std::env::set_var("HOME", "/home/test-user");
-        }
-        assert_eq!(expand_tilde("~/foo/bar"), "/home/test-user/foo/bar");
-        assert_eq!(expand_tilde("~"), "/home/test-user");
-        assert_eq!(expand_tilde("/abs/path"), "/abs/path");
-        assert_eq!(expand_tilde("relative"), "relative");
-        // SAFETY: restoring HOME after the test.
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
+        let home = Some("/home/test-user");
+        assert_eq!(
+            expand_tilde_with("~/foo/bar", home),
+            "/home/test-user/foo/bar"
+        );
+        assert_eq!(expand_tilde_with("~", home), "/home/test-user");
+        assert_eq!(expand_tilde_with("/abs/path", home), "/abs/path");
+        assert_eq!(expand_tilde_with("relative", home), "relative");
+        // A bare "~user" form is not expanded - only "~" and "~/".
+        assert_eq!(expand_tilde_with("~other/x", home), "~other/x");
+    }
+
+    #[test]
+    fn expand_tilde_without_home_is_identity() {
+        assert_eq!(expand_tilde_with("~/foo", None), "~/foo");
+        assert_eq!(expand_tilde_with("~", None), "~");
+        assert_eq!(expand_tilde_with("/abs", None), "/abs");
     }
 
     #[test]
@@ -896,21 +906,19 @@ mod tests {
 
     #[test]
     fn identity_file_tilde_expansion() {
-        let prev = std::env::var("HOME").ok();
-        unsafe {
-            std::env::set_var("HOME", "/home/u");
-        }
+        // Reads HOME rather than setting it: mutating the environment needs
+        // `unsafe` under the 2024 edition and races a parallel test runner.
+        // The expansion rules themselves are covered by the pure tests above;
+        // this one only asserts that `resolve` applies them at all.
+        let Ok(home) = std::env::var("HOME") else {
+            eprintln!("HOME unset - skipping identity_file_tilde_expansion");
+            return;
+        };
         let cfg =
             SshConfigFile::parse_str("Host r1\n  IdentityFile ~/.ssh/id_lab\n", None).unwrap();
         assert_eq!(
             cfg.resolve("r1").identity_file.as_deref(),
-            Some("/home/u/.ssh/id_lab")
+            Some(format!("{home}/.ssh/id_lab").as_str())
         );
-        unsafe {
-            match prev {
-                Some(v) => std::env::set_var("HOME", v),
-                None => std::env::remove_var("HOME"),
-            }
-        }
     }
 }


### PR DESCRIPTION
Closes #79.

Four README claims did not match the tree.

## "No unsafe code" was false — now made true and enforced

`src/ssh_config.rs` had four `unsafe` blocks (`std::env::set_var`/`remove_var`, unsafe under the 2024 edition). All were in `#[cfg(test)]`, so the shipped library was genuinely unsafe-free — but the sentence was wrong and nothing enforced it.

Rather than reword, the `unsafe` is gone: `expand_tilde` splits into a thin wrapper reading `HOME` and a pure `expand_tilde_with(path, home)`, so expansion rules are tested directly with no environment mutation. The one test needing end-to-end `resolve()` now *reads* `HOME` instead of setting it. That mutation was never really safe anyway — it races a parallel test runner, which the old `SAFETY: tests run single-threaded by default` comment quietly depended on.

Enforcement is `unsafe_code = "forbid"` in **`[workspace.lints.rust]`**, not a crate-root attribute. Build scripts, examples and integration tests compile as separate crates, so `#![forbid(unsafe_code)]` in `lib.rs` would have left exactly the targets most likely to reach for FFI unguarded. Verified by injecting an `unsafe` block into each:

| target | result |
|---|---|
| `rustnetconf-yang/build.rs` | fails to compile |
| `tests/rpc_reply_contract.rs` | fails to compile |
| `examples/get_config.rs` | fails to compile |

## Dependency table — a release behind, and incomplete

`quick-xml` 0.37 → **0.41**, `russh` 0.60 → **0.62**. It also omitted `aws-lc-rs` and `base64ct`, both direct dependencies — `aws-lc-rs` is not incidental, `src/transport/known_hosts.rs` uses it for SHA-256 fingerprints and HMAC on the core path.

## Test count

Said 197. The real figure is scope-dependent, so the scope is now stated: **504** under `cargo test --workspace --all-features` (what CI runs) — 489 harness tests plus 15 doc-tests. Default features give 487, which is why an unqualified number invites drift.

The "32 tests against a live vSRX" claim was checked and **is correct** (23 + 9), so it stands.

## Operations table

`lock`/`unlock` were listed at RFC 6241 §7.4-7.5. They are **§7.5-7.6** — §7.4 is `delete-config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)