### PR TITLE
feat(rpc): add copy-config, delete-config and cancel-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,7 +543,7 @@ let config = conn.get_config(Datastore::Running).await?;
 - **SSH + TLS transports** — SSH (RFC 6242) by default, TLS (RFC 7589) via `tls` feature flag
 - **SSH bastion support** — `ProxyJump` (multi-hop), `ProxyCommand` (shell-escaped), and OpenSSH `~/.ssh/config` alias resolution
 - **NETCONF 1.0 + 1.1** — EOM and chunked framing with auto-negotiation
-- **All core RPCs** — get, get-config, edit-config, lock/unlock, commit, validate, close/kill-session, discard-changes
+- **All core RPCs** — get, get-config, edit-config, copy-config, delete-config, lock/unlock, commit, confirmed-commit, cancel-commit, validate, close/kill-session, discard-changes
 - **Subtree and XPath filters** — `SubtreeFilter` builds subtree filters; `XPathFilter` builds XPath ones (RFC 6241 §6.4) with namespace binding, gated on the device advertising `:xpath:1.0` so an unsupported filter fails loudly instead of silently returning the whole datastore
 - **Confirmed commit** — auto-rollback safety net (RFC 6241 §8.4)
 - **Event notifications** — `create-subscription`, inline notification demux, buffered drain/recv API (RFC 5277)
