### PR TITLE
feat(rpc): add XPathFilter, which the module doc already promised

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@ let config = conn.get_config(Datastore::Running).await?;
 - **SSH bastion support** — `ProxyJump` (multi-hop), `ProxyCommand` (shell-escaped), and OpenSSH `~/.ssh/config` alias resolution
 - **NETCONF 1.0 + 1.1** — EOM and chunked framing with auto-negotiation
 - **All core RPCs** — get, get-config, edit-config, lock/unlock, commit, validate, close/kill-session, discard-changes
+- **Subtree and XPath filters** — `SubtreeFilter` builds subtree filters; `XPathFilter` builds XPath ones (RFC 6241 §6.4) with namespace binding, gated on the device advertising `:xpath:1.0` so an unsupported filter fails loudly instead of silently returning the whole datastore
 - **Confirmed commit** — auto-rollback safety net (RFC 6241 §8.4)
 - **Event notifications** — `create-subscription`, inline notification demux, buffered drain/recv API (RFC 5277)
 - **RPC timeout** — configurable per-session deadline prevents indefinite blocking on unresponsive devices

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -33,6 +33,8 @@ pub mod uri {
     pub const NOTIFICATION: &str = "urn:ietf:params:netconf:capability:notification:1.0";
     /// Interleave capability — allows RPCs during an active notification subscription.
     pub const INTERLEAVE: &str = "urn:ietf:params:netconf:capability:interleave:1.0";
+    /// XPath filter capability (RFC 6241 §8.9).
+    pub const XPATH: &str = "urn:ietf:params:netconf:capability:xpath:1.0";
 }
 
 /// The negotiated NETCONF version for the session.

--- a/src/client.rs
+++ b/src/client.rs
@@ -10,6 +10,7 @@ use crate::capability::Capabilities;
 use crate::error::NetconfError;
 use crate::facts::Facts;
 use crate::notification::Notification;
+use crate::rpc::filter::XPathFilter;
 use crate::rpc::RpcErrorInfo;
 use crate::session::Session;
 use crate::ssh_config::{SshConfigError, SshConfigFile};
@@ -721,6 +722,33 @@ impl Client {
     /// Fetch operational and configuration data.
     pub async fn get(&mut self, filter: Option<&str>) -> Result<String, NetconfError> {
         self.session.get(filter).await
+    }
+
+    /// Fetch configuration using an XPath filter (RFC 6241 §6.4).
+    ///
+    /// Errors with [`ProtocolError::CapabilityMissing`](crate::error::ProtocolError::CapabilityMissing)
+    /// if the device did not advertise `:xpath:1.0`.
+    ///
+    /// ```no_run
+    /// # use rustnetconf::{Client, Datastore};
+    /// # use rustnetconf::rpc::filter::XPathFilter;
+    /// # async fn demo(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let filter = XPathFilter::new("/if:interfaces/if:interface[if:name='ge-0/0/0']")
+    ///     .namespace("if", "urn:ietf:params:xml:ns:yang:ietf-interfaces");
+    /// let xml = client.get_config_xpath(Datastore::Running, &filter).await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn get_config_xpath(
+        &mut self,
+        source: Datastore,
+        filter: &XPathFilter,
+    ) -> Result<String, NetconfError> {
+        self.session.get_config_xpath(source, filter).await
+    }
+
+    /// Fetch operational and configuration data using an XPath filter.
+    pub async fn get_xpath(&mut self, filter: &XPathFilter) -> Result<String, NetconfError> {
+        self.session.get_xpath(filter).await
     }
 
     /// Start building an edit-config operation.

--- a/src/rpc/filter.rs
+++ b/src/rpc/filter.rs
@@ -1,5 +1,39 @@
 //! Subtree and XPath filter builders for NETCONF `<get>` and `<get-config>`.
 
