### PR TITLE
feat(rpc): support partial lock (RFC 5717)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ audit (RNC-SEC-001..006 + CI hardening). Merged via PR #27.
 | RFC 6242 | NETCONF over SSH | ✅ supported |
 | RFC 7589 | NETCONF over TLS | ✅ supported (feature flag `tls`) — **needs physical SRX or non-vSRX for TLS test** |
 | RFC 5277 | Event Notifications | ✅ supported — tested on Junos 24.4 vSRX (subscription + capability; interleave limited by device) |
-| RFC 5717 | Partial Lock RPC | 💡 planned |
+| RFC 5717 | Partial Lock RPC | ✅ supported — gated on `:partial-lock:1.0` |
 | RFC 8071 | NETCONF Call Home | 💡 planned |
 | RFC 6243 | With-defaults Capability | ✅ supported — mode gated on the device's `basic-mode`/`also-supported` list |
 | RFC 6022 | YANG Module for NETCONF Monitoring | 💡 planned |
@@ -552,6 +552,7 @@ let config = conn.get_config(Datastore::Running).await?;
 - **XML fragment validation** — user-provided RPC content is validated before insertion to prevent XML injection
 - **CommitUnknown detection** — distinguishes "commit failed" from "maybe committed, connection lost"
 - **Stale lock recovery** — `lock_or_kill_stale()` kills crashed sessions holding locks
+- **Partial locking (RFC 5717)** — lock only the subtrees an XPath names, **in `running`**. RFC 5717 does not cover `candidate` or `startup`, so this is not a substitute for the candidate lock the `netconf apply` flow takes. An indeterminate result poisons the session so a pooled connection is never recycled holding a lock it cannot release; a definitive rejection such as `lock-denied` does not, since a failed partial lock is atomic
 - **Framing mismatch detection** — catches firmware bugs where devices send wrong framing
 - **IPv6 support** — connect to devices using bracket notation (`[::1]:830`) or bare IPv6 addresses
 