@@ -614,11 +614,14 @@ match result {
 | `get` | §7.7 | Done |
 | `get-config` | §7.1 | Done |
 | `edit-config` | §7.2 | Done |
+| `copy-config` | §7.3 | Done |
+| `delete-config` | §7.4 | Done (startup / url) |
 | `lock` / `unlock` | §7.5-7.6 | Done |
 | `close-session` | §7.8 | Done |
 | `kill-session` | §7.9 | Done |
 | `commit` | §8.4 | Done |
 | `confirmed-commit` | §8.4 | Done |
+| `cancel-commit` | §8.4.4.1 | Done |
 | `validate` | §8.6 | Done |
 | `discard-changes` | §8.3 | Done |
 

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -35,6 +35,8 @@ pub mod uri {
     pub const INTERLEAVE: &str = "urn:ietf:params:netconf:capability:interleave:1.0";
     /// XPath filter capability (RFC 6241 §8.9).
     pub const XPATH: &str = "urn:ietf:params:netconf:capability:xpath:1.0";
+    /// URL capability (RFC 6241 §8.8) — `<url>` as a config source or target.
+    pub const URL: &str = "urn:ietf:params:netconf:capability:url:1.0";
 }
 
 /// The negotiated NETCONF version for the session.

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,6 +20,7 @@ use crate::transport::ssh::{
 #[cfg(feature = "tls")]
 use crate::transport::tls::{TlsConfig, TlsTransport};
 use crate::transport::Transport;
+use crate::types::{ConfigLocation, CopySource, DeleteTarget};
 use crate::types::{
     Datastore, DefaultOperation, ErrorOption, LoadAction, LoadFormat, OpenConfigurationMode,
     TestOption,
@@ -749,6 +750,42 @@ impl Client {
     /// Fetch operational and configuration data using an XPath filter.
     pub async fn get_xpath(&mut self, filter: &XPathFilter) -> Result<String, NetconfError> {
         self.session.get_xpath(filter).await
+    }
+
+    /// Copy a configuration from one location to another (RFC 6241 §7.3).
+    ///
+    /// ```no_run
+    /// # use rustnetconf::{Client, Datastore};
+    /// # use rustnetconf::types::{ConfigLocation, CopySource};
+    /// # async fn demo(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// // Snapshot running into startup.
+    /// client.copy_config(
+    ///     &ConfigLocation::Datastore(Datastore::Startup),
+    ///     &CopySource::Datastore(Datastore::Running),
+    /// ).await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn copy_config(
+        &mut self,
+        target: &ConfigLocation,
+        source: &CopySource,
+    ) -> Result<(), NetconfError> {
+        self.session.copy_config(target, source).await
+    }
+
+    /// Delete a configuration datastore or URL-backed config (RFC 6241 §7.4).
+    ///
+    /// [`DeleteTarget`] can only name `startup` or a URL — the two the RFC's
+    /// `config-target` choice permits for this operation.
+    pub async fn delete_config(&mut self, target: &DeleteTarget) -> Result<(), NetconfError> {
+        self.session.delete_config(target).await
+    }
+
+    /// Cancel an in-progress confirmed commit (RFC 6241 §8.4.4.1).
+    ///
+    /// Requires `:confirmed-commit:1.1`.
+    pub async fn cancel_commit(&mut self, persist_id: Option<&str>) -> Result<(), NetconfError> {
+        self.session.cancel_commit(persist_id).await
     }
 
     /// Start building an edit-config operation.

--- a/src/error.rs
+++ b/src/error.rs
@@ -213,6 +213,11 @@ pub enum ProtocolError {
     /// XML parsing error during protocol message handling.
     #[error("XML error: {0}")]
     Xml(String),
+
+    /// A request the RFC requires the server to reject with `invalid-value`,
+    /// caught locally instead of being sent.
+    #[error("invalid value: {0}")]
+    InvalidValue(String),
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,8 +58,8 @@ pub use notification::Notification;
 pub use rpc::RpcErrorInfo;
 pub use ssh_config::{ResolvedHost, SshConfigError, SshConfigFile};
 pub use types::{
-    Datastore, DefaultOperation, ErrorOption, LoadAction, LoadFormat, OpenConfigurationMode,
-    TestOption,
+    ConfigLocation, CopySource, Datastore, DefaultOperation, DeleteTarget, ErrorOption, LoadAction,
+    LoadFormat, OpenConfigurationMode, TestOption,
 };
 
 #[cfg(feature = "tls")]

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -62,6 +62,24 @@ pub fn validate_xml_fragment(xml: &str) -> Result<(), ProtocolError> {
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Eof) => break,
+            // A fragment is embedded inside an RPC we have already opened with
+            // its own declaration. An `<?xml ...?>` here would put a second
+            // declaration mid-document, which is malformed however well-formed
+            // the fragment looked on its own — and the synthetic `<_>` root
+            // above is exactly what hides that from the parser.
+            Ok(Event::Decl(_)) => {
+                return Err(ProtocolError::Xml(
+                    "XML fragment must not contain a document declaration; strip the                      leading `<?xml ...?>` before embedding it"
+                        .to_string(),
+                ));
+            }
+            // Likewise a DOCTYPE, which additionally carries the entity
+            // machinery behind XXE and entity-expansion attacks.
+            Ok(Event::DocType(_)) => {
+                return Err(ProtocolError::Xml(
+                    "XML fragment must not contain a DOCTYPE declaration".to_string(),
+                ));
+            }
             Err(e) => {
                 return Err(ProtocolError::Xml(format!(
                     "XML fragment is not well-formed: {e}"
@@ -126,5 +144,30 @@ mod xml_validate_tests {
             result.is_err(),
             "malformed attribute should fail validation"
         );
+    }
+}
+
+#[cfg(test)]
+mod fragment_validation_tests {
+    use super::validate_xml_fragment;
+
+    #[test]
+    fn rejects_document_declaration() {
+        let err = validate_xml_fragment("<?xml version=\"1.0\"?><system/>")
+            .expect_err("a declaration cannot be embedded");
+        assert!(err.to_string().contains("declaration"), "got {err}");
+    }
+
+    #[test]
+    fn rejects_doctype() {
+        assert!(validate_xml_fragment("<!DOCTYPE x><system/>").is_err());
+    }
+
+    #[test]
+    fn still_accepts_ordinary_fragments() {
+        validate_xml_fragment("<system><host-name>r1</host-name></system>").unwrap();
+        validate_xml_fragment("<a/><b/>").unwrap();
+        validate_xml_fragment("<!-- a comment --><a/>").unwrap();
+        validate_xml_fragment("").unwrap();
     }
 }

--- a/src/rpc/operations.rs
+++ b/src/rpc/operations.rs
@@ -8,6 +8,7 @@
 
 use crate::error::NetconfError;
 use crate::rpc::filter::XPathFilter;
+use crate::types::{ConfigLocation, CopySource, DeleteTarget};
 use crate::types::{
     Datastore, DefaultOperation, ErrorOption, LoadAction, LoadFormat, OpenConfigurationMode,
     TestOption,
@@ -27,6 +28,31 @@ pub(crate) fn escape_xml_text(value: &str) -> String {
         }
     }
     escaped
+}
+
+/// Escape for XML text content, preserving carriage returns exactly.
+///
+/// [`escape_xml_text`] is right for content we generate, but not for opaque
+/// tokens we must round-trip byte-for-byte. XML 1.0 §2.11 applies *line-ending
+/// normalization* to text content: a literal CR is turned into LF (and CRLF
+/// into a single LF) before the application sees it. A `persist-id` minted by
+/// another session and echoed back through a literal CR would come back
+/// altered and no longer match, so cancellation would silently fail.
+///
+/// Returns `None` for characters XML 1.0 cannot represent at all.
+pub(crate) fn escape_xml_text_exact(value: &str) -> Option<String> {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '\r' => escaped.push_str("&#13;"),
+            c if !crate::rpc::reply::lexical::is_valid_xml_char(c) => return None,
+            c => escaped.push(c),
+        }
+    }
+    Some(escaped)
 }
 
 /// Escape for an XML attribute value, preserving significant whitespace.
@@ -262,6 +288,100 @@ pub fn discard_changes_xml(message_id: &str) -> String {
   <nc:discard-changes/>
 </nc:rpc>"#,
     )
+}
+
+/// Render a `<source>`/`<target>` body for a [`ConfigLocation`].
+///
+/// URLs are text content, so they use the text escaper; a datastore renders as
+/// an empty element named for the datastore.
+fn location_body(location: &ConfigLocation, indent: &str) -> String {
+    match location {
+        ConfigLocation::Datastore(ds) => format!("{indent}<nc:{}/>", ds.as_xml_tag()),
+        ConfigLocation::Url(url) => {
+            format!("{indent}<nc:url>{}</nc:url>", escape_xml_text(url))
+        }
+    }
+}
+
+/// Render a `<source>` body for a [`CopySource`].
+///
+/// The inline form is inserted verbatim and must have been validated by the
+/// caller — same contract as `edit-config`'s config payload.
+fn copy_source_body(source: &CopySource, indent: &str) -> String {
+    match source {
+        CopySource::Datastore(ds) => format!("{indent}<nc:{}/>", ds.as_xml_tag()),
+        CopySource::Url(url) => format!("{indent}<nc:url>{}</nc:url>", escape_xml_text(url)),
+        CopySource::Config(cfg) => format!("{indent}<nc:config>{cfg}</nc:config>"),
+    }
+}
+
+/// Generate a `<copy-config>` RPC request (RFC 6241 §7.3).
+pub fn copy_config_xml(message_id: &str, target: &ConfigLocation, source: &CopySource) -> String {
+    let safe_id = escape_xml_attr(message_id);
+    let target_body = location_body(target, "      ");
+    let source_body = copy_source_body(source, "      ");
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">
+  <nc:copy-config>
+    <nc:target>
+{target_body}
+    </nc:target>
+    <nc:source>
+{source_body}
+    </nc:source>
+  </nc:copy-config>
+</nc:rpc>"#
+    )
+}
+
+/// Generate a `<delete-config>` RPC request (RFC 6241 §7.4).
+pub fn delete_config_xml(message_id: &str, target: &DeleteTarget) -> String {
+    let safe_id = escape_xml_attr(message_id);
+    let target_body = match target {
+        DeleteTarget::Startup => "      <nc:startup/>".to_string(),
+        DeleteTarget::Url(url) => {
+            format!("      <nc:url>{}</nc:url>", escape_xml_text(url))
+        }
+    };
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">
+  <nc:delete-config>
+    <nc:target>
+{target_body}
+    </nc:target>
+  </nc:delete-config>
+</nc:rpc>"#
+    )
+}
+
+/// Generate a `<cancel-commit>` RPC request (RFC 6241 §8.4.4.1).
+///
+/// `persist_id` cancels a confirmed commit that was issued with a `<persist>`
+/// token, possibly from a different session.
+pub fn cancel_commit_xml(
+    message_id: &str,
+    persist_id: Option<&str>,
+) -> Result<String, NetconfError> {
+    let safe_id = escape_xml_attr(message_id);
+    let body = match persist_id {
+        Some(id) => {
+            let escaped = escape_xml_text_exact(id).ok_or_else(|| {
+                NetconfError::Protocol(crate::error::ProtocolError::Xml(
+                    "persist-id contains a character XML 1.0 cannot represent".to_string(),
+                ))
+            })?;
+            format!("\n    <nc:persist-id>{escaped}</nc:persist-id>\n  ")
+        }
+        None => String::new(),
+    };
+    Ok(format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<nc:rpc xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">
+  <nc:cancel-commit>{body}</nc:cancel-commit>
+</nc:rpc>"#
+    ))
 }
 
 /// Generate a `<commit>` RPC request.