+use crate::error::{NetconfError, ProtocolError};
+use crate::rpc::operations::{escape_xml_attr, escape_xml_attr_preserving_ws};
+
+fn xml_err(message: String) -> NetconfError {
+    NetconfError::Protocol(ProtocolError::Xml(message))
+}
+
+/// Conservative XML `NCName` check, restricted to ASCII.
+///
+/// Deliberately narrower than the XML production. Rust's `char::is_alphanumeric`
+/// is true for the whole Unicode `N` category, which includes characters such as
+/// `\u{b2}` (SUPERSCRIPT TWO) that an XML parser rejects in a name — so using it
+/// would accept prefixes that produce unparseable output. Full Unicode NCName
+/// validation needs the XML character tables; refusing non-ASCII prefixes costs
+/// nothing here, since namespace prefixes in NETCONF are conventionally short
+/// ASCII tokens.
+fn is_valid_ncname(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    if !(first.is_ascii_alphabetic() || first == '_') {
+        return false;
+    }
+    s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.')
+}
+
+/// The one URI the `xml` prefix may be bound to (Namespaces in XML §3).
+const XML_NAMESPACE_URI: &str = "http://www.w3.org/XML/1998/namespace";
+
+/// Reserved; no prefix may be bound to it.
+const XMLNS_NAMESPACE_URI: &str = "http://www.w3.org/2000/xmlns/";
+
 /// Builder for constructing subtree filters.
 ///
 /// # Examples