@@ -623,6 +624,7 @@ match result {
 | `commit` | §8.4 | Done |
 | `confirmed-commit` | §8.4 | Done |
 | `cancel-commit` | §8.4.4.1 | Done |
+| `partial-lock` / `partial-unlock` | RFC 5717 | Done |
 | `validate` | §8.6 | Done |
 | `discard-changes` | §8.3 | Done |
 

--- a/src/capability.rs
+++ b/src/capability.rs
@@ -37,6 +37,8 @@ pub mod uri {
     pub const XPATH: &str = "urn:ietf:params:netconf:capability:xpath:1.0";
     /// URL capability (RFC 6241 §8.8) — `<url>` as a config source or target.
     pub const URL: &str = "urn:ietf:params:netconf:capability:url:1.0";
+    /// Partial lock capability (RFC 5717).
+    pub const PARTIAL_LOCK: &str = "urn:ietf:params:netconf:capability:partial-lock:1.0";
     /// With-defaults capability (RFC 6243).
     pub const WITH_DEFAULTS: &str = "urn:ietf:params:netconf:capability:with-defaults:1.0";
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -20,7 +20,7 @@ use crate::transport::ssh::{
 #[cfg(feature = "tls")]
 use crate::transport::tls::{TlsConfig, TlsTransport};
 use crate::transport::Transport;
-use crate::types::{ConfigLocation, CopySource, DeleteTarget, WithDefaults};
+use crate::types::{ConfigLocation, CopySource, DeleteTarget, PartialLock, WithDefaults};
 use crate::types::{
     Datastore, DefaultOperation, ErrorOption, LoadAction, LoadFormat, OpenConfigurationMode,
     TestOption,
@@ -794,6 +794,32 @@ impl Client {
         self.session
             .copy_config_with_defaults(target, source, mode)
             .await
+    }
+
+    /// Lock only the subtrees named by XPath expressions (RFC 5717).
+    ///
+    /// ```no_run
+    /// # use rustnetconf::Client;
+    /// # async fn demo(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let lock = client.partial_lock(
+    ///     &["/if:interfaces/if:interface[if:name='ge-0/0/0']".to_string()],
+    ///     &[("if".to_string(), "urn:ietf:params:xml:ns:yang:ietf-interfaces".to_string())],
+    /// ).await?;
+    /// // ... edit only that subtree ...
+    /// client.partial_unlock(lock.lock_id).await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn partial_lock(
+        &mut self,
+        selects: &[String],
+        namespaces: &[(String, String)],
+    ) -> Result<PartialLock, NetconfError> {
+        self.session.partial_lock(selects, namespaces).await
+    }
+
+    /// Release a partial lock (RFC 5717).
+    pub async fn partial_unlock(&mut self, lock_id: u32) -> Result<(), NetconfError> {
+        self.session.partial_unlock(lock_id).await
     }
 
     /// The `<with-defaults>` modes this device advertises (empty if unsupported).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use rpc::RpcErrorInfo;
 pub use ssh_config::{ResolvedHost, SshConfigError, SshConfigFile};
 pub use types::{
     ConfigLocation, CopySource, Datastore, DefaultOperation, DeleteTarget, ErrorOption, LoadAction,
-    LoadFormat, OpenConfigurationMode, TestOption, WithDefaults,
+    LoadFormat, LockedNode, OpenConfigurationMode, PartialLock, TestOption, WithDefaults,
 };
 
 #[cfg(feature = "tls")]

--- a/src/rpc/filter.rs
+++ b/src/rpc/filter.rs
@@ -77,6 +77,103 @@ impl Default for SubtreeFilter {
     }
 }
 
+/// Validate and render a set of `xmlns:` declarations for one element.
+///
+/// Shared by the XPath filter and by RFC 5717 partial-lock, which both let a
+/// caller bind prefixes used in an XPath expression and therefore share every
+/// way of getting that wrong.
+///
+/// `envelope_prefix` is the element-name prefix the declarations will sit
+/// beside (`"nc:"` or `""`). Binding it is refused: an `xmlns:` declaration
+/// applies to the element it sits on *including that element's own name*, so
+/// rebinding the envelope prefix would silently move the element out of the
+/// NETCONF namespace.
+///
+/// `what` names the caller in error messages.
+pub(crate) fn render_namespace_bindings(
+    namespaces: &[(String, String)],
+    envelope_prefix: &str,
+    what: &str,
+) -> Result<String, NetconfError> {
+    let envelope = envelope_prefix.strip_suffix(':').unwrap_or(envelope_prefix);
+
+    // Emitting the same prefix twice produces duplicate attributes on one
+    // element, which is malformed XML - the server cannot execute the request at
+    // all. Callers combining bindings for several expressions hit this
+    // naturally, so an identical repeat is folded away; a prefix bound to two
+    // different URIs is a genuine ambiguity and is refused rather than silently
+    // resolved to whichever came first.
+    let mut seen: Vec<(&str, &str)> = Vec::new();
+    let mut deduped: Vec<(&String, &String)> = Vec::new();
+    for (p, uri) in namespaces {
+        match seen.iter().find(|(sp, _)| *sp == p.as_str()) {
+            Some((_, existing)) if *existing == uri.as_str() => continue,
+            Some((_, existing)) => {
+                return Err(xml_err(format!(
+                    "{what} binds the prefix `{p}` to two different URIs: `{existing}` and `{uri}`"
+                )));
+            }
+            None => {
+                seen.push((p.as_str(), uri.as_str()));
+                deduped.push((p, uri));
+            }
+        }
+    }
+
+    let mut xmlns = String::new();
+    for (p, uri) in deduped {
+        if !envelope.is_empty() && p == envelope {
+            return Err(xml_err(format!(
+                "{what} cannot bind the prefix `{p}`: it is the NETCONF envelope \
+                 prefix, and rebinding it would move the element out of the NETCONF \
+                 namespace"
+            )));
+        }
+        if !is_valid_ncname(p) {
+            return Err(xml_err(format!(
+                "{what} namespace prefix `{p}` is not a valid XML name"
+            )));
+        }
+        // Namespaces in XML §3 reserves these two prefixes.
+        if p == "xmlns" {
+            return Err(xml_err(
+                "the `xmlns` prefix is reserved and cannot be declared".to_string(),
+            ));
+        }
+        if p == "xml" && uri != XML_NAMESPACE_URI {
+            return Err(xml_err(format!(
+                "the `xml` prefix may only be bound to `{XML_NAMESPACE_URI}`"
+            )));
+        }
+        // The reciprocal rules: the reserved URIs are equally restricted, not
+        // just the reserved prefixes.
+        if p != "xml" && uri == XML_NAMESPACE_URI {
+            return Err(xml_err(format!(
+                "`{XML_NAMESPACE_URI}` may only be bound to the `xml` prefix, not `{p}`"
+            )));
+        }
+        if uri == XMLNS_NAMESPACE_URI {
+            return Err(xml_err(format!(
+                "`{XMLNS_NAMESPACE_URI}` is reserved and cannot be bound to any prefix, \
+                 including `{p}`"
+            )));
+        }
+        if uri.is_empty() {
+            return Err(xml_err(format!(
+                "{what} namespace prefix `{p}` cannot be bound to an empty URI"
+            )));
+        }
+        let uri_esc = escape_xml_attr_preserving_ws(uri).ok_or_else(|| {
+            xml_err(format!(
+                "namespace URI for prefix `{p}` contains a control character that XML 1.0 \
+                 cannot represent"
+            ))
+        })?;
+        xmlns.push_str(&format!(" xmlns:{}=\"{}\"", escape_xml_attr(p), uri_esc));
+    }
+    Ok(xmlns)
+}
+
 /// Builder for an XPath filter (RFC 6241 §6.4).
 ///
 /// An XPath filter is expressed as attributes on `<filter>` rather than as
@@ -163,58 +260,7 @@ impl XPathFilter {
     /// Also rejects prefixes that are not usable as XML names, which would
     /// produce malformed output rather than a wrong namespace.
     pub(crate) fn to_filter_element(&self, prefix: &str) -> Result<String, NetconfError> {
-        let envelope = prefix.strip_suffix(':').unwrap_or(prefix);
-        let mut xmlns = String::new();
-        for (p, uri) in &self.namespaces {
-            if !envelope.is_empty() && p == envelope {
-                return Err(xml_err(format!(
-                    "XPath filter cannot bind the prefix `{p}`: it is the NETCONF \
-                     envelope prefix, and rebinding it would move <{p}:filter> out \
-                     of the NETCONF namespace"
-                )));
-            }
-            if !is_valid_ncname(p) {
-                return Err(xml_err(format!(
-                    "XPath filter namespace prefix `{p}` is not a valid XML name"
-                )));
-            }
-            // Namespaces in XML §3 reserves these two prefixes.
-            if p == "xmlns" {
-                return Err(xml_err(
-                    "the `xmlns` prefix is reserved and cannot be declared".to_string(),
-                ));
-            }
-            if p == "xml" && uri != XML_NAMESPACE_URI {
-                return Err(xml_err(format!(
-                    "the `xml` prefix may only be bound to `{XML_NAMESPACE_URI}`"
-                )));
-            }
-            // The reciprocal rules: the reserved URIs are equally restricted,
-            // not just the reserved prefixes.
-            if p != "xml" && uri == XML_NAMESPACE_URI {
-                return Err(xml_err(format!(
-                    "`{XML_NAMESPACE_URI}` may only be bound to the `xml` prefix, not `{p}`"
-                )));
-            }
-            if uri == XMLNS_NAMESPACE_URI {
-                return Err(xml_err(format!(
-                    "`{XMLNS_NAMESPACE_URI}` is reserved and cannot be bound to any \
-                     prefix, including `{p}`"
-                )));
-            }
-            if uri.is_empty() {
-                return Err(xml_err(format!(
-                    "XPath filter namespace prefix `{p}` cannot be bound to an empty URI"
-                )));
-            }
-            let uri_esc = escape_xml_attr_preserving_ws(uri).ok_or_else(|| {
-                xml_err(format!(
-                    "namespace URI for prefix `{p}` contains a control character that \
-                     XML 1.0 cannot represent"
-                ))
-            })?;
-            xmlns.push_str(&format!(" xmlns:{}=\"{}\"", escape_xml_attr(p), uri_esc));
-        }
+        let xmlns = render_namespace_bindings(&self.namespaces, prefix, "XPath filter")?;
         let select = escape_xml_attr_preserving_ws(&self.select).ok_or_else(|| {
             xml_err(
                 "XPath select expression contains a control character that XML 1.0 \

--- a/src/rpc/operations.rs
+++ b/src/rpc/operations.rs
@@ -6,9 +6,11 @@
 //! All RPCs use a prefixed namespace (`nc:`) instead of a default namespace
 //! to avoid `xmlns=""` on child elements, which Junos 24.4 rejects.
 
-use crate::error::NetconfError;
+use crate::error::{NetconfError, ProtocolError};
 use crate::rpc::filter::XPathFilter;
-use crate::types::{ConfigLocation, CopySource, DeleteTarget, WithDefaults};
+use crate::types::{
+    ConfigLocation, CopySource, DeleteTarget, LockedNode, PartialLock, WithDefaults,
+};
 use crate::types::{
     Datastore, DefaultOperation, ErrorOption, LoadAction, LoadFormat, OpenConfigurationMode,
     TestOption,
@@ -465,6 +467,328 @@ pub fn cancel_commit_xml(
     ))
 }
 
+/// RFC 5717's namespace for partial locking.
+const PARTIAL_LOCK_NS: &str = "urn:ietf:params:xml:ns:netconf:partial-lock:1.0";
+
+/// The base NETCONF XML namespace, which a reply's envelope normally declares
+/// as the default. A device that omits RFC 5717's namespace on its output
+/// elements leaves them inheriting this one.
+///
+/// There is exactly one. NETCONF 1.1 changed the capability URI
+/// (`urn:ietf:params:netconf:base:1.1`) and the framing, but RFC 6241 keeps the
+/// protocol XML namespace at `:base:1.0`; a `…xml:ns:netconf:base:1.1` does not
+/// exist, and accepting it would let a foreign element be read as the lock id.
+const BASE_XML_NS: &str = "urn:ietf:params:xml:ns:netconf:base:1.0";
+
+/// Generate a `<partial-lock>` RPC request (RFC 5717 §2.4.1).
+///
+/// Each `select` is an XPath expression naming a subtree to lock. Prefixes used
+/// in those expressions must be bound via `namespaces`; the declarations land on
+/// `<partial-lock>` itself, where the expressions can see them.
+///
+/// The expressions are element *text* here, unlike the XPath filter's `select`
+/// attribute, so they use the text escaper.
+pub fn partial_lock_xml(
+    message_id: &str,
+    selects: &[String],
+    namespaces: &[(String, String)],
+) -> Result<String, NetconfError> {
+    if selects.is_empty() {
+        return Err(NetconfError::Protocol(ProtocolError::InvalidValue(
+            "<partial-lock> requires at least one <select> expression".to_string(),
+        )));
+    }
+    // The element is unprefixed (it carries PARTIAL_LOCK_NS as its default
+    // namespace), so there is no envelope prefix a binding could shadow.
+    let xmlns = crate::rpc::filter::render_namespace_bindings(namespaces, "", "partial-lock")?;
+
+    let mut body = String::new();
+    for select in selects {
+        let escaped = escape_xml_text_exact(select).ok_or_else(|| {
+            NetconfError::Protocol(ProtocolError::Xml(
+                "partial-lock select expression contains a character XML 1.0 cannot \
+                 represent"
+                    .to_string(),
+            ))
+        })?;
+        body.push_str(&format!("\n    <select>{escaped}</select>"));
+    }
+
+    let safe_id = escape_xml_attr(message_id);
+    Ok(format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">
+  <partial-lock xmlns="{PARTIAL_LOCK_NS}"{xmlns}>{body}
+  </partial-lock>
+</rpc>"#
+    ))
+}
+
+/// Parse a `<partial-lock>` reply payload into a [`PartialLock`].
+///
+/// Deliberately crate-private. It runs on a payload `parse_rpc_reply` has
+/// already validated — undeclared prefixes rejected, entity references
+/// resolved, lexical checks applied. Exposed on its own it would accept input
+/// that validation would have caught: `<lock-id>7&bogus;</lock-id>` reads as 7
+/// once the unresolvable reference is dropped, and `<v:lock-id>` with an
+/// undeclared `v` looks unqualified and so passes the namespace check.
+pub(crate) fn parse_partial_lock_reply(payload: &str) -> Result<PartialLock, NetconfError> {
+    use quick_xml::events::Event;
+    use quick_xml::Reader;
+
+    let wrapped = format!("<_>{payload}</_>");
+    let mut reader = Reader::from_str(&wrapped);
+    reader.config_mut().check_end_names = true;
+
+    let mut lock_id: Option<u32> = None;
+    let mut locked_nodes: Vec<LockedNode> = Vec::new();
+    let mut current: Option<&'static str> = None;
+    // Namespace declarations in scope, as a stack: a `<locked-node>` resolves
+    // its prefixes against whatever is declared on it or on an enclosing
+    // element of the payload.
+    let mut scopes: Vec<Vec<(Option<String>, String)>> = Vec::new();
+    // Accumulated across Text and GeneralRef: this quick-xml streams entity
+    // references as their own events, so a loop reading only Text silently
+    // truncates any value containing one (see `crate::xml_entity`). A locked
+    // node path with an escaped `&` would otherwise come back cut in half.
+    let mut text_buf = String::new();
+    let mut buf = Vec::new();
+
+    /// Namespace declarations on one start tag: `(Some(prefix), uri)` for a
+    /// prefixed binding, `(None, uri)` for the default `xmlns`.
+    ///
+    /// Values go through the reply parser's own `decode_attribute`, which
+    /// unescapes and validates them. Reading `attr.value` raw would store
+    /// `urn:x?a=1&amp;b=2` instead of the actual URI, leaving the binding wrong
+    /// and the prefixed path unresolvable.
+    fn bindings_of(
+        e: &quick_xml::events::BytesStart<'_>,
+    ) -> Result<Vec<(Option<String>, String)>, NetconfError> {
+        let mut out = Vec::new();
+        for attr in e.attributes().with_checks(true) {
+            // `with_checks(true)` reports duplicate attributes and other
+            // malformedness. Swallowing that would let this public helper
+            // return a lock from a document no conforming parser would accept.
+            let attr = attr.map_err(|e| {
+                NetconfError::Protocol(ProtocolError::Xml(format!(
+                    "partial-lock reply has an invalid attribute: {e}"
+                )))
+            })?;
+            let key = attr.key.as_ref();
+            let prefix = if key == b"xmlns" {
+                None
+            } else if let Some(p) = key.strip_prefix(b"xmlns:") {
+                match std::str::from_utf8(p) {
+                    Ok(p) => Some(p.to_string()),
+                    Err(_) => continue,
+                }
+            } else {
+                continue;
+            };
+            let value = crate::rpc::reply::lexical::decode_attribute(
+                attr.value.as_ref(),
+                "namespace declaration value",
+            )
+            .map_err(|e| NetconfError::Protocol(ProtocolError::Xml(e.to_string())))?;
+            out.push((prefix, value));
+        }
+        Ok(out)
+    }
+
+    /// Resolve an element's namespace against the declarations in scope.
+    fn resolve_ns(raw_name: &[u8], scopes: &[Vec<(Option<String>, String)>]) -> Option<String> {
+        let prefix = raw_name
+            .iter()
+            .position(|b| *b == b':')
+            .and_then(|i| std::str::from_utf8(&raw_name[..i]).ok())
+            .map(|s| s.to_string());
+        // `xml` is bound implicitly and never appears in a declaration, so it
+        // must be resolved here; otherwise <xml:lock-id> looks unqualified and
+        // would be wrongly accepted.
+        if prefix.as_deref() == Some("xml") {
+            return Some("http://www.w3.org/XML/1998/namespace".to_string());
+        }
+
+        for scope in scopes.iter().rev() {
+            for (p, uri) in scope {
+                if p.as_deref() == prefix.as_deref() {
+                    // `xmlns=""` is an *undeclaration* (Namespaces in XML §6.2):
+                    // the element is in NO namespace, not in one whose URI is
+                    // empty. Returning Some("") would reject a valid unqualified
+                    // <lock-id> — the costly direction, since the server has
+                    // already granted the lock and the caller would be unable to
+                    // release it.
+                    return if uri.is_empty() {
+                        None
+                    } else {
+                        Some(uri.clone())
+                    };
+                }
+            }
+        }
+        None
+    }
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(_)) if current.is_some() => {
+                return Err(NetconfError::Protocol(ProtocolError::Xml(
+                    "partial-lock reply has a nested element inside a scalar field".to_string(),
+                )));
+            }
+            Ok(Event::Start(e)) => {
+                scopes.push(bindings_of(&e)?);
+                // Match on the *expanded* name. Matching the local name alone
+                // would accept a `<v:lock-id>` from an unrelated namespace and
+                // hand back a foreign id as a successful lock. An unqualified
+                // element is accepted as well: RFC 5717 puts these in its own
+                // namespace, but servers that omit it are common enough that
+                // refusing them outright would be less useful than the risk it
+                // removes.
+                let ns = resolve_ns(e.name().as_ref(), &scopes);
+                let in_scope = match ns.as_deref() {
+                    Some(PARTIAL_LOCK_NS) => true,
+                    // No namespace, or the base namespace inherited from the
+                    // reply envelope. Devices that omit RFC 5717's namespace on
+                    // their output elements are common, and their `<lock-id>`
+                    // arrives carrying whatever `<rpc-reply>` declared as the
+                    // default. Rejecting that would error out *after* the server
+                    // granted the lock, leaving the caller unable to release it
+                    // — much worse than the risk of accepting a stray element.
+                    None => true,
+                    Some(BASE_XML_NS) => true,
+                    // A genuinely foreign namespace (a vendor extension, say) is
+                    // still not RFC 5717 output.
+                    Some(_) => false,
+                };
+                current = if in_scope {
+                    match e.local_name().as_ref() {
+                        b"lock-id" => Some("lock-id"),
+                        b"locked-node" => Some("locked-node"),
+                        _ => None,
+                    }
+                } else {
+                    None
+                };
+                text_buf.clear();
+            }
+            Ok(Event::Empty(_)) if current.is_some() => {
+                // `<lock-id>1<meta/>2</lock-id>` is well-formed but not valid
+                // here. Ignoring the child would leave `current` set and
+                // concatenate the surrounding text into "12" — a lock id the
+                // device never sent.
+                return Err(NetconfError::Protocol(ProtocolError::Xml(
+                    "partial-lock reply has a nested element inside a scalar field".to_string(),
+                )));
+            }
+            Ok(Event::Empty(_)) => {}
+            Ok(Event::Text(ref text)) if current.is_some() => {
+                let decoded = text.decode().map_err(|e| {
+                    NetconfError::Protocol(ProtocolError::Xml(format!(
+                        "partial-lock reply text is not decodable: {e}"
+                    )))
+                })?;
+                text_buf.push_str(&decoded);
+            }
+            Ok(Event::CData(ref cdata)) if current.is_some() => {
+                let decoded = cdata.decode().map_err(|e| {
+                    NetconfError::Protocol(ProtocolError::Xml(format!(
+                        "partial-lock reply CDATA is not decodable: {e}"
+                    )))
+                })?;
+                text_buf.push_str(&decoded);
+            }
+            Ok(Event::GeneralRef(ref entity)) if current.is_some() => {
+                if let Some(resolved) = crate::xml_entity::resolve_entity_ref(entity) {
+                    text_buf.push_str(&resolved);
+                }
+            }
+            Ok(Event::End(_)) => {
+                let text = text_buf.trim().to_string();
+                match current {
+                    Some("lock-id") if !text.is_empty() => {
+                        // RFC 5717 permits exactly one. Taking the last would
+                        // pick arbitrarily between them, and `partial_unlock`
+                        // would then release a lock we do not hold while the
+                        // real one stays held.
+                        if lock_id.is_some() {
+                            return Err(NetconfError::Protocol(ProtocolError::Xml(
+                                "partial-lock reply carried more than one <lock-id>".to_string(),
+                            )));
+                        }
+                        lock_id = Some(text.parse::<u32>().map_err(|_| {
+                            // Bounded: the value is device-controlled and the
+                            // reply cap is 100 MB, so formatting it whole would
+                            // duplicate an arbitrarily large allocation into an
+                            // error string and a log line.
+                            let preview: String = text.chars().take(32).collect();
+                            NetconfError::Protocol(ProtocolError::Xml(format!(
+                                "<lock-id> is not a u32 (first 32 chars: {preview:?})"
+                            )))
+                        })?);
+                    }
+                    Some("locked-node") if !text.is_empty() => {
+                        // Innermost binding wins for a repeated prefix. Only
+                        // prefixed bindings are useful to a caller resolving the
+                        // path, so the default xmlns is not reported.
+                        let mut namespaces: Vec<(String, String)> = Vec::new();
+                        for scope in scopes.iter() {
+                            for (p, uri) in scope {
+                                let Some(p) = p else { continue };
+                                match namespaces.iter_mut().find(|(np, _)| np == p) {
+                                    Some(entry) => entry.1 = uri.clone(),
+                                    None => namespaces.push((p.clone(), uri.clone())),
+                                }
+                            }
+                        }
+                        locked_nodes.push(LockedNode {
+                            path: text,
+                            namespaces,
+                        });
+                    }
+                    _ => {}
+                }
+                current = None;
+                text_buf.clear();
+                scopes.pop();
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(NetconfError::Protocol(ProtocolError::Xml(format!(
+                    "partial-lock reply is not well-formed: {e}"
+                ))));
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    let lock_id = lock_id.ok_or_else(|| {
+        NetconfError::Protocol(ProtocolError::Xml(
+            "<partial-lock> reply carried no <lock-id>; the lock cannot be released \
+             without it"
+                .to_string(),
+        ))
+    })?;
+    Ok(PartialLock {
+        lock_id,
+        locked_nodes,
+    })
+}
+
+/// Generate a `<partial-unlock>` RPC request (RFC 5717 §2.4.2).
+pub fn partial_unlock_xml(message_id: &str, lock_id: u32) -> String {
+    let safe_id = escape_xml_attr(message_id);
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<rpc xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="{safe_id}">
+  <partial-unlock xmlns="{PARTIAL_LOCK_NS}">
+    <lock-id>{lock_id}</lock-id>
+  </partial-unlock>
+</rpc>"#
+    )
+}
+
 /// Generate a `<commit>` RPC request.
 pub fn commit_xml(message_id: &str) -> String {
     let safe_id = escape_xml_attr(message_id);
@@ -870,6 +1194,238 @@ mod tests {
             &CopySource::Datastore(Datastore::Running),
         );
         assert!(!xml.contains("with-defaults"), "got {xml}");
+    }
+
+    #[test]
+    fn test_partial_lock_emits_selects_and_namespaces() {
+        let xml = partial_lock_xml(
+            "1",
+            &["/if:interfaces/if:interface[if:name='ge-0/0/0']".to_string()],
+            &[(
+                "if".to_string(),
+                "urn:ietf:params:xml:ns:yang:ietf-interfaces".to_string(),
+            )],
+        )
+        .unwrap();
+        assert!(
+            xml.contains(
+                r#"<partial-lock xmlns="urn:ietf:params:xml:ns:netconf:partial-lock:1.0""#
+            ),
+            "got {xml}"
+        );
+        assert!(
+            xml.contains(r#"xmlns:if="urn:ietf:params:xml:ns:yang:ietf-interfaces""#),
+            "got {xml}"
+        );
+        assert!(xml.contains("<select>/if:interfaces"), "got {xml}");
+    }
+
+    #[test]
+    fn test_partial_lock_escapes_select_as_text() {
+        // element text, not an attribute - so &, < and > matter and quotes do not
+        let xml =
+            partial_lock_xml("2", &["/x[a='1' and b<'2' and c='&']".to_string()], &[]).unwrap();
+        assert!(xml.contains("&lt;"), "got {xml}");
+        assert!(xml.contains("&amp;"), "got {xml}");
+    }
+
+    #[test]
+    fn test_partial_lock_requires_at_least_one_select() {
+        let err = partial_lock_xml("3", &[], &[]).unwrap_err();
+        assert!(err.to_string().contains("at least one"), "got {err}");
+    }
+
+    #[test]
+    fn test_partial_lock_rejects_bad_namespace_bindings() {
+        // shared validation with the XPath filter
+        assert!(partial_lock_xml(
+            "4",
+            &["/x".to_string()],
+            &[("xmlns".into(), "urn:x".into())]
+        )
+        .is_err());
+        assert!(partial_lock_xml(
+            "4",
+            &["/x".to_string()],
+            &[("a\u{b2}".into(), "urn:x".into())]
+        )
+        .is_err());
+        assert!(partial_lock_xml("4", &["/x".to_string()], &[("a".into(), "".into())]).is_err());
+    }
+
+    #[test]
+    fn test_partial_unlock_carries_the_lock_id() {
+        let xml = partial_unlock_xml("5", 127);
+        assert!(xml.contains("<lock-id>127</lock-id>"), "got {xml}");
+        assert!(
+            xml.contains(
+                r#"<partial-unlock xmlns="urn:ietf:params:xml:ns:netconf:partial-lock:1.0">"#
+            ),
+            "got {xml}"
+        );
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply() {
+        let reply = r#"<lock-id xmlns="urn:ietf:params:xml:ns:netconf:partial-lock:1.0">127</lock-id>
+<locked-node xmlns="urn:ietf:params:xml:ns:netconf:partial-lock:1.0">/interfaces/interface[name='eth0']</locked-node>"#;
+        let got = parse_partial_lock_reply(reply).unwrap();
+        assert_eq!(got.lock_id, 127);
+        assert_eq!(got.locked_nodes.len(), 1);
+        assert!(got.locked_nodes[0].path.contains("eth0"));
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_stitches_entities() {
+        // Entities stream as their own events; a naive loop truncates here.
+        let reply = r#"<lock-id>7</lock-id><locked-node>/a[n='x&amp;y']</locked-node>"#;
+        let got = parse_partial_lock_reply(reply).unwrap();
+        assert_eq!(got.lock_id, 7);
+        assert_eq!(
+            got.locked_nodes[0].path, "/a[n='x&y']",
+            "entity must be stitched back, not dropped"
+        );
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_captures_prefix_bindings() {
+        // The server may use its own prefixes; the path is unusable without them.
+        let reply = r#"<lock-id>9</lock-id><locked-node xmlns:x="urn:example:if">/x:interfaces</locked-node>"#;
+        let got = parse_partial_lock_reply(reply).unwrap();
+        assert_eq!(got.locked_nodes[0].path, "/x:interfaces");
+        assert_eq!(
+            got.locked_nodes[0].namespaces,
+            vec![("x".to_string(), "urn:example:if".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_partial_lock_folds_identical_duplicate_prefixes() {
+        // Combining bindings for several selects naturally repeats them; a
+        // duplicate xmlns attribute would be malformed XML.
+        let xml = partial_lock_xml(
+            "6",
+            &["/a:x".to_string(), "/a:y".to_string()],
+            &[
+                ("a".to_string(), "urn:a".to_string()),
+                ("a".to_string(), "urn:a".to_string()),
+            ],
+        )
+        .unwrap();
+        assert_eq!(xml.matches("xmlns:a=").count(), 1, "duplicate xmlns: {xml}");
+    }
+
+    #[test]
+    fn test_partial_lock_rejects_conflicting_prefix_bindings() {
+        let err = partial_lock_xml(
+            "7",
+            &["/a:x".to_string()],
+            &[
+                ("a".to_string(), "urn:one".to_string()),
+                ("a".to_string(), "urn:two".to_string()),
+            ],
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("two different URIs"), "got {err}");
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_unescapes_namespace_uris() {
+        let reply = r#"<lock-id>3</lock-id><locked-node xmlns:x="urn:example?a=1&amp;b=2">/x:i</locked-node>"#;
+        let got = parse_partial_lock_reply(reply).unwrap();
+        assert_eq!(
+            got.locked_nodes[0].namespaces,
+            vec![("x".to_string(), "urn:example?a=1&b=2".to_string())],
+            "the stored URI must be the real one, not the escaped source"
+        );
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_ignores_foreign_namespaces() {
+        // A <v:lock-id> from an unrelated namespace is not RFC 5717 output;
+        // accepting it would return someone else's id as our lock.
+        let reply = r#"<v:lock-id xmlns:v="urn:vendor:private">999</v:lock-id>"#;
+        let err = parse_partial_lock_reply(reply).unwrap_err();
+        assert!(err.to_string().contains("lock-id"), "got {err}");
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_accepts_the_rfc_namespace_prefixed() {
+        let reply = r#"<pl:lock-id xmlns:pl="urn:ietf:params:xml:ns:netconf:partial-lock:1.0">5</pl:lock-id>"#;
+        assert_eq!(parse_partial_lock_reply(reply).unwrap().lock_id, 5);
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_accepts_undeclared_default_namespace() {
+        // xmlns="" is an undeclaration: the element is in NO namespace, the
+        // accepted unqualified form. Rejecting it would error out after the
+        // server had already granted the lock.
+        let reply = r#"<lock-id xmlns="">7</lock-id>"#;
+        assert_eq!(parse_partial_lock_reply(reply).unwrap().lock_id, 7);
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_rejects_the_implicit_xml_prefix() {
+        assert!(parse_partial_lock_reply("<xml:lock-id>7</xml:lock-id>").is_err());
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_default_namespace_scopes_correctly() {
+        let ok = r#"<x xmlns="urn:ietf:params:xml:ns:netconf:partial-lock:1.0"><lock-id>4</lock-id></x>"#;
+        assert_eq!(parse_partial_lock_reply(ok).unwrap().lock_id, 4);
+        let foreign = r#"<x xmlns="urn:vendor:private"><lock-id>4</lock-id></x>"#;
+        assert!(parse_partial_lock_reply(foreign).is_err());
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_accepts_inherited_base_namespace() {
+        let reply =
+            r#"<x xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"><lock-id>7</lock-id></x>"#;
+        assert_eq!(parse_partial_lock_reply(reply).unwrap().lock_id, 7);
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_rejects_malformed_attributes() {
+        // Duplicate xmlns:x is not well-formed; returning a lock from it would
+        // accept a document no conforming parser would.
+        let reply = r#"<lock-id xmlns:x="urn:a" xmlns:x="urn:b">7</lock-id>"#;
+        assert!(parse_partial_lock_reply(reply).is_err());
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_rejects_duplicate_lock_ids() {
+        let reply = "<lock-id>1</lock-id><lock-id>2</lock-id>";
+        let err = parse_partial_lock_reply(reply).unwrap_err();
+        assert!(err.to_string().contains("more than one"), "got {err}");
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_rejects_mixed_content() {
+        // Well-formed but schema-invalid; concatenating would invent id 12.
+        assert!(parse_partial_lock_reply("<lock-id>1<meta/>2</lock-id>").is_err());
+        assert!(parse_partial_lock_reply("<lock-id>1<m>x</m>2</lock-id>").is_err());
+        assert!(parse_partial_lock_reply("<locked-node>/a<m/>/b</locked-node>").is_err());
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_rejects_the_invented_base_1_1_namespace() {
+        // ...xml:ns:netconf:base:1.1 is not a real namespace; NETCONF 1.1 keeps
+        // the protocol namespace at :base:1.0.
+        let reply =
+            r#"<x xmlns="urn:ietf:params:xml:ns:netconf:base:1.1"><lock-id>9</lock-id></x>"#;
+        assert!(parse_partial_lock_reply(reply).is_err());
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_accepts_cdata() {
+        let reply = "<lock-id><![CDATA[7]]></lock-id>";
+        assert_eq!(parse_partial_lock_reply(reply).unwrap().lock_id, 7);
+    }
+
+    #[test]
+    fn test_parse_partial_lock_reply_without_lock_id_is_an_error() {
+        let err = parse_partial_lock_reply("<locked-node>/a</locked-node>").unwrap_err();
+        assert!(err.to_string().contains("lock-id"), "got {err}");
     }
 
     #[test]

--- a/src/rpc/reply/lexical.rs
+++ b/src/rpc/reply/lexical.rs
@@ -296,7 +296,7 @@ pub(super) fn validate_xml_chars(value: &str, field: &'static str) -> Result<(),
     }
 }
 
-pub(super) fn decode_attribute(raw: &[u8], field: &'static str) -> Result<String, RpcError> {
+pub(crate) fn decode_attribute(raw: &[u8], field: &'static str) -> Result<String, RpcError> {
     validate_attribute_lexical(raw)?;
     let raw = str::from_utf8(raw).map_err(|_| parse_error(format!("invalid {field} encoding")))?;
     let normalized = normalize_literal_attribute_whitespace(raw);

--- a/src/session.rs
+++ b/src/session.rs
@@ -36,7 +36,7 @@ use crate::rpc::RpcReply;
 use crate::transport::Transport;
 use crate::types::{
     ConfigLocation, CopySource, Datastore, DefaultOperation, DeleteTarget, ErrorOption, LoadAction,
-    LoadFormat, OpenConfigurationMode, TestOption, WithDefaults,
+    LoadFormat, OpenConfigurationMode, PartialLock, TestOption, WithDefaults,
 };
 use crate::vendor::{self, CloseSequence, VendorProfile};
 
@@ -100,6 +100,9 @@ pub struct Session {
     /// Maximum number of bytes that may accumulate in `read_buffer` before
     /// the read is aborted. Defaults to [`MAX_READ_BUFFER`].
     max_read_buffer: usize,
+    /// Set before a `<partial-lock>` is written and cleared only once a
+    /// `lock-id` has been parsed from the reply. See [`Session::is_alive`].
+    partial_lock_uncertain: bool,
     /// True if this session may have left uncommitted changes in the shared
     /// candidate datastore. Used to decide whether to send `<discard-changes/>`
     /// on close.
@@ -130,6 +133,7 @@ impl Session {
             has_subscription: false,
             rpc_timeout: None,
             max_read_buffer: MAX_READ_BUFFER,
+            partial_lock_uncertain: false,
             candidate_dirty: false,
         }
     }
@@ -368,7 +372,7 @@ impl Session {
     ///
     /// Fast in-memory check — does not send any RPC.
     pub fn is_alive(&self) -> bool {
-        self.state == SessionState::Established
+        self.state == SessionState::Established && !self.partial_lock_uncertain
     }
 
     /// Probe the session by sending a lightweight RPC.
@@ -1044,6 +1048,137 @@ impl Session {
         let msg_id = self.next_message_id();
         let xml = operations::lock_xml(&msg_id, target);
         self.send_rpc(&xml, &msg_id).await?;
+        Ok(())
+    }
+
+    /// Lock only the subtrees named by XPath expressions, **in `running`**
+    /// (RFC 5717).
+    ///
+    /// # Scope
+    ///
+    /// This applies to the running datastore and nothing else. RFC 5717 §1:
+    /// *"Partial locking only affects configuration data and only the running
+    /// datastore. The candidate or the start-up datastore are not affected"*,
+    /// and *"The candidate datastore cannot be locked using the
+    /// `<partial-lock>` operation."*
+    ///
+    /// So this is **not** a narrower substitute for a candidate lock, and it
+    /// does not help the candidate-based `netconf apply` flow — that path edits,
+    /// validates and commits `candidate`, and still needs its full `<lock>`.
+    /// Dropping that lock because a partial lock is held would leave concurrent
+    /// candidate edits unprotected. Partial locking is for writable-running
+    /// workflows, where it lets edits to unrelated subtrees proceed
+    /// concurrently instead of serializing on one datastore-wide lock.
+    ///
+    /// Prefixes used in the expressions must be bound via `namespaces`; the
+    /// declarations are emitted on `<partial-lock>` where the expressions can
+    /// see them, and are validated exactly as the XPath filter's are.
+    ///
+    /// Returns the server-assigned [`PartialLock`]. Its `locked_nodes` are
+    /// worth checking rather than assuming: an expression may match several
+    /// nodes or none.
+    pub async fn partial_lock(
+        &mut self,
+        selects: &[String],
+        namespaces: &[(String, String)],
+    ) -> Result<PartialLock, NetconfError> {
+        self.require_capability(crate::capability::uri::PARTIAL_LOCK, "partial-lock")?;
+        // Refuse outright rather than retry. If an earlier partial-lock or
+        // -unlock left this set, the server may still hold a lock this session
+        // cannot name; a second attempt that succeeded would clear the flag and
+        // report health while that first lock is still outstanding, and the pool
+        // would then recycle the connection. The flag is only cleared by a
+        // definitive outcome of the request that set it, or by reconnecting.
+        self.ensure_lock_state_known()?;
+        let msg_id = self.next_message_id();
+        let xml = operations::partial_lock_xml(&msg_id, selects, namespaces)?;
+
+        // Set *before* the write, and cleared only once a lock-id is in hand.
+        //
+        // Every way this can fail after the bytes leave - an RPC timeout, the
+        // future being cancelled, an `<ok/>` with no id, an unparseable reply -
+        // may leave the server holding a lock this session cannot name, and so
+        // cannot release. Marking first is what makes that survive
+        // cancellation: nothing after an await runs if the future is dropped.
+        //
+        // `is_alive` reports false while this is set, so a pooled connection is
+        // discarded on check-in rather than recycled still holding the lock.
+        self.partial_lock_uncertain = true;
+
+        let reply = match self.send_rpc(&xml, &msg_id).await {
+            Ok(reply) => reply,
+            Err(e) => {
+                // A parsed `<rpc-error>` is definitive: RFC 5717 makes a failed
+                // partial lock atomic, so `lock-denied` or `no-matches` means no
+                // lock was retained and the session is perfectly healthy. Only
+                // the genuinely unknown outcomes — timeouts, cancellation, a
+                // reply we could not parse — leave the flag set. Otherwise
+                // routine lock contention would throw away good pooled
+                // connections.
+                if matches!(e, NetconfError::Rpc(crate::error::RpcError::ServerError(_))) {
+                    self.partial_lock_uncertain = false;
+                }
+                return Err(e);
+            }
+        };
+        let result = match reply {
+            RpcReply::Data(data) | RpcReply::DataWithWarnings(data, _) => {
+                operations::parse_partial_lock_reply(&data)
+            }
+            // An `<ok/>` means the server accepted the lock but told us nothing
+            // about it. Without the lock-id it cannot be released, so this is an
+            // error rather than a silent success.
+            RpcReply::Ok | RpcReply::OkWithWarnings(_) => Err(ProtocolError::Xml(
+                "<partial-lock> returned <ok/> with no <lock-id>; the lock could not \
+                     be released"
+                    .to_string(),
+            )
+            .into()),
+        };
+        if result.is_ok() {
+            self.partial_lock_uncertain = false;
+        }
+        result
+    }
+
+    /// Release a partial lock (RFC 5717).
+    pub async fn partial_unlock(&mut self, lock_id: u32) -> Result<(), NetconfError> {
+        self.require_capability(crate::capability::uri::PARTIAL_LOCK, "partial-unlock")?;
+        self.ensure_lock_state_known()?;
+        let msg_id = self.next_message_id();
+        let xml = operations::partial_unlock_xml(&msg_id, lock_id);
+
+        // The release is as indeterminate as the acquire. If this times out or
+        // is cancelled after the write, the lock may still be held — and the
+        // caller is about to drop the only copy of `lock_id`. Poisoning before
+        // the write means `PoolGuard` discards the connection instead of
+        // returning a session that silently holds a lock nobody can name.
+        self.partial_lock_uncertain = true;
+
+        match self.send_rpc(&xml, &msg_id).await {
+            Ok(_) => {
+                self.partial_lock_uncertain = false;
+                Ok(())
+            }
+            Err(e) => {
+                // Deliberately asymmetric with `partial_lock`. There, a parsed
+                // rejection proves *no* lock was taken, so the session is clean.
+                // Here the inference inverts: the server processed the release
+                // and refused it, which means the lock is still held. Clearing
+                // the flag would let `PoolGuard` recycle a session that still
+                // owns a lock nobody is going to release, blocking other writers
+                // until it ages out. Stay poisoned regardless of the error kind.
+                Err(e)
+            }
+        }
+    }
+
+    /// Error when a previous partial lock or unlock left this session's lock
+    /// state unknown.
+    fn ensure_lock_state_known(&self) -> Result<(), NetconfError> {
+        if self.partial_lock_uncertain {
+            return Err(ProtocolError::SessionExpired.into());
+        }
         Ok(())
     }
 
@@ -3209,6 +3344,260 @@ mod tests {
             .expect_err("report-all is not advertised");
         assert!(err.to_string().contains("report-all"), "got {err}");
         assert_eq!(written.lock().unwrap().len(), before, "nothing sent");
+    }
+
+    fn mock_partial_lock_hello() -> Vec<u8> {
+        let hello = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+    <capability>urn:ietf:params:netconf:capability:partial-lock:1.0</capability>
+  </capabilities>
+  <session-id>1</session-id>
+</hello>"#;
+        let mut buf = hello.as_bytes().to_vec();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    #[tokio::test]
+    async fn partial_lock_accepts_a_namespace_omitting_device() {
+        // The common shape: the envelope declares the base namespace as the
+        // default and the device omits RFC 5717's on its output elements, so
+        // <lock-id> inherits the base one. Rejecting that would error out after
+        // the server granted the lock, stranding it.
+        let hello = br#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"><capabilities><capability>urn:ietf:params:netconf:base:1.0</capability><capability>urn:ietf:params:netconf:capability:partial-lock:1.0</capability></capabilities><session-id>1</session-id></hello>]]>]]>"#;
+        let reply = br#"<rpc-reply xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" message-id="1"><data><lock-id>7</lock-id></data></rpc-reply>]]>]]>"#;
+        let mut data = hello.to_vec();
+        data.extend_from_slice(reply);
+
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let lock = session
+            .partial_lock(&["/x".to_string()], &[])
+            .await
+            .expect("a namespace-omitting device must still yield its lock-id");
+        assert_eq!(lock.lock_id, 7);
+    }
+
+    #[tokio::test]
+    async fn partial_lock_requires_the_capability() {
+        let transport = MockTransport::new(mock_device_hello());
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let before = written.lock().unwrap().len();
+        let err = session
+            .partial_lock(&["/x".to_string()], &[])
+            .await
+            .expect_err("partial-lock is not advertised");
+        assert!(err.to_string().contains("partial-lock"), "got {err}");
+        assert_eq!(written.lock().unwrap().len(), before, "nothing sent");
+    }
+
+    #[tokio::test]
+    async fn partial_lock_returns_the_lock_id() {
+        let mut data = mock_partial_lock_hello();
+        data.extend_from_slice(&mock_data_reply(
+            "1",
+            r#"<lock-id xmlns="urn:ietf:params:xml:ns:netconf:partial-lock:1.0">127</lock-id><locked-node xmlns="urn:ietf:params:xml:ns:netconf:partial-lock:1.0">/interfaces</locked-node>"#,
+        ));
+        let transport = MockTransport::new(data);
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let lock = session
+            .partial_lock(
+                &["/if:interfaces".to_string()],
+                &[(
+                    "if".to_string(),
+                    "urn:ietf:params:xml:ns:yang:ietf-interfaces".to_string(),
+                )],
+            )
+            .await
+            .expect("partial-lock");
+        assert_eq!(lock.lock_id, 127);
+        assert_eq!(lock.locked_nodes.len(), 1);
+        assert_eq!(lock.locked_nodes[0].path, "/interfaces");
+
+        let sent = String::from_utf8_lossy(&written.lock().unwrap()).to_string();
+        assert!(
+            sent.contains("<select>/if:interfaces</select>"),
+            "sent: {sent}"
+        );
+        assert!(sent.contains("xmlns:if="), "sent: {sent}");
+    }
+
+    #[tokio::test]
+    async fn partial_lock_ok_without_lock_id_is_an_error() {
+        // An <ok/> means the server took a lock we can never release.
+        let mut data = mock_partial_lock_hello();
+        data.extend_from_slice(&mock_ok_reply("1"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let err = session
+            .partial_lock(&["/x".to_string()], &[])
+            .await
+            .expect_err("<ok/> carries no lock-id");
+        assert!(err.to_string().contains("lock-id"), "got {err}");
+    }
+
+    #[tokio::test]
+    async fn indeterminate_partial_lock_poisons_the_session() {
+        // <ok/> with no lock-id: the server may hold a lock we cannot name.
+        // The session must not go back into a pool still holding it.
+        let mut data = mock_partial_lock_hello();
+        data.extend_from_slice(&mock_ok_reply("1"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert!(session.is_alive());
+
+        let _ = session
+            .partial_lock(&["/x".to_string()], &[])
+            .await
+            .expect_err("<ok/> carries no lock-id");
+
+        assert!(
+            !session.is_alive(),
+            "an indeterminate partial-lock must poison the session so the pool \
+             discards it rather than recycling an unreleasable lock"
+        );
+    }
+
+    #[tokio::test]
+    async fn lock_denied_does_not_poison_the_session() {
+        // Routine contention. RFC 5717 makes a failed partial lock atomic, so a
+        // parsed <rpc-error> definitively means no lock is held and the session
+        // is healthy - poisoning here would throw away good pooled connections
+        // every time two operators collide.
+        let mut data = mock_partial_lock_hello();
+        data.extend_from_slice(&mock_lock_denied_reply("1", 42));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let err = session
+            .partial_lock(&["/x".to_string()], &[])
+            .await
+            .expect_err("lock is held elsewhere");
+        assert!(err.to_string().contains("LockDenied"), "got {err}");
+        assert!(
+            session.is_alive(),
+            "a definitive rejection must leave the session usable"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_poisoned_session_refuses_further_lock_operations() {
+        // A retry that succeeded would clear the flag and report health while
+        // the *first* request's lock is still outstanding and unnameable.
+        let mut data = mock_partial_lock_hello();
+        data.extend_from_slice(&mock_ok_reply("1")); // <ok/>: no lock-id
+        data.extend_from_slice(&mock_data_reply(
+            "2",
+            r#"<lock-id xmlns="urn:ietf:params:xml:ns:netconf:partial-lock:1.0">5</lock-id>"#,
+        ));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let _ = session
+            .partial_lock(&["/x".to_string()], &[])
+            .await
+            .expect_err("<ok/> carries no lock-id");
+        assert!(!session.is_alive());
+
+        // Even though a good reply is queued, the retry must be refused.
+        assert!(
+            session
+                .partial_lock(&["/y".to_string()], &[])
+                .await
+                .is_err(),
+            "a poisoned session must not accept another partial-lock"
+        );
+        assert!(
+            session.partial_unlock(5).await.is_err(),
+            "nor an unlock, which would look like it resolved the uncertainty"
+        );
+        assert!(!session.is_alive(), "still poisoned");
+    }
+
+    #[tokio::test]
+    async fn rejected_partial_unlock_keeps_the_session_poisoned() {
+        // Inverse of the acquire case: a refused release means the lock is
+        // still held, so the session must not go back into the pool.
+        let mut data = mock_partial_lock_hello();
+        data.extend_from_slice(&mock_commit_error_reply("1"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let _ = session
+            .partial_unlock(5)
+            .await
+            .expect_err("server refused the release");
+        assert!(
+            !session.is_alive(),
+            "a refused unlock leaves the lock held; the session must not be recycled"
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_partial_unlock_leaves_the_session_usable() {
+        let mut data = mock_partial_lock_hello();
+        data.extend_from_slice(&mock_ok_reply("1"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        session.partial_unlock(9).await.expect("partial-unlock");
+        assert!(
+            session.is_alive(),
+            "a clean unlock must leave the session reusable"
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_partial_lock_leaves_the_session_usable() {
+        let mut data = mock_partial_lock_hello();
+        data.extend_from_slice(&mock_data_reply(
+            "1",
+            r#"<lock-id xmlns="urn:ietf:params:xml:ns:netconf:partial-lock:1.0">3</lock-id>"#,
+        ));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        session
+            .partial_lock(&["/x".to_string()], &[])
+            .await
+            .expect("partial-lock");
+        assert!(
+            session.is_alive(),
+            "a clean lock must not poison the session"
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_unlock_sends_the_lock_id() {
+        let mut data = mock_partial_lock_hello();
+        data.extend_from_slice(&mock_ok_reply("1"));
+        let transport = MockTransport::new(data);
+        let written = transport.written_handle();
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        session.partial_unlock(127).await.expect("partial-unlock");
+        let sent = String::from_utf8_lossy(&written.lock().unwrap()).to_string();
+        assert!(sent.contains("<lock-id>127</lock-id>"), "sent: {sent}");
     }
 
     #[tokio::test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -34,6 +34,46 @@ pub enum ConfigLocation {
     Url(String),
 }
 
+/// One instance-identifier the server reported locking.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LockedNode {
+    /// The instance-identifier, verbatim.
+    pub path: String,
+    /// The prefix bindings in scope for [`path`](Self::path).
+    ///
+    /// An XPath prefix means nothing without its binding, and RFC 5717 does not
+    /// require the server to reuse the prefixes from the request — it may return
+    /// `/x:interfaces` for a request written as `/if:interfaces`. Returning the
+    /// path alone would hand back a string that cannot be resolved.
+    ///
+    /// Only declarations visible inside the reply payload are captured. A server
+    /// that declares them further up, on `<rpc-reply>`, puts them outside what
+    /// this layer receives, so this can be empty even for a prefixed path.
+    pub namespaces: Vec<(String, String)>,
+}
+
+/// The result of a successful `<partial-lock>` (RFC 5717).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PartialLock {
+    /// Server-assigned identifier, required by `<partial-unlock>`.
+    pub lock_id: u32,
+    /// The instance-identifiers the server actually locked.
+    ///
+    /// Worth checking rather than assuming: RFC 5717 has the server report what
+    /// it locked, which need not be one node per `<select>` — an expression may
+    /// match several nodes.
+    ///
+    /// **An empty list means the server reported locking nothing.** RFC 5717
+    /// requires at least one `<locked-node>` in a successful reply, and answers
+    /// an all-empty match with `operation-failed` / `no-matches` instead, so
+    /// this shape indicates a non-conforming device. It is surfaced rather than
+    /// turned into an error on purpose: the lock *was* granted and the
+    /// `lock_id` is the only way to release it, and refusing the reply would
+    /// discard that id and strand the lock on the device with no way to recover
+    /// it. Treat an empty list as "extent unknown, release it".
+    pub locked_nodes: Vec<LockedNode>,
+}
+
 /// `<with-defaults>` retrieval mode (RFC 6243).
 ///
 /// Without this, what a device reports for a leaf sitting at its YANG default


### PR DESCRIPTION
Closes #73.

Lock only the subtrees an XPath names, so edits to unrelated parts of a config need not serialize on one datastore-wide lock.

## Scoped to `running` — and that matters

RFC 5717 §1: *"Partial locking only affects configuration data and only the running datastore. The candidate or the start-up datastore are not affected"*, and *"The candidate datastore cannot be locked using the `<partial-lock>` operation."*

An earlier revision of this branch pitched it as narrowing the **candidate** lock. That was wrong in a way that mattered: a reader could have dropped the `<lock>` that `netconf apply` depends on, believing a partial lock covered them, and left concurrent candidate edits unprotected. Now scoped explicitly in both the method docs and the README.

## Lock lifecycle

`partial_lock` returns `PartialLock { lock_id, locked_nodes }`, where `locked_nodes` are `LockedNode { path, namespaces }` — the server need not reuse the request's prefixes, and a prefixed path without its bindings is a string nobody can resolve.

Session health distinguishes three outcomes, not two:

| outcome | session |
|---|---|
| parsed `<rpc-error>` on **acquire** (`lock-denied`, `no-matches`) | healthy — RFC 5717 makes a failed partial lock atomic, so no lock is held |
| parsed success | healthy |
| timeout, cancellation, `<ok/>` with no id, unparseable reply | **poisoned** |
| parsed `<rpc-error>` on **release** | **poisoned** — the inference inverts: the server refused, so the lock is still held |

The flag is set *before* the write, because nothing after an `await` runs if the future is dropped. `is_alive()` reports false while set, so `PoolGuard` discards rather than recycles. A poisoned session refuses further lock operations outright — a successful retry would otherwise clear poison belonging to an earlier, still-unnameable lock.

Same reasoning the crate already applies to `CommitUnknown`: distinguish *failed* from *may have happened*.

## Reply parsing

Nearly all the difficulty. Each of these is a way to get a silently wrong answer from vendor-controlled input:

- **expanded-name matching** — a vendor `<v:lock-id>` is not taken as ours
- **inherited base namespace accepted** — what a namespace-omitting device produces; rejecting it errored out *after* the lock was granted (verified against a normal reply shape before fixing)
- **`xmlns=""` is an undeclaration**, not an empty namespace; the implicitly-bound `xml` prefix is resolved so `<xml:lock-id>` isn't mistaken for unqualified
- **no `…xml:ns:netconf:base:1.1`** — that namespace does not exist; NETCONF 1.1 changed the capability URI and framing, not the protocol namespace
- **URIs unescaped** via the reply parser's own `decode_attribute`, so a binding isn't stored as `urn:x?a=1&amp;b=2`
- **`Event::GeneralRef` stitched back in** — this quick-xml streams entities separately, so a path with an escaped `&` would come back cut in half
- **mixed content rejected** — `<lock-id>1<meta/>2</lock-id>` would otherwise concatenate to id `12`
- CDATA accepted, attribute-parse failures propagated, duplicate `<lock-id>` refused, diagnostics bounded (the value is device-controlled under a 100 MB cap)

`parse_partial_lock_reply` is crate-private: it relies on validation `parse_rpc_reply` already performed.

## Deliberate non-change

A success carrying no `<locked-node>` is surfaced, not rejected, even though RFC 5717 requires at least one. The lock *was* granted and `lock_id` is the only way to release it — erroring would discard that id and strand the lock with no recovery path. The field documents that an empty list means "extent unknown, release it".

## Shared validation

Request-side namespace validation is shared with the XPath filter rather than reimplemented (`render_namespace_bindings`), and folds duplicate bindings — two `xmlns:a` attributes on one element is malformed XML the server cannot execute.

607 tests pass, clippy `-D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
