### PR TITLE
fix(tests): correct the integration suite's default username

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@
 //! | Env var | Required | Default | Notes |
 //! |---|---|---|---|
 //! | `RUSTNETCONF_TEST_VSRX_HOST` | yes | — | e.g. `192.168.1.227:830` |
-//! | `RUSTNETCONF_TEST_VSRX_USER` | no | `srxoutpost` | Junos username |
+//! | `RUSTNETCONF_TEST_VSRX_USER` | no | `netconf` | Junos username |
 //! | `RUSTNETCONF_TEST_VSRX_KEY` | no | `$HOME/.ssh/id_ed25519` | SSH private key path |
 //!
 //! ## Examples
@@ -48,7 +48,7 @@ impl VsrxTarget {
 pub fn vsrx_target() -> Option<VsrxTarget> {
     let host = std::env::var("RUSTNETCONF_TEST_VSRX_HOST").ok()?;
     let username =
-        std::env::var("RUSTNETCONF_TEST_VSRX_USER").unwrap_or_else(|_| "srxoutpost".to_string());
+        std::env::var("RUSTNETCONF_TEST_VSRX_USER").unwrap_or_else(|_| "netconf".to_string());
     let key_path = std::env::var("RUSTNETCONF_TEST_VSRX_KEY").unwrap_or_else(|_| {
         let home = std::env::var("HOME").unwrap_or_else(|_| "/home/mharman".to_string());
         format!("{home}/.ssh/id_ed25519")

--- a/tests/integration_vsrx.rs
+++ b/tests/integration_vsrx.rs
@@ -11,6 +11,27 @@
 //! RUSTNETCONF_TEST_VSRX_HOST=192.168.1.227:830 \
 //!     cargo test --test integration_vsrx
 //! ```
+//!
+//! ## Credentials
+//!
+//! The default user is `netconf`, which is what the lab vSRX actually defines.
+//! It was `srxoutpost` — a user that does not exist on that device, so the whole
+//! suite failed with `authentication failed` against a host that was otherwise
+//! reachable and correct. The confusing part is that `srxoutpost` *can* log in
+//! over plain SSH on some lab hosts but is not served the `netconf` subsystem,
+//! so the failure looked like a device or transport fault rather than a wrong
+//! username.
+//!
+//! The key must be one the device's `netconf` user authorises. If you get
+//! `authentication failed`, check with:
+//!
+//! ```sh
+//! ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes -p 830 -s netconf@<host> netconf
+//! ```
+//!
+//! A NETCONF `<hello>` on stdout means the credentials work. Silence on stdout
+//! with a login banner on stderr means the user authenticates but has no
+//! netconf subsystem access, which is a different problem entirely.
 
 mod common;
 


### PR DESCRIPTION
Relates to #77.

The vSRX integration suite defaulted to user `srxoutpost`, **which does not exist on the lab device**. `show configuration system login` on vsrx-ci lists `netconf` (class super-user) and `sduser`, and nothing else. Every test in the suite failed with `authentication failed` against a host that was reachable, correct, and running the expected Junos version.

## Why this cost time to find

`srxoutpost` authenticates over plain SSH on some lab hosts while *not* being served the `netconf` subsystem. Probing it returns a login banner on **stderr** and nothing on **stdout** — which reads as a device or transport fault, not a credential mismatch. The diagnostic is now in the test header:

```sh
ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes -p 830 -s netconf@<host> netconf
```

A `<hello>` on stdout means the credentials work. Silence on stdout with a banner on stderr means the user authenticates but has no netconf subsystem access — a different problem entirely.

## Also corrects a claim of mine

The doc header described the target as "VM114 / CI-tester-vSRX", and I had noted the address looked stale. **It is not.** `192.168.1.227` is vsrx-ci's fxp0, running Junos 24.4R1.9 — the host was always right. Only the guest number in the prose was outdated (renumbered to 907).

## Scope

This does not make the suite runnable here — the device authorises two keys for `netconf`, both the MCP server's, and neither is on this box. #77 carries the details of why that cannot be fixed from here.

617 tests pass, clippy clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)