@@ -40,5 +74,386 @@ impl SubtreeFilter {
 impl Default for SubtreeFilter {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Builder for an XPath filter (RFC 6241 §6.4).
+///
+/// An XPath filter is expressed as attributes on `<filter>` rather than as
+/// child elements, so — unlike [`SubtreeFilter`] — it cannot be reduced to a
+/// string of XML to be dropped inside the element. Pass it to
+/// [`Client::get_xpath`](crate::Client::get_xpath) or
+/// [`Client::get_config_xpath`](crate::Client::get_config_xpath), which render
+/// it and check the device advertises `:xpath:1.0` first.
+///
+/// Prefixes used in the expression must be bound with [`namespace`]. NETCONF
+/// gives the filter element no useful default namespace for this purpose, so
+/// an unprefixed path will not match on most devices.
+///
+/// [`namespace`]: XPathFilter::namespace
+///
+/// # Examples
+/// ```
+/// use rustnetconf::rpc::filter::XPathFilter;
+///
+/// let filter = XPathFilter::new("/if:interfaces/if:interface[if:name='ge-0/0/0']")
+///     .namespace("if", "urn:ietf:params:xml:ns:yang:ietf-interfaces");
+/// assert_eq!(filter.select(), "/if:interfaces/if:interface[if:name='ge-0/0/0']");
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct XPathFilter {
+    select: String,
+    namespaces: Vec<(String, String)>,
+}
+
+impl XPathFilter {
+    /// Create an XPath filter from a select expression.
+    pub fn new(select: impl Into<String>) -> Self {
+        Self {
+            select: select.into(),
+            namespaces: Vec::new(),
+        }
+    }
+
+    /// Bind a namespace prefix used in the select expression.
+    ///
+    /// Re-binding a prefix replaces the previous URI rather than emitting a
+    /// duplicate `xmlns:` attribute, which would be malformed XML.
+    pub fn namespace(mut self, prefix: impl Into<String>, uri: impl Into<String>) -> Self {
+        let prefix = prefix.into();
+        let uri = uri.into();
+        match self.namespaces.iter_mut().find(|(p, _)| *p == prefix) {
+            Some(entry) => entry.1 = uri,
+            None => self.namespaces.push((prefix, uri)),
+        }
+        self
+    }
+
+    /// The select expression, unescaped.
+    pub fn select(&self) -> &str {
+        &self.select
+    }
+
+    /// The bound prefixes, in binding order.
+    pub fn namespaces(&self) -> &[(String, String)] {
+        &self.namespaces
+    }
+
+    /// Render the `<filter>` element for this XPath expression.
+    ///
+    /// `prefix` is the element-name prefix used by the caller's RPC envelope
+    /// (`"nc:"` for the namespaced envelope, `""` for a bare one).
+    ///
+    /// The select expression and every namespace URI are attribute-escaped.
+    /// This matters more than usual here: the expression is the one part of a
+    /// filter that is routinely built from user input (an interface name, a
+    /// hostname), and it lands in an attribute value rather than in text.
+    ///
+    /// # Errors
+    ///
+    /// Rejects a binding that would shadow the envelope prefix. An `xmlns:`
+    /// declaration applies to the element it sits on *including that element's
+    /// own name*, so binding `nc` here would render
+    /// `<nc:filter xmlns:nc="urn:something-else">` and move `filter` out of the
+    /// NETCONF namespace. The device would then not see a filter at all — and
+    /// the plausible outcome is not an error but an unfiltered reply carrying
+    /// the whole datastore, which is exactly the silent over-fetch the
+    /// capability gate exists to prevent.
+    ///
+    /// Also rejects prefixes that are not usable as XML names, which would
+    /// produce malformed output rather than a wrong namespace.
+    pub(crate) fn to_filter_element(&self, prefix: &str) -> Result<String, NetconfError> {
+        let envelope = prefix.strip_suffix(':').unwrap_or(prefix);
+        let mut xmlns = String::new();
+        for (p, uri) in &self.namespaces {
+            if !envelope.is_empty() && p == envelope {
+                return Err(xml_err(format!(
+                    "XPath filter cannot bind the prefix `{p}`: it is the NETCONF \
+                     envelope prefix, and rebinding it would move <{p}:filter> out \
+                     of the NETCONF namespace"
+                )));
+            }
+            if !is_valid_ncname(p) {
+                return Err(xml_err(format!(
+                    "XPath filter namespace prefix `{p}` is not a valid XML name"
+                )));
+            }
+            // Namespaces in XML §3 reserves these two prefixes.
+            if p == "xmlns" {
+                return Err(xml_err(
+                    "the `xmlns` prefix is reserved and cannot be declared".to_string(),
+                ));
+            }
+            if p == "xml" && uri != XML_NAMESPACE_URI {
+                return Err(xml_err(format!(
+                    "the `xml` prefix may only be bound to `{XML_NAMESPACE_URI}`"
+                )));
+            }
+            // The reciprocal rules: the reserved URIs are equally restricted,
+            // not just the reserved prefixes.
+            if p != "xml" && uri == XML_NAMESPACE_URI {
+                return Err(xml_err(format!(
+                    "`{XML_NAMESPACE_URI}` may only be bound to the `xml` prefix, not `{p}`"
+                )));
+            }
+            if uri == XMLNS_NAMESPACE_URI {
+                return Err(xml_err(format!(
+                    "`{XMLNS_NAMESPACE_URI}` is reserved and cannot be bound to any \
+                     prefix, including `{p}`"
+                )));
+            }
+            if uri.is_empty() {
+                return Err(xml_err(format!(
+                    "XPath filter namespace prefix `{p}` cannot be bound to an empty URI"
+                )));
+            }
+            let uri_esc = escape_xml_attr_preserving_ws(uri).ok_or_else(|| {
+                xml_err(format!(
+                    "namespace URI for prefix `{p}` contains a control character that \
+                     XML 1.0 cannot represent"
+                ))
+            })?;
+            xmlns.push_str(&format!(" xmlns:{}=\"{}\"", escape_xml_attr(p), uri_esc));
+        }
+        let select = escape_xml_attr_preserving_ws(&self.select).ok_or_else(|| {
+            xml_err(
+                "XPath select expression contains a control character that XML 1.0 \
+                 cannot represent"
+                    .to_string(),
+            )
+        })?;
+        Ok(format!(
+            "\n    <{prefix}filter type=\"xpath\"{xmlns} select=\"{select}\"/>"
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xpath_renders_type_and_select() {
+        let f = XPathFilter::new("/if:interfaces");
+        let xml = f.to_filter_element("nc:").unwrap();
+        assert!(xml.contains("type=\"xpath\""), "got {xml}");
+        assert!(xml.contains("select=\"/if:interfaces\""), "got {xml}");
+        assert!(xml.contains("<nc:filter"), "got {xml}");
+    }
+
+    #[test]
+    fn xpath_binds_namespaces_in_order() {
+        let xml = XPathFilter::new("/a:x/b:y")
+            .namespace("a", "urn:a")
+            .namespace("b", "urn:b")
+            .to_filter_element("")
+            .unwrap();
+        let a = xml.find("xmlns:a=\"urn:a\"").expect("a bound");
+        let b = xml.find("xmlns:b=\"urn:b\"").expect("b bound");
+        assert!(a < b, "bindings should keep insertion order: {xml}");
+        assert!(xml.contains("<filter"), "bare prefix: {xml}");
+    }
+
+    #[test]
+    fn rebinding_a_prefix_replaces_it() {
+        let f = XPathFilter::new("/a:x")
+            .namespace("a", "urn:old")
+            .namespace("a", "urn:new");
+        assert_eq!(f.namespaces(), &[("a".to_string(), "urn:new".to_string())]);
+        let xml = f.to_filter_element("").unwrap();
+        assert!(!xml.contains("urn:old"), "stale binding kept: {xml}");
+        assert_eq!(xml.matches("xmlns:a=").count(), 1, "duplicate xmlns: {xml}");
+    }
+
+    #[test]
+    fn select_expression_is_attribute_escaped() {
+        // A quote in the expression must not be able to close the attribute
+        // and inject further attributes or elements.
+        let xml = XPathFilter::new("/x[name=\"a\" onload=\"evil\"]/y")
+            .to_filter_element("")
+            .unwrap();
+        assert!(!xml.contains("onload=\"evil\""), "injection escaped: {xml}");
+        assert!(xml.contains("&quot;"), "quote not escaped: {xml}");
+    }
+
+    #[test]
+    fn namespace_uri_is_attribute_escaped() {
+        let xml = XPathFilter::new("/a:x")
+            .namespace("a", "urn:a\"><evil")
+            .to_filter_element("")
+            .unwrap();
+        assert!(!xml.contains("><evil"), "injection escaped: {xml}");
+        assert!(xml.contains("&quot;"), "quote not escaped: {xml}");
+    }
+
+    #[test]
+    fn ampersand_and_angle_brackets_escaped() {
+        let xml = XPathFilter::new("/x[a='1' and b<'2' and c>'0' and d='&']")
+            .to_filter_element("")
+            .unwrap();
+        assert!(xml.contains("&amp;"), "got {xml}");
+        assert!(xml.contains("&lt;"), "got {xml}");
+        assert!(xml.contains("&gt;"), "got {xml}");
+    }
+
+    #[test]
+    fn binding_the_envelope_prefix_is_refused() {
+        // <nc:filter xmlns:nc="urn:not-netconf"> would move the filter element
+        // itself out of the NETCONF namespace, and the likely device response
+        // is an *unfiltered* datastore rather than an error.
+        let err = XPathFilter::new("/x")
+            .namespace("nc", "urn:not-netconf")
+            .to_filter_element("nc:")
+            .expect_err("binding the envelope prefix must be refused");
+        let msg = err.to_string();
+        assert!(msg.contains("nc"), "got {msg}");
+        assert!(msg.contains("NETCONF"), "got {msg}");
+    }
+
+    #[test]
+    fn binding_envelope_prefix_is_fine_when_envelope_is_bare() {
+        // With no envelope prefix there is nothing to shadow.
+        let xml = XPathFilter::new("/x")
+            .namespace("nc", "urn:anything")
+            .to_filter_element("")
+            .expect("no envelope prefix to collide with");
+        assert!(xml.contains(r#"xmlns:nc="urn:anything""#), "got {xml}");
+    }
+
+    #[test]
+    fn malformed_prefixes_are_refused() {
+        for bad in ["", "a:b", "1abc", "-x", "x y"] {
+            assert!(
+                XPathFilter::new("/x")
+                    .namespace(bad, "urn:u")
+                    .to_filter_element("nc:")
+                    .is_err(),
+                "prefix {bad:?} should be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_prefixes_are_accepted() {
+        for ok in ["if", "_x", "a-b", "a.b", "A1"] {
+            assert!(
+                XPathFilter::new("/x")
+                    .namespace(ok, "urn:u")
+                    .to_filter_element("nc:")
+                    .is_ok(),
+                "prefix {ok:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn whitespace_in_select_survives_attribute_normalization() {
+        // An XML parser folds a literal TAB/LF/CR in an attribute to a space
+        // (XML 1.0 3.3.3), which would silently rewrite the query.
+        let xml = XPathFilter::new("/x[a='line1\nline2\ttabbed']")
+            .to_filter_element("nc:")
+            .unwrap();
+        assert!(xml.contains("&#10;"), "newline not preserved: {xml}");
+        assert!(xml.contains("&#9;"), "tab not preserved: {xml}");
+        // Check the attribute value itself — the element is rendered with a
+        // leading newline for indentation, which is not part of any attribute.
+        let select = xml
+            .split_once("select=\"")
+            .and_then(|(_, rest)| rest.split_once('"'))
+            .map(|(v, _)| v)
+            .expect("select attribute present");
+        assert!(
+            !select.contains(['\n', '\t', '\r']),
+            "raw whitespace inside the select attribute: {select:?}"
+        );
+    }
+
+    #[test]
+    fn control_characters_are_refused() {
+        assert!(XPathFilter::new("/x[a='\u{1}']")
+            .to_filter_element("nc:")
+            .is_err());
+        assert!(XPathFilter::new("/x")
+            .namespace("a", "urn:\u{1}")
+            .to_filter_element("nc:")
+            .is_err());
+    }
+
+    #[test]
+    fn reserved_prefixes_are_refused() {
+        assert!(XPathFilter::new("/x")
+            .namespace("xmlns", "urn:whatever")
+            .to_filter_element("nc:")
+            .is_err());
+        assert!(XPathFilter::new("/x")
+            .namespace("xml", "urn:wrong")
+            .to_filter_element("nc:")
+            .is_err());
+        // `xml` bound to its one legal URI is fine.
+        assert!(XPathFilter::new("/x")
+            .namespace("xml", "http://www.w3.org/XML/1998/namespace")
+            .to_filter_element("nc:")
+            .is_ok());
+    }
+
+    #[test]
+    fn empty_namespace_uri_is_refused() {
+        assert!(XPathFilter::new("/x")
+            .namespace("a", "")
+            .to_filter_element("nc:")
+            .is_err());
+    }
+
+    #[test]
+    fn non_ascii_prefix_is_refused() {
+        // `char::is_alphanumeric` would accept these; XML names do not.
+        for bad in ["a\u{b2}", "\u{e9}x", "a\u{5b57}"] {
+            assert!(
+                XPathFilter::new("/x")
+                    .namespace(bad, "urn:u")
+                    .to_filter_element("nc:")
+                    .is_err(),
+                "prefix {bad:?} should be refused"
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_namespace_uris_are_refused() {
+        // Reciprocal of the reserved-prefix rules.
+        assert!(XPathFilter::new("/x")
+            .namespace("notxml", "http://www.w3.org/XML/1998/namespace")
+            .to_filter_element("nc:")
+            .is_err());
+        assert!(XPathFilter::new("/x")
+            .namespace("a", "http://www.w3.org/2000/xmlns/")
+            .to_filter_element("nc:")
+            .is_err());
+    }
+
+    #[test]
+    fn noncharacters_are_refused() {
+        // U+FFFE and U+FFFF are excluded from XML 1.0's Char production; they
+        // are not C0 controls, so a naive control-only check would let them by.
+        for bad in ["/x[a='\u{fffe}']", "/x[a='\u{ffff}']"] {
+            assert!(
+                XPathFilter::new(bad).to_filter_element("nc:").is_err(),
+                "{bad:?} should be refused"
+            );
+        }
+        assert!(XPathFilter::new("/x")
+            .namespace("a", "urn:\u{fffe}")
+            .to_filter_element("nc:")
+            .is_err());
+        // A supplementary-plane character is perfectly legal, though.
+        assert!(XPathFilter::new("/x[a='\u{1f600}']")
+            .to_filter_element("nc:")
+            .is_ok());
+    }
+
+    #[test]
+    fn subtree_filter_still_builds() {
+        let f = SubtreeFilter::new().add("<interfaces/>").build();
+        assert_eq!(f, "<interfaces/>");
     }
 }

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -6,7 +6,7 @@
 pub mod filter;
 pub mod operations;
 
-mod reply;
+pub(crate) mod reply;
 
 pub use reply::{parse_rpc_reply, RpcErrorInfo, RpcReply};
 

--- a/src/rpc/operations.rs
+++ b/src/rpc/operations.rs
@@ -6,6 +6,8 @@
 //! All RPCs use a prefixed namespace (`nc:`) instead of a default namespace
 //! to avoid `xmlns=""` on child elements, which Junos 24.4 rejects.
 
+use crate::error::NetconfError;
+use crate::rpc::filter::XPathFilter;
 use crate::types::{
     Datastore, DefaultOperation, ErrorOption, LoadAction, LoadFormat, OpenConfigurationMode,
     TestOption,
@@ -25,6 +27,39 @@ pub(crate) fn escape_xml_text(value: &str) -> String {
         }
     }
     escaped
+}
+
+/// Escape for an XML attribute value, preserving significant whitespace.
+///
+/// [`escape_xml_attr`] is fine for values that contain no tabs or newlines, but
+/// an XML parser applies *attribute-value normalization* (XML 1.0 §3.3.3) and
+/// folds a literal TAB, LF, or CR in an attribute into a space before the value
+/// is ever seen. For an XPath `select` expression that is not cosmetic: a
+/// newline inside a string literal would silently become a different query.
+/// Emitting them as numeric character references survives normalization.
+///
+/// Returns `None` if the value contains any character XML 1.0 cannot represent
+/// — those cannot be escaped, only rejected. This uses the same
+/// `is_valid_xml_char` the reply parser validates incoming documents with, so
+/// the two directions cannot drift: C0 controls other than TAB/LF/CR, and also
+/// `U+FFFE`/`U+FFFF`, which are excluded from the `Char` production.
+pub(crate) fn escape_xml_attr_preserving_ws(value: &str) -> Option<String> {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            '\t' => escaped.push_str("&#9;"),
+            '\n' => escaped.push_str("&#10;"),
+            '\r' => escaped.push_str("&#13;"),
+            c if !crate::rpc::reply::lexical::is_valid_xml_char(c) => return None,
+            c => escaped.push(c),
+        }
+    }
+    Some(escaped)
 }
 
 /// Escape a string for safe inclusion in an XML attribute value.
@@ -68,6 +103,44 @@ pub fn get_config_xml(message_id: &str, source: Datastore, filter: Option<&str>)
 </nc:rpc>"#,
         source = source.as_xml_tag(),
     )
+}
+
+/// Build a `<get-config>` RPC with an XPath filter (RFC 6241 §6.4).
+///
+/// Unlike the subtree form, the expression is carried in a `select` attribute
+/// and is attribute-escaped by [`XPathFilter::to_filter_element`], so it does
+/// not need to be pre-validated as an XML fragment.
+pub fn get_config_xpath_xml(
+    message_id: &str,
+    source: Datastore,
+    filter: &XPathFilter,
+) -> Result<String, NetconfError> {
+    let safe_id = escape_xml_attr(message_id);
+    let filter_xml = filter.to_filter_element("nc:")?;
+    Ok(format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">
+  <nc:get-config>
+    <nc:source>
+      <nc:{source}/>
+    </nc:source>{filter_xml}
+  </nc:get-config>
+</nc:rpc>"#,
+        source = source.as_xml_tag(),
+    ))
+}
+
+/// Build a `<get>` RPC with an XPath filter (RFC 6241 §6.4).
+pub fn get_xpath_xml(message_id: &str, filter: &XPathFilter) -> Result<String, NetconfError> {
+    let safe_id = escape_xml_attr(message_id);
+    let filter_xml = filter.to_filter_element("nc:")?;
+    Ok(format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">
+  <nc:get>{filter_xml}
+  </nc:get>
+</nc:rpc>"#
+    ))
 }
 
 /// Generate a `<get>` RPC request.
@@ -472,6 +545,28 @@ mod tests {
         assert!(xml.contains("<nc:running/>"));
         assert!(xml.contains("<nc:get-config>"));
         assert!(!xml.contains("<nc:filter"));
+    }
+
+    #[test]
+    fn test_get_config_xpath_emits_type_and_source() {
+        let f = XPathFilter::new("/if:interfaces")
+            .namespace("if", "urn:ietf:params:xml:ns:yang:ietf-interfaces");
+        let xml = get_config_xpath_xml("7", Datastore::Running, &f).unwrap();
+        assert!(xml.contains(r#"type="xpath""#), "got {xml}");
+        assert!(xml.contains(r#"select="/if:interfaces""#), "got {xml}");
+        assert!(xml.contains("<nc:running/>"), "got {xml}");
+        assert!(xml.contains(r#"message-id="7""#), "got {xml}");
+        // XPath filters are attribute-only: no child content in <filter>.
+        assert!(xml.contains("/>"), "filter should be self-closing: {xml}");
+        assert!(!xml.contains("type=\"subtree\""), "got {xml}");
+    }
+
+    #[test]
+    fn test_get_xpath_has_no_source_element() {
+        let xml = get_xpath_xml("8", &XPathFilter::new("/x")).unwrap();
+        assert!(xml.contains("<nc:get>"), "got {xml}");
+        assert!(!xml.contains("<nc:source>"), "get takes no source: {xml}");
+        assert!(xml.contains(r#"type="xpath""#), "got {xml}");
     }
 
     #[test]

--- a/src/rpc/reply/lexical.rs
+++ b/src/rpc/reply/lexical.rs
@@ -281,7 +281,7 @@ fn is_ncname_char(value: char) -> bool {
         )
 }
 
-pub(super) fn is_valid_xml_char(value: char) -> bool {
+pub(crate) fn is_valid_xml_char(value: char) -> bool {
     matches!(
         value as u32,
         0x9 | 0xA | 0xD | 0x20..=0xD7FF | 0xE000..=0xFFFD | 0x10000..=0x10FFFF

--- a/src/rpc/reply/mod.rs
+++ b/src/rpc/reply/mod.rs
@@ -1,5 +1,5 @@
 mod capture;
-mod lexical;
+pub(crate) mod lexical;
 mod parser;
 mod repair;
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -29,6 +29,7 @@ use crate::framing::eom::EomFramer;
 use crate::framing::Framer;
 use crate::notification::{self, MessageKind, Notification};
 use crate::rpc;
+use crate::rpc::filter::XPathFilter;
 use crate::rpc::operations::{self, EditConfigParams};
 use crate::rpc::RpcErrorInfo;
 use crate::rpc::RpcReply;
@@ -846,6 +847,53 @@ impl Session {
     ///
     /// `filter`, when provided, must be a well-formed XML subtree filter
     /// fragment. It is validated before sending; a `ProtocolError::Xml` is
+    /// Fetch configuration using an XPath filter (RFC 6241 §6.4).
+    ///
+    /// Returns [`ProtocolError::CapabilityMissing`] when the device did not
+    /// advertise `:xpath:1.0` in its `<hello>`. Failing here rather than on the
+    /// wire is deliberate: a device without XPath support answers an XPath
+    /// filter with an `operation-not-supported` rpc-error at best, and at worst
+    /// ignores the filter and returns the entire datastore — which looks like
+    /// success and is the more dangerous outcome.
+    pub async fn get_config_xpath(
+        &mut self,
+        source: Datastore,
+        filter: &XPathFilter,
+    ) -> Result<String, NetconfError> {
+        self.require_xpath()?;
+        let msg_id = self.next_message_id();
+        let xml = operations::get_config_xpath_xml(&msg_id, source, filter)?;
+        match self.send_rpc(&xml, &msg_id).await? {
+            RpcReply::Data(data) | RpcReply::DataWithWarnings(data, _) => {
+                Ok(self.vendor_profile.unwrap_config(&data))
+            }
+            RpcReply::Ok | RpcReply::OkWithWarnings(_) => Ok(String::new()),
+        }
+    }
+
+    /// Fetch operational and configuration data using an XPath filter.
+    ///
+    /// Same capability gate as [`Session::get_config_xpath`].
+    pub async fn get_xpath(&mut self, filter: &XPathFilter) -> Result<String, NetconfError> {
+        self.require_xpath()?;
+        let msg_id = self.next_message_id();
+        let xml = operations::get_xpath_xml(&msg_id, filter)?;
+        match self.send_rpc(&xml, &msg_id).await? {
+            RpcReply::Data(data) | RpcReply::DataWithWarnings(data, _) => Ok(data),
+            RpcReply::Ok | RpcReply::OkWithWarnings(_) => Ok(String::new()),
+        }
+    }
+
+    /// Error unless the peer advertised `:xpath:1.0`.
+    fn require_xpath(&self) -> Result<(), NetconfError> {
+        if self.supports(capability::uri::XPATH) {
+            return Ok(());
+        }
+        Err(NetconfError::Protocol(ProtocolError::CapabilityMissing(
+            capability::uri::XPATH.to_string(),
+        )))
+    }
+
     /// returned if it is malformed.
     pub async fn get(&mut self, filter: Option<&str>) -> Result<String, NetconfError> {
         if let Some(filter_xml) = filter {
@@ -2396,6 +2444,89 @@ mod tests {
         assert_eq!(
             discard_count, 1,
             "explicit discard_changes followed by close should produce exactly 1 discard"
+        );
+    }
+
+    /// An `<rpc-reply>` carrying a `<data>` payload.
+    fn mock_data_reply(message_id: &str, payload: &str) -> Vec<u8> {
+        let reply = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{message_id}">
+  <data>{payload}</data>
+</rpc-reply>"#
+        );
+        let mut buf = reply.into_bytes();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    /// A hello that advertises `:xpath:1.0`, unlike `mock_junos_hello`.
+    fn mock_xpath_hello() -> Vec<u8> {
+        let hello = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+    <capability>urn:ietf:params:netconf:capability:xpath:1.0</capability>
+  </capabilities>
+  <session-id>1</session-id>
+</hello>"#;
+        let mut buf = hello.as_bytes().to_vec();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    #[tokio::test]
+    async fn xpath_without_capability_is_refused_before_sending() {
+        // mock_junos_hello does not advertise :xpath:1.0.
+        let transport = MockTransport::new(mock_junos_hello());
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let before = written.lock().unwrap().len();
+        let err = session
+            .get_xpath(&XPathFilter::new("/x"))
+            .await
+            .expect_err("should refuse without :xpath:1.0");
+
+        assert!(
+            matches!(
+                err,
+                NetconfError::Protocol(ProtocolError::CapabilityMissing(ref uri))
+                    if uri == capability::uri::XPATH
+            ),
+            "unexpected error: {err:?}"
+        );
+        // The point of the gate: nothing reached the wire. A device lacking
+        // XPath may ignore the filter and return the whole datastore, which
+        // would look like success.
+        assert_eq!(
+            written.lock().unwrap().len(),
+            before,
+            "no bytes should have been written"
+        );
+    }
+
+    #[tokio::test]
+    async fn xpath_with_capability_sends_an_xpath_filter() {
+        let mut data = mock_xpath_hello();
+        data.extend_from_slice(&mock_data_reply("1", "<interfaces/>"));
+
+        let transport = MockTransport::new(data);
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let filter = XPathFilter::new("/if:interfaces")
+            .namespace("if", "urn:ietf:params:xml:ns:yang:ietf-interfaces");
+        session.get_xpath(&filter).await.expect("get_xpath failed");
+
+        let sent = String::from_utf8_lossy(&written.lock().unwrap()).to_string();
+        assert!(sent.contains(r#"type="xpath""#), "sent: {sent}");
+        assert!(sent.contains(r#"select="/if:interfaces""#), "sent: {sent}");
+        assert!(
+            sent.contains(r#"xmlns:if="urn:ietf:params:xml:ns:yang:ietf-interfaces""#),
+            "sent: {sent}"
         );
     }
 


### PR DESCRIPTION
Closes #72.

`src/rpc/filter.rs` opened with *"Subtree and XPath filter builders"* and contained only `SubtreeFilter`. The doc has been describing an API that did not exist.

## Shape

`XPathFilter` cannot be a `build() -> String` like its sibling — an XPath filter lives in `type` and `select` **attributes** on `<filter>`, not in child elements, so there is nothing to splice into the existing hole. It is a type that renders its own element, exposed as `get_config_xpath` / `get_xpath` on both `Session` and `Client`.

```rust
let filter = XPathFilter::new("/if:interfaces/if:interface[if:name='ge-0/0/0']")
    .namespace("if", "urn:ietf:params:xml:ns:yang:ietf-interfaces");
let xml = client.get_config_xpath(Datastore::Running, &filter).await?;
```

## The failure mode this is built around

A device without XPath support may answer `operation-not-supported` — **or it may ignore the filter and return the entire datastore**, which looks like success and silently ships far more data than asked for. Everything below defends that one property:

- Gated on `:xpath:1.0`, refusing **before anything reaches the wire**. A test asserts zero bytes written on the refusal path.
- Rendering is fallible, because an `xmlns:` declaration applies to the element it sits on *including that element's own name*. Binding `nc` would emit `<nc:filter xmlns:nc="urn:something-else">` and move the filter out of the NETCONF namespace — reintroducing the same silent-unfiltered-reply outcome from a different direction.

## Validation

| input | outcome |
|---|---|
| binding the envelope prefix (`nc`) | refused |
| `xmlns` prefix, or `xml` bound to a non-XML URI | refused |
| XML namespace URI on a non-`xml` prefix; `xmlns` URI on any prefix | refused |
| non-ASCII prefix (`a²`, `éx`) | refused — `char::is_alphanumeric` accepts Unicode `No`, XML names do not |
| empty namespace URI | refused |
| `U+FFFE` / `U+FFFF` in select or URI | refused |
| supplementary-plane char (`😀`) | accepted — legal XML |

Escaping uses a new `escape_xml_attr_preserving_ws`. Plain `escape_xml_attr` leaves TAB/LF/CR literal, and XML attribute-value normalization (XML 1.0 §3.3.3) folds those to spaces before the value is evaluated — which would **silently rewrite the query** when a newline sits inside an XPath string literal. They are emitted as numeric references instead.

Character validity reuses the reply parser's existing `is_valid_xml_char` rather than a second copy, so the send and receive sides cannot drift.

## Notes

- Rebinding a prefix replaces it rather than appending — two `xmlns:if=` attributes on one element is malformed XML, not a last-wins override.
- No new error variant: `ProtocolError::CapabilityMissing` and `ProtocolError::Xml` already fit, which keeps the error sizes #66 shrank.
- 528 tests pass (up from 517), clippy `-D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)