@@ -545,6 +665,105 @@ mod tests {
         assert!(xml.contains("<nc:running/>"));
         assert!(xml.contains("<nc:get-config>"));
         assert!(!xml.contains("<nc:filter"));
+    }
+
+    #[test]
+    fn test_copy_config_datastore_to_datastore() {
+        let xml = copy_config_xml(
+            "1",
+            &ConfigLocation::Datastore(Datastore::Startup),
+            &CopySource::Datastore(Datastore::Running),
+        );
+        assert!(xml.contains("<nc:copy-config>"), "got {xml}");
+        // Order matters: RFC 6241 puts <target> before <source>.
+        let t = xml.find("<nc:target>").expect("target");
+        let src = xml.find("<nc:source>").expect("source");
+        assert!(t < src, "target must precede source: {xml}");
+        assert!(xml.contains("<nc:startup/>"), "got {xml}");
+        assert!(xml.contains("<nc:running/>"), "got {xml}");
+    }
+
+    #[test]
+    fn test_copy_config_url_is_text_escaped() {
+        let xml = copy_config_xml(
+            "2",
+            &ConfigLocation::Url("file:///tmp/a&b<c".to_string()),
+            &CopySource::Datastore(Datastore::Running),
+        );
+        assert!(xml.contains("<nc:url>"), "got {xml}");
+        assert!(xml.contains("file:///tmp/a&amp;b&lt;c"), "got {xml}");
+        assert!(!xml.contains("a&b<c"), "unescaped url: {xml}");
+    }
+
+    #[test]
+    fn test_copy_config_inline_config_source() {
+        let xml = copy_config_xml(
+            "9",
+            &ConfigLocation::Datastore(Datastore::Candidate),
+            &CopySource::Config("<system><host-name>r1</host-name></system>".to_string()),
+        );
+        assert!(xml.contains("<nc:config>"), "got {xml}");
+        assert!(xml.contains("<host-name>r1</host-name>"), "got {xml}");
+        assert!(!xml.contains("<nc:url>"), "got {xml}");
+    }
+
+    #[test]
+    fn test_delete_config_url_is_text_escaped() {
+        let xml = delete_config_xml("10", &DeleteTarget::Url("file:///t/a&b".to_string()));
+        assert!(
+            xml.contains("<nc:url>file:///t/a&amp;b</nc:url>"),
+            "got {xml}"
+        );
+    }
+
+    #[test]
+    fn test_delete_config_targets_only() {
+        let xml = delete_config_xml("3", &DeleteTarget::Startup);
+        assert!(xml.contains("<nc:delete-config>"), "got {xml}");
+        assert!(xml.contains("<nc:startup/>"), "got {xml}");
+        assert!(
+            !xml.contains("<nc:source>"),
+            "delete takes no source: {xml}"
+        );
+    }
+
+    #[test]
+    fn test_cancel_commit_without_persist_id() {
+        let xml = cancel_commit_xml("4", None).unwrap();
+        assert!(
+            xml.contains("<nc:cancel-commit></nc:cancel-commit>"),
+            "got {xml}"
+        );
+        assert!(!xml.contains("persist-id"), "got {xml}");
+    }
+
+    #[test]
+    fn test_cancel_commit_with_persist_id_escapes_it() {
+        let xml = cancel_commit_xml("5", Some("token&<1")).unwrap();
+        assert!(
+            xml.contains("<nc:persist-id>token&amp;&lt;1</nc:persist-id>"),
+            "got {xml}"
+        );
+    }
+
+    #[test]
+    fn test_cancel_commit_persist_id_preserves_cr() {
+        // XML 1.0 line-ending normalization turns a literal CR in text content
+        // into LF, which would corrupt an opaque token minted elsewhere.
+        let xml = cancel_commit_xml("6", Some("a\rb")).unwrap();
+        assert!(xml.contains("&#13;"), "got {xml}");
+        let body = xml
+            .split_once("<nc:persist-id>")
+            .and_then(|(_, r)| r.split_once("</nc:persist-id>"))
+            .map(|(v, _)| v)
+            .expect("persist-id present");
+        assert!(!body.contains('\r'), "raw CR survives: {body:?}");
+    }
+
+    #[test]
+    fn test_cancel_commit_rejects_invalid_xml_chars() {
+        assert!(cancel_commit_xml("7", Some("a\u{1}b")).is_err());
+        assert!(cancel_commit_xml("7", Some("a\u{fffe}b")).is_err());
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -35,8 +35,8 @@ use crate::rpc::RpcErrorInfo;
 use crate::rpc::RpcReply;
 use crate::transport::Transport;
 use crate::types::{
-    Datastore, DefaultOperation, ErrorOption, LoadAction, LoadFormat, OpenConfigurationMode,
-    TestOption,
+    ConfigLocation, CopySource, Datastore, DefaultOperation, DeleteTarget, ErrorOption, LoadAction,
+    LoadFormat, OpenConfigurationMode, TestOption,
 };
 use crate::vendor::{self, CloseSequence, VendorProfile};
 
@@ -987,6 +987,207 @@ impl Session {
         let xml = operations::validate_xml(&msg_id, source);
         self.send_rpc(&xml, &msg_id).await?;
         Ok(())
+    }
+
+    /// Copy a configuration from one location to another (RFC 6241 §7.3).
+    ///
+    /// Either side may be a datastore or a URL; the URL form requires the
+    /// device to advertise `:url`, which is checked before sending.
+    pub async fn copy_config(
+        &mut self,
+        target: &ConfigLocation,
+        source: &CopySource,
+    ) -> Result<(), NetconfError> {
+        // RFC 6241 §7.3: "If the <source> and <target> parameters identify the
+        // same URL or configuration datastore, an error MUST be returned with
+        // an error-tag containing 'invalid-value'." Caught here so the
+        // candidate is never marked dirty for a request that cannot succeed.
+        let same = match (target, source) {
+            (ConfigLocation::Datastore(t), CopySource::Datastore(s)) => t == s,
+            (ConfigLocation::Url(t), CopySource::Url(s)) => t == s,
+            _ => false,
+        };
+        if same {
+            return Err(ProtocolError::InvalidValue(format!(
+                "<copy-config> source and target are both `{target}` (RFC 6241 §7.3)"
+            ))
+            .into());
+        }
+
+        match target {
+            ConfigLocation::Url(url) => self.require_url_scheme(url)?,
+            ConfigLocation::Datastore(ds) => self.require_datastore(*ds, true)?,
+        }
+        // Inline config is vendor-wrapped exactly as `edit_config` wraps its
+        // payload — on Junos a bare `<system>...</system>` needs the
+        // `<configuration>` wrapper or the device misreads it.
+        let wrapped_source;
+        let source = match source {
+            CopySource::Url(url) => {
+                self.require_url_scheme(url)?;
+                source
+            }
+            CopySource::Config(cfg) => {
+                rpc::validate_xml_fragment(cfg)?;
+                wrapped_source = CopySource::Config(self.vendor_profile.wrap_config(cfg));
+                &wrapped_source
+            }
+            CopySource::Datastore(ds) => {
+                self.require_datastore(*ds, false)?;
+                source
+            }
+        };
+        // Preflight must complete before the flag is set, and the flag must be
+        // set before the write — the ordering `dispatch_candidate_change`
+        // documents. Too early and a call that never reaches the wire (an
+        // unestablished session, a failed keepalive) still marks the candidate
+        // dirty, and a later Junos `close_session` would discard a shared
+        // candidate nobody touched. Too late and a copy the device applied but
+        // whose reply was lost goes unrecorded, so the discard is skipped.
+        self.keepalive_check().await?;
+        self.ensure_established()?;
+
+        let msg_id = self.next_message_id();
+        let xml = operations::copy_config_xml(&msg_id, target, source);
+        if matches!(target, ConfigLocation::Datastore(Datastore::Candidate)) {
+            self.candidate_dirty = true;
+        }
+        // send_rpc_raw, not send_rpc: the latter runs its own keepalive probe,
+        // which would land *after* the flag is set. A probe that fails or is
+        // cancelled there would leave the candidate marked dirty with nothing
+        // written. Same reason `dispatch_candidate_change` bypasses it.
+        self.send_rpc_raw(&xml, &msg_id, false).await?;
+
+        // A successful copy between running and candidate — in either
+        // direction — synchronizes the two, so the candidate holds nothing
+        // uncommitted and needs no discard on close. candidate -> running is
+        // the same synchronization `commit` performs, and `commit` clears the
+        // flag for exactly this reason. Leaving it set would make a later Junos
+        // `close_session` send `<discard-changes/>` and destroy edits another
+        // session had since made to the shared candidate.
+        //
+        // The pre-write marking above still stands for the uncertain case: if
+        // the reply is lost we do not know the copy landed, and assuming dirty
+        // is the safe side of that.
+        let synchronized = matches!(
+            (target, source),
+            (
+                ConfigLocation::Datastore(Datastore::Candidate),
+                CopySource::Datastore(Datastore::Running)
+            ) | (
+                ConfigLocation::Datastore(Datastore::Running),
+                CopySource::Datastore(Datastore::Candidate)
+            )
+        );
+        if synchronized {
+            self.candidate_dirty = false;
+        }
+        Ok(())
+    }
+
+    /// Delete a configuration datastore or URL-backed config (RFC 6241 §7.4).
+    ///
+    /// [`DeleteTarget`] can only name `startup` or a URL, which is what the
+    /// RFC's `config-target` choice permits here — `running` and `candidate`
+    /// are not expressible rather than rejected at runtime.
+    pub async fn delete_config(&mut self, target: &DeleteTarget) -> Result<(), NetconfError> {
+        match target {
+            DeleteTarget::Url(url) => self.require_url_scheme(url)?,
+            DeleteTarget::Startup => {
+                self.require_capability(crate::capability::uri::STARTUP, "delete-config startup")?
+            }
+        }
+        let msg_id = self.next_message_id();
+        let xml = operations::delete_config_xml(&msg_id, target);
+        self.send_rpc(&xml, &msg_id).await?;
+        Ok(())
+    }
+
+    /// Cancel an in-progress confirmed commit (RFC 6241 §8.4.4.1).
+    ///
+    /// Requires `:confirmed-commit:1.1` — `cancel-commit` does not exist in the
+    /// 1.0 capability, where the only way out is to let the timer expire.
+    ///
+    /// `persist_id` cancels a commit issued with a `<persist>` token, which may
+    /// have come from another session.
+    pub async fn cancel_commit(&mut self, persist_id: Option<&str>) -> Result<(), NetconfError> {
+        self.require_capability(
+            crate::capability::uri::CONFIRMED_COMMIT_1_1,
+            "cancel-commit",
+        )?;
+        let msg_id = self.next_message_id();
+        let xml = operations::cancel_commit_xml(&msg_id, persist_id)?;
+        self.send_rpc(&xml, &msg_id).await?;
+        Ok(())
+    }
+
+    /// Require the capability a datastore needs, per its `if-feature` in
+    /// RFC 6241's YANG module.
+    ///
+    /// `running` needs nothing to read but `:writable-running` to write, which
+    /// is why the direction is a parameter rather than inferred.
+    fn require_datastore(&self, ds: Datastore, as_target: bool) -> Result<(), NetconfError> {
+        match (ds, as_target) {
+            (Datastore::Candidate, _) => {
+                self.require_capability(crate::capability::uri::CANDIDATE, "candidate datastore")
+            }
+            (Datastore::Startup, _) => {
+                self.require_capability(crate::capability::uri::STARTUP, "startup datastore")
+            }
+            (Datastore::Running, true) => self.require_capability(
+                crate::capability::uri::WRITABLE_RUNNING,
+                "writable running datastore",
+            ),
+            (Datastore::Running, false) => Ok(()),
+        }
+    }
+
+    /// Require `:url`, and that the device lists this URL's scheme.
+    ///
+    /// The capability carries its supported schemes as a query parameter —
+    /// `...:url:1.0?scheme=http,ftp,file` — so checking only the base URI would
+    /// accept a `file://` path against a device advertising `scheme=https`.
+    /// A device that advertises `:url` with no `scheme` parameter names no
+    /// schemes at all, so nothing is accepted for it rather than everything.
+    fn require_url_scheme(&self, url: &str) -> Result<(), NetconfError> {
+        self.require_capability(crate::capability::uri::URL, "url config location")?;
+
+        let Some(scheme) = url.split_once(':').map(|(s, _)| s) else {
+            return Err(ProtocolError::Xml(format!("`{url}` has no URL scheme")).into());
+        };
+        let scheme = scheme.to_ascii_lowercase();
+
+        let advertised: Vec<String> = self
+            .capabilities()
+            .map(|caps| caps.all_uris().iter().cloned().collect())
+            .unwrap_or_default();
+        let supported: Vec<String> = advertised
+            .iter()
+            .filter(|uri| uri.starts_with(crate::capability::uri::URL))
+            .filter_map(|uri| uri.split_once("scheme="))
+            .flat_map(|(_, list)| {
+                list.split('&')
+                    .next()
+                    .unwrap_or("")
+                    .split(',')
+                    .map(|s| s.trim().to_ascii_lowercase())
+                    .collect::<Vec<_>>()
+            })
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        if supported.contains(&scheme) {
+            return Ok(());
+        }
+        Err(ProtocolError::CapabilityMissing(format!(
+            "device does not advertise URL scheme `{scheme}` (advertised: {})",
+            if supported.is_empty() {
+                "none".to_string()
+            } else {
+                supported.join(", ")
+            }
+        ))
+        .into())
     }
 
     /// Discard uncommitted candidate configuration changes.
@@ -2473,6 +2674,348 @@ mod tests {
         let mut buf = hello.as_bytes().to_vec();
         buf.extend_from_slice(b"]]>]]>");
         buf
+    }
+
+    #[test]
+    fn delete_target_cannot_name_running_or_candidate() {
+        // Compile-time property, asserted as documentation: RFC 6241's
+        // config-target choice for delete-config has only startup and url, so
+        // DeleteTarget has exactly two variants and the illegal targets are
+        // unrepresentable rather than rejected at runtime.
+        let targets = [
+            DeleteTarget::Startup,
+            DeleteTarget::Url("file:///tmp/x".to_string()),
+        ];
+        assert_eq!(targets.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn delete_config_allows_startup() {
+        let mut data = mock_startup_hello();
+        data.extend_from_slice(&mock_ok_reply("1"));
+        let transport = MockTransport::new(data);
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        session
+            .delete_config(&DeleteTarget::Startup)
+            .await
+            .expect("deleting startup is legal");
+        let sent = String::from_utf8_lossy(&written.lock().unwrap()).to_string();
+        assert!(sent.contains("<nc:delete-config>"), "sent: {sent}");
+        assert!(sent.contains("<nc:startup/>"), "sent: {sent}");
+    }
+
+    #[tokio::test]
+    async fn url_location_requires_the_url_capability() {
+        // mock_device_hello does not advertise :url.
+        let transport = MockTransport::new(mock_device_hello());
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let before = written.lock().unwrap().len();
+        let err = session
+            .copy_config(
+                &ConfigLocation::Url("file:///tmp/backup.xml".to_string()),
+                &CopySource::Datastore(Datastore::Running),
+            )
+            .await
+            .expect_err("url without :url capability must be refused");
+        assert!(err.to_string().contains("url"), "got {err}");
+        assert_eq!(written.lock().unwrap().len(), before, "nothing sent");
+    }
+
+    /// A hello advertising `:candidate` and `:writable-running`.
+    fn mock_writable_running_hello() -> Vec<u8> {
+        let hello = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+    <capability>urn:ietf:params:netconf:capability:candidate:1.0</capability>
+    <capability>urn:ietf:params:netconf:capability:writable-running:1.0</capability>
+  </capabilities>
+  <session-id>1</session-id>
+</hello>"#;
+        let mut buf = hello.as_bytes().to_vec();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    /// A hello advertising `:startup`.
+    fn mock_startup_hello() -> Vec<u8> {
+        let hello = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+    <capability>urn:ietf:params:netconf:capability:startup:1.0</capability>
+  </capabilities>
+  <session-id>1</session-id>
+</hello>"#;
+        let mut buf = hello.as_bytes().to_vec();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    /// A hello advertising `:url` with an explicit scheme list.
+    fn mock_url_hello(schemes: &str) -> Vec<u8> {
+        let hello = format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+    <capability>urn:ietf:params:netconf:capability:url:1.0?scheme={schemes}</capability>
+  </capabilities>
+  <session-id>1</session-id>
+</hello>"#
+        );
+        let mut buf = hello.into_bytes();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    #[tokio::test]
+    async fn url_scheme_must_be_advertised() {
+        // Device offers https only; a file:// URL must not slip through on the
+        // strength of the bare :url capability.
+        let transport = MockTransport::new(mock_url_hello("https"));
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let before = written.lock().unwrap().len();
+        let err = session
+            .delete_config(&DeleteTarget::Url("file:///tmp/x.xml".to_string()))
+            .await
+            .expect_err("file scheme is not advertised");
+        assert!(err.to_string().contains("file"), "got {err}");
+        assert_eq!(written.lock().unwrap().len(), before, "nothing sent");
+    }
+
+    #[tokio::test]
+    async fn advertised_url_scheme_is_accepted() {
+        let mut data = mock_url_hello("http,file,ftp");
+        data.extend_from_slice(&mock_ok_reply("1"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        session
+            .delete_config(&DeleteTarget::Url("FILE:///tmp/x.xml".to_string()))
+            .await
+            .expect("scheme matching is case-insensitive");
+    }
+
+    #[tokio::test]
+    async fn copy_config_preflight_failure_leaves_candidate_clean() {
+        // No establish(), so no capabilities and no wire. Whichever preflight
+        // check trips first, nothing is written — and the candidate must not be
+        // marked dirty, or a later Junos close would send <discard-changes/>
+        // against a shared candidate nobody touched.
+        let transport = MockTransport::new(Vec::new());
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        assert!(!session.candidate_dirty());
+
+        session
+            .copy_config(
+                &ConfigLocation::Datastore(Datastore::Candidate),
+                &CopySource::Config("<system/>".to_string()),
+            )
+            .await
+            .expect_err("preflight must refuse");
+
+        assert!(
+            written.lock().unwrap().is_empty(),
+            "nothing should have been written"
+        );
+        assert!(
+            !session.candidate_dirty(),
+            "preflight failure must not leave the candidate marked dirty"
+        );
+    }
+
+    #[tokio::test]
+    async fn running_to_candidate_copy_leaves_candidate_clean() {
+        // The two datastores are synchronized afterwards, so there is nothing
+        // uncommitted to discard. Leaving the flag set would make a later Junos
+        // close erase edits another session made to the shared candidate.
+        let mut data = mock_junos_hello();
+        data.extend_from_slice(&mock_ok_reply("1"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        session
+            .copy_config(
+                &ConfigLocation::Datastore(Datastore::Candidate),
+                &CopySource::Datastore(Datastore::Running),
+            )
+            .await
+            .expect("running -> candidate copy");
+        assert!(
+            !session.candidate_dirty(),
+            "a running->candidate copy synchronizes them; nothing to discard"
+        );
+    }
+
+    #[tokio::test]
+    async fn candidate_to_running_copy_leaves_candidate_clean() {
+        // The same synchronization `commit` performs, so the same bookkeeping.
+        let mut data = mock_writable_running_hello();
+        data.extend_from_slice(&mock_ok_reply("1"));
+        data.extend_from_slice(&mock_ok_reply("2"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        session.mark_candidate_dirty();
+        session
+            .copy_config(
+                &ConfigLocation::Datastore(Datastore::Running),
+                &CopySource::Datastore(Datastore::Candidate),
+            )
+            .await
+            .expect("candidate -> running copy");
+        assert!(
+            !session.candidate_dirty(),
+            "candidate -> running synchronizes them; nothing left to discard"
+        );
+    }
+
+    #[tokio::test]
+    async fn identical_source_and_target_is_refused_before_marking_dirty() {
+        // RFC 6241 §7.3 requires the server to answer invalid-value. Catching
+        // it locally also stops the candidate being marked dirty for a request
+        // that cannot succeed - which would make a later Junos close discard
+        // another session's edits.
+        let transport = MockTransport::new(mock_junos_hello());
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let before = written.lock().unwrap().len();
+        let err = session
+            .copy_config(
+                &ConfigLocation::Datastore(Datastore::Candidate),
+                &CopySource::Datastore(Datastore::Candidate),
+            )
+            .await
+            .expect_err("identical source and target must be refused");
+        assert!(err.to_string().contains("invalid value"), "got {err}");
+        assert!(
+            !session.candidate_dirty(),
+            "a refused copy must not mark the candidate dirty"
+        );
+        assert_eq!(written.lock().unwrap().len(), before, "nothing sent");
+    }
+
+    #[tokio::test]
+    async fn inline_copy_into_candidate_stays_dirty_and_is_vendor_wrapped() {
+        let mut data = mock_junos_hello();
+        data.extend_from_slice(&mock_ok_reply("1"));
+        let transport = MockTransport::new(data);
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        session
+            .copy_config(
+                &ConfigLocation::Datastore(Datastore::Candidate),
+                &CopySource::Config("<system><host-name>r1</host-name></system>".to_string()),
+            )
+            .await
+            .expect("inline copy");
+
+        let sent = String::from_utf8_lossy(&written.lock().unwrap()).to_string();
+        assert!(
+            sent.contains("<configuration><system>"),
+            "Junos needs the <configuration> wrapper: {sent}"
+        );
+        assert!(
+            session.candidate_dirty(),
+            "candidate now differs from running"
+        );
+    }
+
+    #[tokio::test]
+    async fn inline_copy_source_rejects_a_document_declaration() {
+        let transport = MockTransport::new(mock_junos_hello());
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let before = written.lock().unwrap().len();
+        let err = session
+            .copy_config(
+                &ConfigLocation::Datastore(Datastore::Candidate),
+                &CopySource::Config("<?xml version=\"1.0\"?><system/>".to_string()),
+            )
+            .await
+            .expect_err("a second declaration mid-document is malformed");
+        assert!(err.to_string().contains("declaration"), "got {err}");
+        assert_eq!(written.lock().unwrap().len(), before, "nothing sent");
+    }
+
+    #[tokio::test]
+    async fn copy_config_gates_candidate_on_the_capability() {
+        // mock_device_hello advertises :candidate; a startup target does not
+        // exist there, so the startup gate must fire locally.
+        let transport = MockTransport::new(mock_device_hello());
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let before = written.lock().unwrap().len();
+        let err = session
+            .copy_config(
+                &ConfigLocation::Datastore(Datastore::Startup),
+                &CopySource::Datastore(Datastore::Running),
+            )
+            .await
+            .expect_err("startup is not advertised");
+        assert!(err.to_string().contains("startup"), "got {err}");
+        assert_eq!(written.lock().unwrap().len(), before, "nothing sent");
+    }
+
+    #[tokio::test]
+    async fn copy_config_marks_candidate_dirty_before_writing() {
+        // The reply never arrives. The flag must already be set, or a Junos
+        // close would skip the discard and leave the shared candidate replaced.
+        let transport = MockTransport::new(mock_device_hello());
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert!(!session.candidate_dirty());
+
+        let _ = session
+            .copy_config(
+                &ConfigLocation::Datastore(Datastore::Candidate),
+                &CopySource::Config("<system/>".to_string()),
+            )
+            .await;
+
+        assert!(
+            session.candidate_dirty(),
+            "candidate must be marked dirty even when the reply is lost"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancel_commit_requires_confirmed_commit_1_1() {
+        // mock_device_hello_with_confirmed_commit advertises 1.0 only.
+        let transport = MockTransport::new(mock_device_hello_with_confirmed_commit());
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let before = written.lock().unwrap().len();
+        let err = session
+            .cancel_commit(None)
+            .await
+            .expect_err("cancel-commit needs :confirmed-commit:1.1");
+        assert!(err.to_string().contains("cancel-commit"), "got {err}");
+        assert_eq!(written.lock().unwrap().len(), before, "nothing sent");
     }
 
     #[tokio::test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -22,6 +22,113 @@ pub enum Datastore {
     Startup,
 }
 
+/// Where a `<copy-config>` or `<delete-config>` reads from or writes to.
+///
+/// RFC 6241 lets these operations name either a datastore or a URL. The URL
+/// form needs the `:url` capability, which the session checks before sending.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ConfigLocation {
+    /// A NETCONF datastore.
+    Datastore(Datastore),
+    /// A URL, valid only if the device advertises `:url` and lists the scheme.
+    Url(String),
+}
+
+/// The `<target>` of a `<delete-config>` (RFC 6241 §7.4).
+///
+/// Narrower than [`ConfigLocation`] on purpose. The `config-target` choice in
+/// RFC 6241's `ietf-netconf` YANG module offers exactly two leaves for this
+/// operation:
+///
+/// ```text
+/// rpc delete-config {
+///   input { container target { choice config-target {
+///     mandatory true;
+///     leaf startup { if-feature startup; type empty; }
+///     leaf url     { if-feature url;     type inet:uri; }
+/// } } } }
+/// ```
+///
+/// Neither `running` nor `candidate` appears — the prose in §7.4 mentions only
+/// running, but the module is the normative list. Modelling it as its own type
+/// means a conforming server never has to reject what we send, and no runtime
+/// check is needed to enforce it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum DeleteTarget {
+    /// The startup datastore (requires `:startup`).
+    Startup,
+    /// A URL-backed configuration (requires `:url` and the scheme).
+    Url(String),
+}
+
+impl fmt::Display for DeleteTarget {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DeleteTarget::Startup => f.write_str("startup"),
+            DeleteTarget::Url(url) => write!(f, "url({url})"),
+        }
+    }
+}
+
+/// The `<source>` of a `<copy-config>` (RFC 6241 §7.3).
+///
+/// Wider than [`ConfigLocation`] because the RFC also allows a complete
+/// configuration inline: *"the configuration datastore to use as the source of
+/// the `<copy-config>` operation, or the `<config>` element containing the
+/// complete configuration to copy."* Targets have no such form, so they stay
+/// [`ConfigLocation`] and the inline case cannot be expressed where it would be
+/// invalid.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CopySource {
+    /// A NETCONF datastore.
+    Datastore(Datastore),
+    /// A URL, valid only if the device advertises `:url` and the scheme.
+    Url(String),
+    /// A complete configuration, inline. Replaces the target outright — this
+    /// is `copy-config`, not `edit-config`, so there is no merge semantics.
+    Config(String),
+}
+
+impl From<Datastore> for CopySource {
+    fn from(ds: Datastore) -> Self {
+        CopySource::Datastore(ds)
+    }
+}
+
+impl From<ConfigLocation> for CopySource {
+    fn from(loc: ConfigLocation) -> Self {
+        match loc {
+            ConfigLocation::Datastore(ds) => CopySource::Datastore(ds),
+            ConfigLocation::Url(u) => CopySource::Url(u),
+        }
+    }
+}
+
+impl fmt::Display for CopySource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CopySource::Datastore(ds) => f.write_str(ds.as_xml_tag()),
+            CopySource::Url(url) => write!(f, "url({url})"),
+            CopySource::Config(_) => f.write_str("inline-config"),
+        }
+    }
+}
+
+impl From<Datastore> for ConfigLocation {
+    fn from(ds: Datastore) -> Self {
+        ConfigLocation::Datastore(ds)
+    }
+}
+
+impl fmt::Display for ConfigLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ConfigLocation::Datastore(ds) => f.write_str(ds.as_xml_tag()),
+            ConfigLocation::Url(url) => write!(f, "url({url})"),
+        }
+    }
+}
+
 impl Datastore {
     /// Returns the XML tag name for this datastore.
     pub fn as_xml_tag(&self) -> &'static str {


### PR DESCRIPTION
Closes #71.

Three conspicuous holes in an otherwise complete RFC 6241 operations table.

## `cancel-commit` is the one that mattered

`netconf apply` uses confirmed-commit as its default write path, and the RFC's own way to abort a pending confirmed commit was missing — the only way out was letting the timer expire. Gated on `:confirmed-commit:1.1` (it does not exist in 1.0), with an optional `persist-id` so a commit issued with a `<persist>` token can be cancelled from another session.

## Types that can't express illegal requests

| type | variants | used for |
|---|---|---|
| `ConfigLocation` | `Datastore \| Url` | copy-config target |
| `CopySource` | `Datastore \| Url \| Config` | copy-config source — §7.3 allows a complete config inline |
| `DeleteTarget` | `Startup \| Url` | delete-config target |

`DeleteTarget` corrects an earlier revision that used `ConfigLocation`, refused `running` at runtime citing §7.4's prose, and declined to restrict `candidate` as unsubstantiated. **The prose is not the normative list** — `ietf-netconf`'s YANG module gives `delete-config` a `config-target` choice of exactly `startup` and `url`, where `copy-config` gets all four:

```
rpc delete-config { input { container target { choice config-target {
  mandatory true;
  leaf startup { if-feature startup; type empty; }
  leaf url     { if-feature url;     type inet:uri; }
} } } }
```

## Gates

- datastores on the capability their `if-feature` names — `:candidate`, `:startup`, `:writable-running` for a running **target**, nothing for a running source
- URLs on the **advertised scheme**, not just `:url` — it is published as `:url:1.0?scheme=http,ftp,file`, so matching the base URI alone would accept `file://` against a device offering `scheme=https`
- identical source and target refused locally, which §7.3 requires the server to reject with `invalid-value`

Every gate is asserted to write **zero bytes** on the refusal path.

## Candidate bookkeeping

The delicate part, and it took several passes. The flag encodes *"will `close_session` discard?"*, and on Junos the candidate is **shared** — so every wrong answer either strands changes or destroys another operator's work.

- preflight → **mark** → write. Marking earlier lets a call that never reaches the wire leave a shared candidate looking dirty; marking later loses a copy whose reply was lost.
- `send_rpc_raw`, not `send_rpc` — the latter runs its own keepalive probe that would land *after* the flag is set, reopening the same window.
- on success, a copy **between running and candidate in either direction** clears the flag: the datastores are then synchronized, and candidate→running is the same synchronization `commit` performs, which clears it for exactly this reason.

Each case has a test.

## A pre-existing hole, fixed

`validate_xml_fragment` accepted `<?xml ...?>` and `<!DOCTYPE ...>`. It wraps input in a synthetic `<_>` root, which makes a document declaration parse cleanly — but embedding it puts a second declaration mid-document. **`edit_config` shares this validator**, so this was reachable before this change. Both now reject it; rejecting DOCTYPE also closes the entity machinery behind XXE and expansion attacks. Relevant to #80.

## Also

- inline config is vendor-wrapped like `edit_config`'s payload — a bare `<system>` fragment needs Junos's `<configuration>` wrapper
- `persist-id` uses `escape_xml_text_exact`: XML 1.0 §2.11 normalizes a literal CR in text content to LF, so a token minted by another session would come back altered and cancellation would silently fail
- new `ProtocolError::InvalidValue` is shaped like `Xml(String)`, so the #66 error-size guard still passes (verified)

555 tests pass, clippy `-D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
