### PR TITLE
feat(client): make the read-buffer ceiling adjustable and durable

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -276,6 +276,14 @@ impl ClientBuilder {
         self
     }
 
+    /// The ceiling this builder will apply, if any.
+    ///
+    /// Exists so the reconnect-persistence property can be asserted without a
+    /// live device.
+    pub fn configured_max_read_buffer(&self) -> Option<usize> {
+        self.max_read_buffer
+    }
+
     /// Establish the SSH connection and perform the NETCONF hello exchange.
     pub async fn connect(self) -> Result<Client, NetconfError> {
         let username = self.username.ok_or_else(|| {
@@ -322,6 +330,7 @@ impl ClientBuilder {
         if let Some(max_bytes) = self.max_read_buffer {
             session.set_max_read_buffer(max_bytes);
         }
+        let max_read_buffer = self.max_read_buffer;
 
         // Set explicit vendor profile if provided (overrides auto-detection)
         if let Some(profile) = self.vendor_profile {
@@ -335,6 +344,7 @@ impl ClientBuilder {
         }
 
         Ok(Client {
+            max_read_buffer,
             session,
             transport_config: TransportConfig::Ssh(config),
             gather_facts: self.gather_facts,
@@ -358,6 +368,10 @@ pub struct Client {
     keepalive_interval: Option<Duration>,
     /// RPC timeout (None = wait forever).
     rpc_timeout: Option<Duration>,
+    /// Reapplied on reconnect, like the other session settings above. A
+    /// deliberately *lowered* ceiling is a memory-exhaustion defence, and
+    /// silently restoring the 100 MB default on reconnect would weaken it.
+    max_read_buffer: Option<usize>,
 }
 
 impl Client {
@@ -468,6 +482,7 @@ impl Client {
     #[cfg(feature = "tls")]
     pub fn connect_tls(config: TlsConfig) -> TlsClientBuilder {
         TlsClientBuilder {
+            max_read_buffer: None,
             tls_config: config,
             vendor_profile: None,
             gather_facts: true,
@@ -694,6 +709,13 @@ impl Client {
             session.set_rpc_timeout(self.rpc_timeout);
         }
 
+        // Carried across, like the settings above. Losing it would silently
+        // restore the 100 MB default — reverting a ceiling a caller lowered on
+        // purpose, not merely one they raised.
+        if let Some(max_bytes) = self.max_read_buffer {
+            session.set_max_read_buffer(max_bytes);
+        }
+
         session.establish().await?;
 
         if self.gather_facts {
@@ -750,6 +772,53 @@ impl Client {
     /// Fetch operational and configuration data using an XPath filter.
     pub async fn get_xpath(&mut self, filter: &XPathFilter) -> Result<String, NetconfError> {
         self.session.get_xpath(filter).await
+    }
+
+    /// Change the read-buffer ceiling on an already-connected client.
+    ///
+    /// [`ClientBuilder::max_read_buffer`] covers the case where you build the
+    /// client yourself. This covers the one where you did not: a connection
+    /// checked out of a [`DevicePool`](crate::pool::DevicePool) was built to the
+    /// pool's settings, and a caller that needs one unusually large
+    /// `<get-config>` would otherwise have to tear the connection down and
+    /// rebuild it just to raise a limit.
+    ///
+    /// Raise it for the fetch and lower it again afterwards — restoring it
+    /// *before* propagating any error, as the example does. An `?` placed
+    /// between the two leaves the raised ceiling in place for the rest of the
+    /// connection's life.
+    ///
+    /// On a pooled connection this is belt-and-braces: `PoolGuard` records the
+    /// ceiling at checkout and restores it on check-in, so an override cannot
+    /// outlive one borrower even if the task is cancelled mid-fetch and the
+    /// restoring statement never runs. Restore it yourself anyway — the
+    /// guarantee only applies to pooled use, and `Drop` is what makes it hold,
+    /// not the trailing statement. The ceiling exists
+    /// to stop a hostile or malfunctioning device exhausting memory, and a
+    /// pooled connection left with a raised limit keeps it for whoever checks it
+    /// out next.
+    ///
+    /// This is not a substitute for streaming (#76). The reply is still
+    /// accumulated whole — this only moves the point at which that is refused.
+    ///
+    /// ```no_run
+    /// # use rustnetconf::{Client, Datastore};
+    /// # async fn demo(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let previous = client.max_read_buffer();
+    /// client.set_max_read_buffer(512 * 1024 * 1024);
+    /// let result = client.get_config(Datastore::Running).await;
+    /// client.set_max_read_buffer(previous); // before `?`, not after
+    /// let cfg = result?;
+    /// # Ok(()) }
+    /// ```
+    pub fn set_max_read_buffer(&mut self, max_bytes: usize) {
+        self.max_read_buffer = Some(max_bytes);
+        self.session.set_max_read_buffer(max_bytes);
+    }
+
+    /// The current read-buffer ceiling in bytes.
+    pub fn max_read_buffer(&self) -> usize {
+        self.session.max_read_buffer()
     }
 
     /// Fetch configuration with an explicit `<with-defaults>` mode (RFC 6243).
@@ -971,6 +1040,7 @@ impl Client {
     pub(crate) fn from_session_for_test(session: Session) -> Self {
         Client {
             session,
+            max_read_buffer: None,
             transport_config: TransportConfig::Ssh(crate::transport::ssh::SshConfig {
                 host: "mock".to_string(),
                 port: 0,
@@ -1187,10 +1257,22 @@ pub struct TlsClientBuilder {
     gather_facts: bool,
     keepalive_interval: Option<Duration>,
     rpc_timeout: Option<Duration>,
+    max_read_buffer: Option<usize>,
 }
 
 #[cfg(feature = "tls")]
 impl TlsClientBuilder {
+    /// Set the maximum read buffer size in bytes.
+    ///
+    /// Mirrors [`ClientBuilder::max_read_buffer`]. The TLS builder previously
+    /// had no way to set this, so a TLS client was stuck with the 100 MB
+    /// default — an asymmetry with the SSH path rather than a deliberate
+    /// choice.
+    pub fn max_read_buffer(mut self, max_bytes: usize) -> Self {
+        self.max_read_buffer = Some(max_bytes);
+        self
+    }
+
     /// Set an explicit vendor profile, overriding auto-detection.
     pub fn vendor_profile(mut self, profile: Box<dyn VendorProfile>) -> Self {
         self.vendor_profile = Some(Arc::from(profile));
@@ -1236,6 +1318,14 @@ impl TlsClientBuilder {
             session.set_rpc_timeout(self.rpc_timeout);
         }
 
+        // Before `establish`, matching the SSH builder. Recording it for
+        // reconnect alone would leave the *initial* session on the 100 MB
+        // default — so a raised limit would not take effect until the first
+        // reconnect, and a lowered one would not be enforced until then either.
+        if let Some(max_bytes) = self.max_read_buffer {
+            session.set_max_read_buffer(max_bytes);
+        }
+
         if let Some(profile) = self.vendor_profile {
             session.set_vendor_profile_arc(profile);
         }
@@ -1248,6 +1338,7 @@ impl TlsClientBuilder {
 
         Ok(Client {
             session,
+            max_read_buffer: self.max_read_buffer,
             transport_config: TransportConfig::Tls(self.tls_config),
             gather_facts: self.gather_facts,
             keepalive_interval: self.keepalive_interval,
@@ -1659,6 +1750,20 @@ mod tests {
     }
 
     /// Test that candidate_dirty() reflects state correctly.
+    #[test]
+    fn a_configured_ceiling_is_recorded_for_reconnect() {
+        // The bug this guards is a *security* regression, not a capability one:
+        // `Client` reapplies keepalive and rpc_timeout on reconnect but never
+        // stored the ceiling, so a deliberately lowered cap silently returned to
+        // the 100 MB default on any reconnect.
+        let builder = Client::connect("127.0.0.1:830").max_read_buffer(4096);
+        assert_eq!(
+            builder.configured_max_read_buffer(),
+            Some(4096),
+            "the builder must carry the ceiling through to the Client"
+        );
+    }
+
     #[tokio::test]
     async fn client_candidate_dirty_reflects_state() {
         use crate::transport::mock::MockTransport;

--- a/src/pool/mod.rs
+++ b/src/pool/mod.rs
@@ -158,6 +158,7 @@ impl DevicePool {
                 while let Some(client) = pool.pop() {
                     if client.session_alive() {
                         return Ok(PoolGuard {
+                            checkout_max_read_buffer: client.max_read_buffer(),
                             client: Some(client),
                             device_name: device_name.to_string(),
                             connections: Arc::clone(&self.connections),
@@ -176,6 +177,7 @@ impl DevicePool {
         let client = connect_device(config).await?;
 
         Ok(PoolGuard {
+            checkout_max_read_buffer: client.max_read_buffer(),
             client: Some(client),
             device_name: device_name.to_string(),
             connections: Arc::clone(&self.connections),
@@ -203,6 +205,16 @@ pub struct PoolGuard<'a> {
     client: Option<Client>,
     device_name: String,
     connections: Arc<Mutex<HashMap<String, Vec<Client>>>>,
+    /// The read-buffer ceiling this connection had when it was checked out.
+    ///
+    /// Restored on check-in so a borrower's temporary override cannot outlive
+    /// their turn with the connection. `Client::set_max_read_buffer` documents
+    /// raising the ceiling for one large fetch and lowering it again, but that
+    /// restore is an ordinary statement — task cancellation at the intervening
+    /// `.await` skips it, and the next borrower would inherit a weakened
+    /// memory-exhaustion defence. `Drop` runs on cancellation; a trailing
+    /// statement does not.
+    checkout_max_read_buffer: usize,
     _permit: SemaphorePermit<'a>,
 }
 
@@ -240,7 +252,10 @@ impl<'a> DerefMut for PoolGuard<'a> {
 
 impl<'a> Drop for PoolGuard<'a> {
     fn drop(&mut self) {
-        if let Some(client) = self.client.take() {
+        if let Some(mut client) = self.client.take() {
+            // Undo any override the borrower left behind, cancelled or not.
+            client.set_max_read_buffer(self.checkout_max_read_buffer);
+
             if !client.session_alive() {
                 tracing::warn!(
                     device = %self.device_name,

--- a/src/session.rs
+++ b/src/session.rs
@@ -160,6 +160,18 @@ impl Session {
     /// If the device sends more data than this without completing a framed
     /// message, the read is aborted to prevent memory exhaustion.
     /// Defaults to 100 MB.
+    /// The current read-buffer ceiling in bytes.
+    pub fn max_read_buffer(&self) -> usize {
+        self.max_read_buffer
+    }
+
+    /// Set the read-buffer ceiling.
+    ///
+    /// This bounds bytes accumulated *without completing a framed message*, not
+    /// total reply size directly — though for one large reply those amount to
+    /// the same thing, since the framer yields nothing until the whole message
+    /// is present. A reply already buffered in full is decoded regardless of the
+    /// ceiling, so lowering it does not retroactively reject data in hand.
     pub fn set_max_read_buffer(&mut self, max_bytes: usize) {
         self.max_read_buffer = max_bytes;
     }
@@ -3381,6 +3393,24 @@ mod tests {
             .await
             .expect("a namespace-omitting device must still yield its lock-id");
         assert_eq!(lock.lock_id, 7);
+    }
+
+    #[tokio::test]
+    async fn read_limit_is_adjustable_on_a_live_session() {
+        let transport = MockTransport::new(mock_device_hello());
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let default = session.max_read_buffer();
+        assert_eq!(default, MAX_READ_BUFFER);
+
+        session.set_max_read_buffer(512 * 1024 * 1024);
+        assert_eq!(session.max_read_buffer(), 512 * 1024 * 1024);
+
+        // And back down again: the ceiling exists to bound a hostile device,
+        // so raising it for one fetch must be reversible.
+        session.set_max_read_buffer(default);
+        assert_eq!(session.max_read_buffer(), default);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Relates to #76 — this is **not** the streaming redesign that issue asks for, and does not close it.

## What prompted it

While scoping #76 I found that the "raise the cap" workaround I'd suggested as a one-liner alternative **already existed** (`ClientBuilder::max_read_buffer`). The real gap was adjusting the ceiling on a connection you did *not* build — a pooled one, where a caller needing one unusually large `<get-config>` had to tear the connection down and rebuild it purely to change a limit.

Then two genuine bugs fell out of the surrounding code.

## A pre-existing security regression

`Client` stores `keepalive_interval`, `rpc_timeout` and `gather_facts`, and `reconnect()` reapplies all three. The read-buffer ceiling was **only ever a builder field** and was never carried onto the client — so a caller who set a deliberately *low* cap as a memory-exhaustion defence had it silently restored to the 100 MB default on any reconnect.

That predates this change. The new setter would merely have made it easier to hit.

## A cancellation hole in my own documented pattern

```rust
client.set_max_read_buffer(large);
let result = client.get_config(...).await;   // task cancelled here
client.set_max_read_buffer(previous);        // never runs
```

`PoolGuard::drop` still sees a live session and checks it back in, so the **next borrower** inherits the weakened ceiling. Nothing after an `.await` runs if the future is dropped — the same fact that forced partial-lock poisoning to be set *before* the write in #73.

A drop-based scoped guard can't work here (it would need `&mut Client` and block using the client), so the fix goes where `Drop` does run: `PoolGuard` records the ceiling at checkout and restores it on check-in, cancelled or not. Callers are still told to restore it themselves, since the guarantee only covers pooled use.

## Also

- **`TlsClientBuilder` gains `max_read_buffer`**, applied before `establish()` like the SSH builder. It previously had no way to set one at all. An intermediate revision of this branch recorded it for reconnect but never applied it to the *initial* session, which would have left a lowered cap unenforced until the first reconnect.
- **Documents what the ceiling actually bounds**, which is not what the name suggests: bytes accumulated *without completing a framed message*, not reply size. For one large reply those coincide — the framer yields nothing until the whole message is present — but a reply already buffered in full is decoded regardless. I found this writing a test that lowered the cap to 64 bytes and expected a 4 KB reply to fail; it succeeded, because the mock had buffered the reply during the hello exchange. That test was deleted rather than left asserting something mock-specific.

## Scope

The reply is still accumulated whole. This moves the point at which that is refused and removes the need to rebuild a pooled connection to move it. #76 stays open for the streaming redesign, with the framing-layer blocker documented there.

620 tests pass, clippy `-D warnings` clean, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
