### PR TITLE
feat(session): stream large replies instead of buffering them (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,12 @@ let config = conn.get_config(Datastore::Running).await?;
 - **Subtree and XPath filters** — `SubtreeFilter` builds subtree filters; `XPathFilter` builds XPath ones (RFC 6241 §6.4) with namespace binding, gated on the device advertising `:xpath:1.0` so an unsupported filter fails loudly instead of silently returning the whole datastore
 - **Confirmed commit** — auto-rollback safety net (RFC 6241 §8.4)
 - **Event notifications** — `create-subscription`, inline notification demux, buffered drain/recv API (RFC 5277)
+- **Streaming replies** — `get_config_streaming` / `get_streaming` write the
+  reply into any `AsyncWrite` as it arrives, so peak memory is one read plus
+  one frame chunk instead of the whole response. Lets you fetch a config
+  larger than the read ceiling, which the buffered call cannot do at any
+  setting. The caller gets the raw `<rpc-reply>` — vendor unwrapping and
+  reply repair both need the complete document, so neither runs on a stream
 - **RPC timeout** — configurable per-session deadline prevents indefinite blocking on unresponsive devices
 - **XML fragment validation** — user-provided RPC content is validated before insertion to prevent XML injection
 - **CommitUnknown detection** — distinguishes "commit failed" from "maybe committed, connection lost"

--- a/src/client.rs
+++ b/src/client.rs
@@ -747,6 +747,57 @@ impl Client {
         self.session.get(filter).await
     }
 
+    /// Stream a `<get-config>` reply into `sink` instead of buffering it.
+    ///
+    /// Peak memory becomes one transport read plus one frame chunk rather than
+    /// the whole reply, so a configuration larger than
+    /// [`max_read_buffer`](Self::max_read_buffer) can be fetched — which
+    /// [`get_config`](Self::get_config) cannot do at any ceiling, since it holds
+    /// the response entire.
+    ///
+    /// The caller receives the raw `<rpc-reply>` document, **not** the unwrapped
+    /// `<data>` contents. Vendor unwrapping needs `rfind` over the whole string
+    /// and reply repair decides on a closed payload, so neither can run on a
+    /// stream. Parse the envelope yourself; `<rpc-error>` replies stream through
+    /// as documents rather than becoming `Err`.
+    ///
+    /// Returns the number of bytes written.
+    ///
+    /// ```no_run
+    /// # use rustnetconf::{Client, Datastore};
+    /// # async fn demo(client: &mut Client) -> Result<(), Box<dyn std::error::Error>> {
+    /// let mut file = tokio::fs::File::create("running.xml").await?;
+    /// let bytes = client.get_config_streaming(Datastore::Running, None, &mut file).await?;
+    /// eprintln!("wrote {bytes} bytes");
+    /// # Ok(()) }
+    /// ```
+    pub async fn get_config_streaming<W>(
+        &mut self,
+        source: Datastore,
+        filter: Option<&str>,
+        sink: &mut W,
+    ) -> Result<usize, NetconfError>
+    where
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        self.session
+            .get_config_streaming(source, filter, sink)
+            .await
+    }
+
+    /// Stream a `<get>` reply into `sink`. See
+    /// [`get_config_streaming`](Self::get_config_streaming).
+    pub async fn get_streaming<W>(
+        &mut self,
+        filter: Option<&str>,
+        sink: &mut W,
+    ) -> Result<usize, NetconfError>
+    where
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        self.session.get_streaming(filter, sink).await
+    }
+
     /// Fetch configuration using an XPath filter (RFC 6241 §6.4).
     ///
     /// Errors with [`ProtocolError::CapabilityMissing`](crate::error::ProtocolError::CapabilityMissing)

--- a/src/framing/chunked.rs
+++ b/src/framing/chunked.rs
@@ -165,10 +165,24 @@ pub(crate) enum EomLikeness {
 
 pub(crate) fn eom_likeness(data: &[u8]) -> EomLikeness {
     const MARKERS: [&[u8]; 3] = [b"<?xml", b"<rpc", b"<!--"];
+    /// The longest marker is five bytes, plus slack for leading whitespace.
+    /// Past this the buffer is always long enough to classify for certain.
+    /// Without the bound a peer that dribbles whitespace keeps the answer
+    /// Undecided forever, and because those bytes are never consumed every
+    /// retry rescans the whole retained buffer — quadratic, and it pins the
+    /// caller until the read ceiling instead of failing fast.
+    const MAX_AMBIGUOUS: usize = 16;
 
-    // All whitespace (or empty): nothing to judge yet.
-    let Some(first) = data.iter().position(|&b| !b.is_ascii_whitespace()) else {
-        return EomLikeness::Undecided;
+    let decided_by_length = data.len() > MAX_AMBIGUOUS;
+    // Scanning is bounded to the window: past it the answer no longer depends
+    // on where the whitespace ends.
+    let window = &data[..data.len().min(MAX_AMBIGUOUS + 1)];
+    let Some(first) = window.iter().position(|&b| !b.is_ascii_whitespace()) else {
+        return if decided_by_length {
+            EomLikeness::No
+        } else {
+            EomLikeness::Undecided
+        };
     };
     let trimmed = &data[first..];
 
@@ -178,10 +192,15 @@ pub(crate) fn eom_likeness(data: &[u8]) -> EomLikeness {
         }
         // A truncated read of this marker — wait rather than misclassify.
         if marker.starts_with(trimmed) {
-            return EomLikeness::Undecided;
+            return if decided_by_length {
+                EomLikeness::No
+            } else {
+                EomLikeness::Undecided
+            };
         }
     }
-    // EOM delimiter anywhere in the buffer.
+    // EOM delimiter anywhere in the buffer. Only reached on a definite answer,
+    // so this scan cannot repeat across reads.
     if data.windows(6).any(|w| w == b"]]>]]>") {
         return EomLikeness::Yes;
     }
@@ -378,6 +397,10 @@ mod tests {
         assert_eq!(eom_likeness(b"garbage"), EomLikeness::No);
         assert_eq!(eom_likeness(b"\x00\x01"), EomLikeness::No);
         assert_eq!(eom_likeness(b"   "), EomLikeness::Undecided);
+        // Bounded: a whitespace flood must resolve rather than stay ambiguous
+        // while every retry rescans a growing buffer.
+        assert_eq!(eom_likeness(&[b' '; 64]), EomLikeness::No);
+        assert_eq!(eom_likeness(&[b'\n'; 17]), EomLikeness::No);
     }
 
     #[test]

--- a/src/framing/chunked.rs
+++ b/src/framing/chunked.rs
@@ -11,11 +11,11 @@
 //! byte count of the chunk data. The end-of-chunks marker is `\n##\n`.
 
 use crate::error::FramingError;
-use crate::framing::{FramePart, Framer};
+use crate::framing::Framer;
 
 /// Maximum allowed chunk size (4 MB). Prevents memory exhaustion from
 /// malformed chunk headers advertising absurd lengths.
-const MAX_CHUNK_SIZE: usize = 4 * 1024 * 1024;
+pub(crate) const MAX_CHUNK_SIZE: usize = 4 * 1024 * 1024;
 
 /// End-of-chunks marker.
 const END_OF_CHUNKS: &[u8] = b"\n##\n";
@@ -136,89 +136,6 @@ impl Framer for ChunkedFramer {
             message.extend_from_slice(&buffer[pos..pos + chunk_len]);
             pos += chunk_len;
         }
-    }
-
-    fn decode_part(&self, buffer: &[u8]) -> Result<FramePart, FramingError> {
-        // One chunk per call. Chunked framing is self-describing — each chunk
-        // announces its length — so a chunk can be emitted as soon as it is
-        // complete, without waiting for the end-of-chunks marker.
-        if buffer.len() < 2 {
-            return Ok(FramePart::NeedMore);
-        }
-        if buffer[0] != b'\n' || buffer[1] != b'#' {
-            // Same firmware-bug detection as the all-at-once path: a device
-            // that advertised :base:1.1 and then sent EOM framing.
-            if looks_like_eom_data(buffer) {
-                return Err(FramingError::Mismatch {
-                    advertised: "1.1 (chunked)".to_string(),
-                    actual: "1.0 (EOM)".to_string(),
-                });
-            }
-            return Err(FramingError::Invalid(format!(
-                "expected chunk header, got {:?}",
-                &buffer[..std::cmp::min(4, buffer.len())]
-            )));
-        }
-
-        let mut pos = 2;
-        // End-of-chunks marker: \n##\n
-        if pos < buffer.len() && buffer[pos] == b'#' {
-            if pos + 2 > buffer.len() {
-                return Ok(FramePart::NeedMore);
-            }
-            if buffer[pos + 1] != b'\n' {
-                return Err(FramingError::Invalid(
-                    "expected \\n after ## in end-of-chunks marker".to_string(),
-                ));
-            }
-            return Ok(FramePart::End { consumed: pos + 2 });
-        }
-
-        let len_start = pos;
-        while pos < buffer.len() && buffer[pos] != b'\n' {
-            if !buffer[pos].is_ascii_digit() {
-                return Err(FramingError::Invalid(format!(
-                    "non-digit in chunk length: {:?}",
-                    buffer[pos] as char
-                )));
-            }
-            pos += 1;
-        }
-        if pos >= buffer.len() {
-            return Ok(FramePart::NeedMore);
-        }
-        if pos == len_start {
-            return Err(FramingError::Invalid("empty chunk length".to_string()));
-        }
-        let len_str = std::str::from_utf8(&buffer[len_start..pos])
-            .map_err(|e| FramingError::Invalid(format!("invalid chunk length: {e}")))?;
-        let chunk_len: usize = len_str
-            .parse()
-            .map_err(|e| FramingError::Invalid(format!("invalid chunk length: {e}")))?;
-        if chunk_len == 0 {
-            return Err(FramingError::Invalid("zero-length chunk".to_string()));
-        }
-        // Same bound the all-at-once path enforces. Without it a device can
-        // announce a huge length and force an allocation to match — and at
-        // exactly `usize::MAX` the `pos + chunk_len` below overflows and panics,
-        // which is reachable from device input.
-        if chunk_len > MAX_CHUNK_SIZE {
-            return Err(FramingError::Invalid(format!(
-                "chunk length {chunk_len} exceeds maximum {MAX_CHUNK_SIZE}"
-            )));
-        }
-        pos += 1; // the \n after the length
-
-        let end = pos
-            .checked_add(chunk_len)
-            .ok_or_else(|| FramingError::Invalid("chunk length overflows".to_string()))?;
-        if buffer.len() < end {
-            return Ok(FramePart::NeedMore);
-        }
-        Ok(FramePart::Data {
-            payload: buffer[pos..end].to_vec(),
-            consumed: end,
-        })
     }
 }
 

--- a/src/framing/chunked.rs
+++ b/src/framing/chunked.rs
@@ -165,20 +165,21 @@ pub(crate) enum EomLikeness {
 
 pub(crate) fn eom_likeness(data: &[u8]) -> EomLikeness {
     const MARKERS: [&[u8]; 3] = [b"<?xml", b"<rpc", b"<!--"];
-    /// The longest marker is five bytes, plus slack for leading whitespace.
-    /// Past this the buffer is always long enough to classify for certain.
-    /// Without the bound a peer that dribbles whitespace keeps the answer
-    /// Undecided forever, and because those bytes are never consumed every
-    /// retry rescans the whole retained buffer — quadratic, and it pins the
-    /// caller until the read ceiling instead of failing fast.
+    /// Bound on how long the answer may stay Undecided. The longest marker is
+    /// five bytes, plus slack for leading whitespace.
+    ///
+    /// Only the ambiguous answer needs bounding: Yes and No both make the
+    /// caller stop, so their scans run once. Undecided is retried after every
+    /// read without consuming anything, so leaving it unbounded lets a peer
+    /// dribble whitespace, rescan a growing buffer each time, and pin the
+    /// caller until the read ceiling.
     const MAX_AMBIGUOUS: usize = 16;
 
-    let decided_by_length = data.len() > MAX_AMBIGUOUS;
-    // Scanning is bounded to the window: past it the answer no longer depends
-    // on where the whitespace ends.
-    let window = &data[..data.len().min(MAX_AMBIGUOUS + 1)];
-    let Some(first) = window.iter().position(|&b| !b.is_ascii_whitespace()) else {
-        return if decided_by_length {
+    let too_long_to_be_ambiguous = data.len() > MAX_AMBIGUOUS;
+
+    // All whitespace: nothing to judge yet, and no marker to find.
+    let Some(first) = data.iter().position(|&b| !b.is_ascii_whitespace()) else {
+        return if too_long_to_be_ambiguous {
             EomLikeness::No
         } else {
             EomLikeness::Undecided
@@ -192,15 +193,14 @@ pub(crate) fn eom_likeness(data: &[u8]) -> EomLikeness {
         }
         // A truncated read of this marker — wait rather than misclassify.
         if marker.starts_with(trimmed) {
-            return if decided_by_length {
+            return if too_long_to_be_ambiguous {
                 EomLikeness::No
             } else {
                 EomLikeness::Undecided
             };
         }
     }
-    // EOM delimiter anywhere in the buffer. Only reached on a definite answer,
-    // so this scan cannot repeat across reads.
+    // EOM delimiter anywhere in the buffer.
     if data.windows(6).any(|w| w == b"]]>]]>") {
         return EomLikeness::Yes;
     }
@@ -401,6 +401,14 @@ mod tests {
         // while every retry rescans a growing buffer.
         assert_eq!(eom_likeness(&[b' '; 64]), EomLikeness::No);
         assert_eq!(eom_likeness(&[b'\n'; 17]), EomLikeness::No);
+        // ...but the cap must not blind the classifier to a marker or a
+        // delimiter sitting past it. Both are definite answers.
+        let mut padded = vec![b' '; 32];
+        padded.extend_from_slice(b"<?xml version=\"1.0\"?>");
+        assert_eq!(eom_likeness(&padded), EomLikeness::Yes);
+        let mut padded = vec![b' '; 32];
+        padded.extend_from_slice(b"garbage]]>]]>");
+        assert_eq!(eom_likeness(&padded), EomLikeness::Yes);
     }
 
     #[test]

--- a/src/framing/chunked.rs
+++ b/src/framing/chunked.rs
@@ -11,7 +11,7 @@
 //! byte count of the chunk data. The end-of-chunks marker is `\n##\n`.
 
 use crate::error::FramingError;
-use crate::framing::Framer;
+use crate::framing::{FramePart, Framer};
 
 /// Maximum allowed chunk size (4 MB). Prevents memory exhaustion from
 /// malformed chunk headers advertising absurd lengths.
@@ -136,6 +136,89 @@ impl Framer for ChunkedFramer {
             message.extend_from_slice(&buffer[pos..pos + chunk_len]);
             pos += chunk_len;
         }
+    }
+
+    fn decode_part(&self, buffer: &[u8]) -> Result<FramePart, FramingError> {
+        // One chunk per call. Chunked framing is self-describing — each chunk
+        // announces its length — so a chunk can be emitted as soon as it is
+        // complete, without waiting for the end-of-chunks marker.
+        if buffer.len() < 2 {
+            return Ok(FramePart::NeedMore);
+        }
+        if buffer[0] != b'\n' || buffer[1] != b'#' {
+            // Same firmware-bug detection as the all-at-once path: a device
+            // that advertised :base:1.1 and then sent EOM framing.
+            if looks_like_eom_data(buffer) {
+                return Err(FramingError::Mismatch {
+                    advertised: "1.1 (chunked)".to_string(),
+                    actual: "1.0 (EOM)".to_string(),
+                });
+            }
+            return Err(FramingError::Invalid(format!(
+                "expected chunk header, got {:?}",
+                &buffer[..std::cmp::min(4, buffer.len())]
+            )));
+        }
+
+        let mut pos = 2;
+        // End-of-chunks marker: \n##\n
+        if pos < buffer.len() && buffer[pos] == b'#' {
+            if pos + 2 > buffer.len() {
+                return Ok(FramePart::NeedMore);
+            }
+            if buffer[pos + 1] != b'\n' {
+                return Err(FramingError::Invalid(
+                    "expected \\n after ## in end-of-chunks marker".to_string(),
+                ));
+            }
+            return Ok(FramePart::End { consumed: pos + 2 });
+        }
+
+        let len_start = pos;
+        while pos < buffer.len() && buffer[pos] != b'\n' {
+            if !buffer[pos].is_ascii_digit() {
+                return Err(FramingError::Invalid(format!(
+                    "non-digit in chunk length: {:?}",
+                    buffer[pos] as char
+                )));
+            }
+            pos += 1;
+        }
+        if pos >= buffer.len() {
+            return Ok(FramePart::NeedMore);
+        }
+        if pos == len_start {
+            return Err(FramingError::Invalid("empty chunk length".to_string()));
+        }
+        let len_str = std::str::from_utf8(&buffer[len_start..pos])
+            .map_err(|e| FramingError::Invalid(format!("invalid chunk length: {e}")))?;
+        let chunk_len: usize = len_str
+            .parse()
+            .map_err(|e| FramingError::Invalid(format!("invalid chunk length: {e}")))?;
+        if chunk_len == 0 {
+            return Err(FramingError::Invalid("zero-length chunk".to_string()));
+        }
+        // Same bound the all-at-once path enforces. Without it a device can
+        // announce a huge length and force an allocation to match — and at
+        // exactly `usize::MAX` the `pos + chunk_len` below overflows and panics,
+        // which is reachable from device input.
+        if chunk_len > MAX_CHUNK_SIZE {
+            return Err(FramingError::Invalid(format!(
+                "chunk length {chunk_len} exceeds maximum {MAX_CHUNK_SIZE}"
+            )));
+        }
+        pos += 1; // the \n after the length
+
+        let end = pos
+            .checked_add(chunk_len)
+            .ok_or_else(|| FramingError::Invalid("chunk length overflows".to_string()))?;
+        if buffer.len() < end {
+            return Ok(FramePart::NeedMore);
+        }
+        Ok(FramePart::Data {
+            payload: buffer[pos..end].to_vec(),
+            consumed: end,
+        })
     }
 }
 

--- a/src/framing/chunked.rs
+++ b/src/framing/chunked.rs
@@ -141,7 +141,7 @@ impl Framer for ChunkedFramer {
 
 /// Heuristic: does this buffer look like EOM-framed data rather than chunked?
 /// Checks for XML start (`<?xml` or `<rpc`) or the EOM delimiter `]]>]]>`.
-fn looks_like_eom_data(data: &[u8]) -> bool {
+pub(crate) fn looks_like_eom_data(data: &[u8]) -> bool {
     if data.is_empty() {
         return false;
     }

--- a/src/framing/chunked.rs
+++ b/src/framing/chunked.rs
@@ -62,11 +62,16 @@ impl Framer for ChunkedFramer {
                 // Detect EOM-framed data arriving when chunked was negotiated.
                 // This is a known firmware bug on some devices (e.g., certain Junos versions)
                 // that advertise :base:1.1 but actually send EOM-framed responses.
-                if looks_like_eom_data(&buffer[pos..]) {
-                    return Err(FramingError::Mismatch {
-                        advertised: "1.1 (chunked)".to_string(),
-                        actual: "1.0 (EOM)".to_string(),
-                    });
+                match eom_likeness(&buffer[pos..]) {
+                    EomLikeness::Yes => {
+                        return Err(FramingError::Mismatch {
+                            advertised: "1.1 (chunked)".to_string(),
+                            actual: "1.0 (EOM)".to_string(),
+                        });
+                    }
+                    // Too little to tell a truncated `<?xml` from real garbage.
+                    EomLikeness::Undecided => return Ok(None),
+                    EomLikeness::No => {}
                 }
                 return Err(FramingError::Invalid(format!(
                     "expected chunk header at position {pos}, got {:?}",
@@ -141,25 +146,46 @@ impl Framer for ChunkedFramer {
 
 /// Heuristic: does this buffer look like EOM-framed data rather than chunked?
 /// Checks for XML start (`<?xml` or `<rpc`) or the EOM delimiter `]]>]]>`.
-pub(crate) fn looks_like_eom_data(data: &[u8]) -> bool {
-    if data.is_empty() {
-        return false;
-    }
-    // Skip leading whitespace
-    let trimmed = match data.iter().position(|&b| !b.is_ascii_whitespace()) {
-        Some(pos) => &data[pos..],
-        None => return false,
+/// Whether a buffer that is not a chunk header looks like EOM-framed data.
+///
+/// Three-valued on purpose. A transport read may split anywhere, so a buffer
+/// holding only `<?` or `<r` is not yet distinguishable from the `<?xml` /
+/// `<rpc` that identifies the known firmware bug. Answering `No` there would
+/// report a generic parse failure for what is actually a framing mismatch,
+/// and the caller keys its recovery off that distinction.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum EomLikeness {
+    /// A recognised EOM marker is present.
+    Yes,
+    /// Cannot be EOM-framed data.
+    No,
+    /// Could still become a marker once more bytes arrive.
+    Undecided,
+}
+
+pub(crate) fn eom_likeness(data: &[u8]) -> EomLikeness {
+    const MARKERS: [&[u8]; 3] = [b"<?xml", b"<rpc", b"<!--"];
+
+    // All whitespace (or empty): nothing to judge yet.
+    let Some(first) = data.iter().position(|&b| !b.is_ascii_whitespace()) else {
+        return EomLikeness::Undecided;
     };
-    // XML document or element start
-    if trimmed.starts_with(b"<?xml") || trimmed.starts_with(b"<rpc") || trimmed.starts_with(b"<!--")
-    {
-        return true;
+    let trimmed = &data[first..];
+
+    for marker in MARKERS {
+        if trimmed.starts_with(marker) {
+            return EomLikeness::Yes;
+        }
+        // A truncated read of this marker — wait rather than misclassify.
+        if marker.starts_with(trimmed) {
+            return EomLikeness::Undecided;
+        }
     }
-    // EOM delimiter anywhere in the buffer
+    // EOM delimiter anywhere in the buffer.
     if data.windows(6).any(|w| w == b"]]>]]>") {
-        return true;
+        return EomLikeness::Yes;
     }
-    false
+    EomLikeness::No
 }
 
 #[cfg(test)]
@@ -325,6 +351,33 @@ mod tests {
             matches!(err, FramingError::Mismatch { .. }),
             "expected FramingError::Mismatch, got: {err:?}"
         );
+    }
+
+    #[test]
+    fn test_decode_waits_for_a_split_eom_prefix() {
+        // A transport read may end anywhere. `<?` alone must not be reported as
+        // a parse failure — once the rest arrives it is the framing mismatch.
+        let framer = ChunkedFramer::new();
+        for partial in [&b"<?"[..], b"<r", b"<!", b"<", b"  <?xm"] {
+            assert!(
+                matches!(framer.decode(partial), Ok(None)),
+                "expected NeedMore for {partial:?}, got {:?}",
+                framer.decode(partial)
+            );
+        }
+        let err = framer.decode(b"<?xml ").unwrap_err();
+        assert!(
+            matches!(err, FramingError::Mismatch { .. }),
+            "expected Mismatch once the prefix completes, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_eom_likeness_rejects_non_prefixes() {
+        assert_eq!(eom_likeness(b"<x"), EomLikeness::No);
+        assert_eq!(eom_likeness(b"garbage"), EomLikeness::No);
+        assert_eq!(eom_likeness(b"\x00\x01"), EomLikeness::No);
+        assert_eq!(eom_likeness(b"   "), EomLikeness::Undecided);
     }
 
     #[test]

--- a/src/framing/eom.rs
+++ b/src/framing/eom.rs
@@ -4,7 +4,7 @@
 //! The hello exchange always uses EOM framing regardless of version.
 
 use crate::error::FramingError;
-use crate::framing::{FramePart, Framer};
+use crate::framing::Framer;
 
 /// The NETCONF 1.0 end-of-message delimiter.
 const EOM_DELIMITER: &[u8] = b"]]>]]>";
@@ -46,32 +46,6 @@ impl Framer for EomFramer {
             }
             None => Ok(None),
         }
-    }
-
-    fn decode_part(&self, buffer: &[u8]) -> Result<FramePart, FramingError> {
-        if let Some(pos) = find_subsequence(buffer, EOM_DELIMITER) {
-            if pos > 0 {
-                return Ok(FramePart::Data {
-                    payload: buffer[..pos].to_vec(),
-                    consumed: pos,
-                });
-            }
-            return Ok(FramePart::End {
-                consumed: EOM_DELIMITER.len(),
-            });
-        }
-
-        // Hold back anything that could still become a delimiter. Emitting a
-        // trailing `]]>]]` because the final `>` has not arrived yet would put
-        // framing bytes into the caller's payload.
-        let safe = buffer.len().saturating_sub(EOM_DELIMITER.len() - 1);
-        if safe == 0 {
-            return Ok(FramePart::NeedMore);
-        }
-        Ok(FramePart::Data {
-            payload: buffer[..safe].to_vec(),
-            consumed: safe,
-        })
     }
 }
 

--- a/src/framing/eom.rs
+++ b/src/framing/eom.rs
@@ -4,7 +4,7 @@
 //! The hello exchange always uses EOM framing regardless of version.
 
 use crate::error::FramingError;
-use crate::framing::Framer;
+use crate::framing::{FramePart, Framer};
 
 /// The NETCONF 1.0 end-of-message delimiter.
 const EOM_DELIMITER: &[u8] = b"]]>]]>";
@@ -46,6 +46,32 @@ impl Framer for EomFramer {
             }
             None => Ok(None),
         }
+    }
+
+    fn decode_part(&self, buffer: &[u8]) -> Result<FramePart, FramingError> {
+        if let Some(pos) = find_subsequence(buffer, EOM_DELIMITER) {
+            if pos > 0 {
+                return Ok(FramePart::Data {
+                    payload: buffer[..pos].to_vec(),
+                    consumed: pos,
+                });
+            }
+            return Ok(FramePart::End {
+                consumed: EOM_DELIMITER.len(),
+            });
+        }
+
+        // Hold back anything that could still become a delimiter. Emitting a
+        // trailing `]]>]]` because the final `>` has not arrived yet would put
+        // framing bytes into the caller's payload.
+        let safe = buffer.len().saturating_sub(EOM_DELIMITER.len() - 1);
+        if safe == 0 {
+            return Ok(FramePart::NeedMore);
+        }
+        Ok(FramePart::Data {
+            payload: buffer[..safe].to_vec(),
+            consumed: safe,
+        })
     }
 }
 

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -11,6 +11,156 @@
 pub mod chunked;
 pub mod eom;
 
+/// Incremental frame decoding with the state the [`Framer`] trait cannot hold.
+///
+/// `Framer::decode` is all-or-nothing by design and its methods take `&self`,
+/// so it cannot report "half of this chunk is here". That matters: this crate's
+/// own chunked encoder emits **one chunk per message**, so a stateless
+/// chunk-granularity decoder degenerates to buffering the whole reply — and the
+/// streaming API would silently not stream against any NETCONF 1.1 peer.
+#[derive(Debug)]
+pub(crate) enum StreamDecoder {
+    /// EOM: emit everything that cannot still be part of the delimiter.
+    Eom,
+    /// Chunked: `remaining` counts bytes still owed by the chunk in progress.
+    Chunked { remaining: usize },
+}
+
+impl StreamDecoder {
+    pub(crate) fn for_version(chunked: bool) -> Self {
+        if chunked {
+            StreamDecoder::Chunked { remaining: 0 }
+        } else {
+            StreamDecoder::Eom
+        }
+    }
+
+    /// Consume what is available, emitting payload as soon as it is unambiguous.
+    pub(crate) fn decode_part(
+        &mut self,
+        buffer: &[u8],
+    ) -> Result<FramePart, crate::error::FramingError> {
+        match self {
+            StreamDecoder::Eom => Self::eom_part(buffer),
+            StreamDecoder::Chunked { remaining } => Self::chunked_part(buffer, remaining),
+        }
+    }
+
+    fn eom_part(buffer: &[u8]) -> Result<FramePart, crate::error::FramingError> {
+        const DELIM: &[u8] = b"]]>]]>";
+        if let Some(pos) = buffer.windows(DELIM.len()).position(|w| w == DELIM) {
+            if pos > 0 {
+                return Ok(FramePart::Data {
+                    payload: buffer[..pos].to_vec(),
+                    consumed: pos,
+                });
+            }
+            return Ok(FramePart::End {
+                consumed: DELIM.len(),
+            });
+        }
+        // Hold back a possible partial delimiter, or framing bytes reach the
+        // caller as payload.
+        let safe = buffer.len().saturating_sub(DELIM.len() - 1);
+        if safe == 0 {
+            return Ok(FramePart::NeedMore);
+        }
+        Ok(FramePart::Data {
+            payload: buffer[..safe].to_vec(),
+            consumed: safe,
+        })
+    }
+
+    fn chunked_part(
+        buffer: &[u8],
+        remaining: &mut usize,
+    ) -> Result<FramePart, crate::error::FramingError> {
+        // Mid-chunk: emit whatever has arrived. This is the whole point — a
+        // single large chunk streams instead of being buffered entire.
+        if *remaining > 0 {
+            if buffer.is_empty() {
+                return Ok(FramePart::NeedMore);
+            }
+            let take = buffer.len().min(*remaining);
+            *remaining -= take;
+            return Ok(FramePart::Data {
+                payload: buffer[..take].to_vec(),
+                consumed: take,
+            });
+        }
+
+        if buffer.len() < 2 {
+            return Ok(FramePart::NeedMore);
+        }
+        if buffer[0] != b'\n' || buffer[1] != b'#' {
+            return Err(crate::error::FramingError::Invalid(format!(
+                "expected chunk header, got {:?}",
+                &buffer[..buffer.len().min(4)]
+            )));
+        }
+        let mut pos = 2;
+        // `\n#` alone: the next byte decides between a length and the
+        // end-of-chunks marker, and indexing for it before it arrives panics on
+        // input a peer fully controls.
+        let Some(&after_hash) = buffer.get(pos) else {
+            return Ok(FramePart::NeedMore);
+        };
+        if after_hash == b'#' {
+            if pos + 2 > buffer.len() {
+                return Ok(FramePart::NeedMore);
+            }
+            if buffer[pos + 1] != b'\n' {
+                return Err(crate::error::FramingError::Invalid(
+                    "expected \\n after ## in end-of-chunks marker".to_string(),
+                ));
+            }
+            return Ok(FramePart::End { consumed: pos + 2 });
+        }
+        let len_start = pos;
+        while pos < buffer.len() && buffer[pos] != b'\n' {
+            if !buffer[pos].is_ascii_digit() {
+                return Err(crate::error::FramingError::Invalid(
+                    "non-digit in chunk length".to_string(),
+                ));
+            }
+            pos += 1;
+        }
+        if pos >= buffer.len() {
+            return Ok(FramePart::NeedMore);
+        }
+        if pos == len_start {
+            return Err(crate::error::FramingError::Invalid(
+                "empty chunk length".to_string(),
+            ));
+        }
+        let len: usize = std::str::from_utf8(&buffer[len_start..pos])
+            .ok()
+            .and_then(|t| t.parse().ok())
+            .ok_or_else(|| {
+                crate::error::FramingError::Invalid("invalid chunk length".to_string())
+            })?;
+        if len == 0 {
+            return Err(crate::error::FramingError::Invalid(
+                "zero-length chunk".to_string(),
+            ));
+        }
+        // The all-at-once path bounds this; so does this one. Unbounded, a peer
+        // can demand an arbitrary allocation.
+        if len > chunked::MAX_CHUNK_SIZE {
+            return Err(crate::error::FramingError::Invalid(format!(
+                "chunk length {len} exceeds maximum {}",
+                chunked::MAX_CHUNK_SIZE
+            )));
+        }
+        pos += 1;
+        *remaining = len;
+        Ok(FramePart::Data {
+            payload: Vec::new(),
+            consumed: pos,
+        })
+    }
+}
+
 /// One step of incremental frame decoding.
 ///
 /// Exists so a large reply can be consumed without holding it whole. The
@@ -43,39 +193,20 @@ pub trait Framer: Send + Sync {
     /// where `consumed` is the number of bytes to drain from the buffer.
     /// Returns `None` if the buffer doesn't contain a complete message yet.
     fn decode(&self, buffer: &[u8]) -> Result<Option<(String, usize)>, crate::error::FramingError>;
-
-    /// Decode as much as is currently possible without waiting for the whole
-    /// message.
-    ///
-    /// Defaults to reporting that streaming is unsupported, so implementations
-    /// written against an earlier version keep compiling. `Framer` is public and
-    /// downstream crates implement it; making this required would break every
-    /// such implementation on a patch upgrade.
-    ///
-    /// Implementations must never emit bytes that could still turn out to be
-    /// part of a terminator once more input arrives — a partial `]]>]]>` at the
-    /// end of the buffer has to be held back, or the caller receives framing
-    /// bytes as payload.
-    fn decode_part(&self, buffer: &[u8]) -> Result<FramePart, crate::error::FramingError> {
-        let _ = buffer;
-        Err(crate::error::FramingError::Invalid(
-            "this Framer does not implement incremental decoding".to_string(),
-        ))
-    }
 }
 
 #[cfg(test)]
 mod incremental_tests {
     use super::chunked::ChunkedFramer;
     use super::eom::EomFramer;
-    use super::{FramePart, Framer};
+    use super::{FramePart, Framer, StreamDecoder};
 
     /// Drive `decode_part` to completion, returning the reassembled payload.
-    fn drain(framer: &dyn Framer, input: &[u8]) -> Vec<u8> {
+    fn drain(mut decoder: StreamDecoder, input: &[u8]) -> Vec<u8> {
         let mut out = Vec::new();
         let mut buf = input.to_vec();
         loop {
-            match framer.decode_part(&buf).expect("decode_part") {
+            match decoder.decode_part(&buf).expect("decode_part") {
                 FramePart::Data { payload, consumed } => {
                     out.extend_from_slice(&payload);
                     buf.drain(..consumed);
@@ -91,18 +222,20 @@ mod incremental_tests {
 
     #[test]
     fn eom_incremental_matches_all_at_once() {
-        let framer = EomFramer;
         let msg = "<rpc-reply><data>x</data></rpc-reply>";
-        let framed = framer.encode(msg);
-        assert_eq!(drain(&framer, &framed), msg.as_bytes());
+        let framed = EomFramer.encode(msg);
+        assert_eq!(
+            drain(StreamDecoder::for_version(false), &framed),
+            msg.as_bytes()
+        );
     }
 
     #[test]
     fn eom_holds_back_a_partial_delimiter() {
         // `]]>]]` could still become the delimiter. Emitting it would put
         // framing bytes into the caller's payload.
-        let framer = EomFramer;
-        match framer.decode_part(b"abc]]>]]").expect("decode_part") {
+        let mut dec = StreamDecoder::for_version(false);
+        match dec.decode_part(b"abc]]>]]").expect("decode_part") {
             FramePart::Data { payload, .. } => {
                 assert_eq!(payload, b"abc", "must stop before the partial delimiter");
             }
@@ -112,44 +245,69 @@ mod incremental_tests {
 
     #[test]
     fn eom_needs_more_when_only_a_partial_delimiter_is_present() {
-        let framer = EomFramer;
+        let mut dec = StreamDecoder::for_version(false);
         assert_eq!(
-            framer.decode_part(b"]]>]]").expect("decode_part"),
+            dec.decode_part(b"]]>]]").expect("decode_part"),
             FramePart::NeedMore
         );
     }
 
     #[test]
     fn chunked_incremental_matches_all_at_once() {
-        let framer = ChunkedFramer;
         let msg = "<rpc-reply><data>hello</data></rpc-reply>";
-        let framed = framer.encode(msg);
-        assert_eq!(drain(&framer, &framed), msg.as_bytes());
+        let framed = ChunkedFramer.encode(msg);
+        assert_eq!(
+            drain(StreamDecoder::for_version(true), &framed),
+            msg.as_bytes()
+        );
+    }
+
+    #[test]
+    fn chunked_emits_a_partial_chunk() {
+        // The property the streaming API rests on. This crate's encoder emits
+        // one chunk per message, so a decoder that waits for a whole chunk
+        // never streams anything at all against a NETCONF 1.1 peer.
+        let mut dec = StreamDecoder::for_version(true);
+        match dec.decode_part(b"\n#100\nhalf").expect("decode_part") {
+            FramePart::Data { payload, consumed } => {
+                // The header alone on the first call.
+                assert!(payload.is_empty());
+                assert_eq!(consumed, 6);
+            }
+            other => panic!("expected the header, got {other:?}"),
+        }
+        match dec.decode_part(b"half").expect("decode_part") {
+            FramePart::Data { payload, consumed } => {
+                assert_eq!(payload, b"half", "must emit what has arrived");
+                assert_eq!(consumed, 4);
+            }
+            other => panic!("expected partial data, got {other:?}"),
+        }
     }
 
     #[test]
     fn chunked_emits_each_chunk_without_waiting_for_the_end_marker() {
         // Two chunks, no terminator yet: the first must still be emitted.
-        let framer = ChunkedFramer;
-        let input = b"\n#5\nhello\n#5\nworld";
-        match framer.decode_part(input).expect("decode_part") {
-            FramePart::Data { payload, consumed } => {
-                assert_eq!(payload, b"hello");
-                assert_eq!(consumed, 9);
+        let mut dec = StreamDecoder::for_version(true);
+        let mut buf: Vec<u8> = b"\n#5\nhello\n#5\nworld".to_vec();
+        let mut out = Vec::new();
+        for _ in 0..2 {
+            match dec.decode_part(&buf).expect("decode_part") {
+                FramePart::Data { payload, consumed } => {
+                    out.extend_from_slice(&payload);
+                    buf.drain(..consumed);
+                }
+                other => panic!("expected Data, got {other:?}"),
             }
-            other => panic!("expected Data, got {other:?}"),
         }
+        assert_eq!(out, b"hello");
     }
 
     #[test]
     fn chunked_needs_more_on_a_truncated_chunk() {
-        let framer = ChunkedFramer;
+        let mut dec = StreamDecoder::for_version(true);
         assert_eq!(
-            framer.decode_part(b"\n#10\nshort").expect("decode_part"),
-            FramePart::NeedMore
-        );
-        assert_eq!(
-            framer.decode_part(b"\n#").expect("decode_part"),
+            dec.decode_part(b"\n#").expect("decode_part"),
             FramePart::NeedMore
         );
     }
@@ -158,15 +316,15 @@ mod incremental_tests {
     fn chunked_bounds_the_announced_length() {
         // Unbounded, a device can demand an arbitrary allocation — and at
         // exactly usize::MAX the offset arithmetic overflows and panics.
-        let framer = ChunkedFramer;
-        assert!(framer.decode_part(b"\n#99999999\nx").is_err());
+        let mut dec = StreamDecoder::for_version(true);
+        assert!(dec.decode_part(b"\n#99999999\nx").is_err());
         let huge = format!("\n#{}\nx", usize::MAX);
-        assert!(framer.decode_part(huge.as_bytes()).is_err());
+        assert!(dec.decode_part(huge.as_bytes()).is_err());
     }
 
     #[test]
     fn chunked_still_detects_eom_framing_from_a_lying_device() {
-        let framer = ChunkedFramer;
-        assert!(framer.decode_part(b"<rpc-reply/>]]>]]>").is_err());
+        let mut dec = StreamDecoder::for_version(true);
+        assert!(dec.decode_part(b"<rpc-reply/>]]>]]>").is_err());
     }
 }

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -11,6 +11,25 @@
 pub mod chunked;
 pub mod eom;
 
+/// One step of incremental frame decoding.
+///
+/// Exists so a large reply can be consumed without holding it whole. The
+/// all-at-once [`Framer::decode`] cannot do that: it returns nothing until the
+/// entire message is buffered, so peak memory is the reply size regardless of
+/// what the caller does with it.
+#[derive(Debug, PartialEq, Eq)]
+pub enum FramePart {
+    /// Payload ready to emit now, plus the input bytes consumed producing it.
+    ///
+    /// `consumed` may exceed `payload.len()` — framing overhead (chunk headers)
+    /// is consumed but not emitted.
+    Data { payload: Vec<u8>, consumed: usize },
+    /// The message ended. `consumed` covers the terminator.
+    End { consumed: usize },
+    /// Not enough input to make progress.
+    NeedMore,
+}
+
 /// Trait for encoding/decoding NETCONF message frames.
 ///
 /// Implementors handle the wire-level framing for one NETCONF version.
@@ -24,4 +43,130 @@ pub trait Framer: Send + Sync {
     /// where `consumed` is the number of bytes to drain from the buffer.
     /// Returns `None` if the buffer doesn't contain a complete message yet.
     fn decode(&self, buffer: &[u8]) -> Result<Option<(String, usize)>, crate::error::FramingError>;
+
+    /// Decode as much as is currently possible without waiting for the whole
+    /// message.
+    ///
+    /// Defaults to reporting that streaming is unsupported, so implementations
+    /// written against an earlier version keep compiling. `Framer` is public and
+    /// downstream crates implement it; making this required would break every
+    /// such implementation on a patch upgrade.
+    ///
+    /// Implementations must never emit bytes that could still turn out to be
+    /// part of a terminator once more input arrives — a partial `]]>]]>` at the
+    /// end of the buffer has to be held back, or the caller receives framing
+    /// bytes as payload.
+    fn decode_part(&self, buffer: &[u8]) -> Result<FramePart, crate::error::FramingError> {
+        let _ = buffer;
+        Err(crate::error::FramingError::Invalid(
+            "this Framer does not implement incremental decoding".to_string(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod incremental_tests {
+    use super::chunked::ChunkedFramer;
+    use super::eom::EomFramer;
+    use super::{FramePart, Framer};
+
+    /// Drive `decode_part` to completion, returning the reassembled payload.
+    fn drain(framer: &dyn Framer, input: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        let mut buf = input.to_vec();
+        loop {
+            match framer.decode_part(&buf).expect("decode_part") {
+                FramePart::Data { payload, consumed } => {
+                    out.extend_from_slice(&payload);
+                    buf.drain(..consumed);
+                }
+                FramePart::End { consumed } => {
+                    buf.drain(..consumed);
+                    return out;
+                }
+                FramePart::NeedMore => panic!("ran out of input mid-frame"),
+            }
+        }
+    }
+
+    #[test]
+    fn eom_incremental_matches_all_at_once() {
+        let framer = EomFramer;
+        let msg = "<rpc-reply><data>x</data></rpc-reply>";
+        let framed = framer.encode(msg);
+        assert_eq!(drain(&framer, &framed), msg.as_bytes());
+    }
+
+    #[test]
+    fn eom_holds_back_a_partial_delimiter() {
+        // `]]>]]` could still become the delimiter. Emitting it would put
+        // framing bytes into the caller's payload.
+        let framer = EomFramer;
+        match framer.decode_part(b"abc]]>]]").expect("decode_part") {
+            FramePart::Data { payload, .. } => {
+                assert_eq!(payload, b"abc", "must stop before the partial delimiter");
+            }
+            other => panic!("expected Data, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn eom_needs_more_when_only_a_partial_delimiter_is_present() {
+        let framer = EomFramer;
+        assert_eq!(
+            framer.decode_part(b"]]>]]").expect("decode_part"),
+            FramePart::NeedMore
+        );
+    }
+
+    #[test]
+    fn chunked_incremental_matches_all_at_once() {
+        let framer = ChunkedFramer;
+        let msg = "<rpc-reply><data>hello</data></rpc-reply>";
+        let framed = framer.encode(msg);
+        assert_eq!(drain(&framer, &framed), msg.as_bytes());
+    }
+
+    #[test]
+    fn chunked_emits_each_chunk_without_waiting_for_the_end_marker() {
+        // Two chunks, no terminator yet: the first must still be emitted.
+        let framer = ChunkedFramer;
+        let input = b"\n#5\nhello\n#5\nworld";
+        match framer.decode_part(input).expect("decode_part") {
+            FramePart::Data { payload, consumed } => {
+                assert_eq!(payload, b"hello");
+                assert_eq!(consumed, 9);
+            }
+            other => panic!("expected Data, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chunked_needs_more_on_a_truncated_chunk() {
+        let framer = ChunkedFramer;
+        assert_eq!(
+            framer.decode_part(b"\n#10\nshort").expect("decode_part"),
+            FramePart::NeedMore
+        );
+        assert_eq!(
+            framer.decode_part(b"\n#").expect("decode_part"),
+            FramePart::NeedMore
+        );
+    }
+
+    #[test]
+    fn chunked_bounds_the_announced_length() {
+        // Unbounded, a device can demand an arbitrary allocation — and at
+        // exactly usize::MAX the offset arithmetic overflows and panics.
+        let framer = ChunkedFramer;
+        assert!(framer.decode_part(b"\n#99999999\nx").is_err());
+        let huge = format!("\n#{}\nx", usize::MAX);
+        assert!(framer.decode_part(huge.as_bytes()).is_err());
+    }
+
+    #[test]
+    fn chunked_still_detects_eom_framing_from_a_lying_device() {
+        let framer = ChunkedFramer;
+        assert!(framer.decode_part(b"<rpc-reply/>]]>]]>").is_err());
+    }
 }

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -93,6 +93,16 @@ impl StreamDecoder {
             return Ok(FramePart::NeedMore);
         }
         if buffer[0] != b'\n' || buffer[1] != b'#' {
+            // Same classification the all-at-once path applies. Some firmware
+            // advertises :base:1.1 and then sends EOM-framed replies; callers
+            // key recovery and diagnostics off this typed variant, so the
+            // streaming path must not flatten it to a generic parse failure.
+            if chunked::looks_like_eom_data(buffer) {
+                return Err(crate::error::FramingError::Mismatch {
+                    advertised: "1.1 (chunked)".to_string(),
+                    actual: "1.0 (EOM)".to_string(),
+                });
+            }
             return Err(crate::error::FramingError::Invalid(format!(
                 "expected chunk header, got {:?}",
                 &buffer[..buffer.len().min(4)]
@@ -325,6 +335,13 @@ mod incremental_tests {
     #[test]
     fn chunked_still_detects_eom_framing_from_a_lying_device() {
         let mut dec = StreamDecoder::for_version(true);
-        assert!(dec.decode_part(b"<rpc-reply/>]]>]]>").is_err());
+        let err = dec
+            .decode_part(b"<?xml version=\"1.0\"?><rpc-reply><ok/></rpc-reply>]]>]]>")
+            .expect_err("EOM data under chunked framing must fail");
+        // The variant, not merely an error: callers switch on it.
+        assert!(
+            matches!(err, crate::error::FramingError::Mismatch { .. }),
+            "expected FramingError::Mismatch, got: {err:?}"
+        );
     }
 }

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -97,11 +97,17 @@ impl StreamDecoder {
             // advertises :base:1.1 and then sends EOM-framed replies; callers
             // key recovery and diagnostics off this typed variant, so the
             // streaming path must not flatten it to a generic parse failure.
-            if chunked::looks_like_eom_data(buffer) {
-                return Err(crate::error::FramingError::Mismatch {
-                    advertised: "1.1 (chunked)".to_string(),
-                    actual: "1.0 (EOM)".to_string(),
-                });
+            match chunked::eom_likeness(buffer) {
+                chunked::EomLikeness::Yes => {
+                    return Err(crate::error::FramingError::Mismatch {
+                        advertised: "1.1 (chunked)".to_string(),
+                        actual: "1.0 (EOM)".to_string(),
+                    });
+                }
+                // A read can split anywhere: `<?` is not yet distinguishable
+                // from `<?xml`. Wait rather than report the wrong error.
+                chunked::EomLikeness::Undecided => return Ok(FramePart::NeedMore),
+                chunked::EomLikeness::No => {}
             }
             return Err(crate::error::FramingError::Invalid(format!(
                 "expected chunk header, got {:?}",
@@ -330,6 +336,24 @@ mod incremental_tests {
         assert!(dec.decode_part(b"\n#99999999\nx").is_err());
         let huge = format!("\n#{}\nx", usize::MAX);
         assert!(dec.decode_part(huge.as_bytes()).is_err());
+    }
+
+    #[test]
+    fn chunked_waits_for_a_split_eom_prefix() {
+        // The streaming loop calls the decoder after every read, so it sees
+        // shorter buffers than the all-at-once path ever does.
+        let mut dec = StreamDecoder::for_version(true);
+        assert_eq!(
+            dec.decode_part(b"<?").expect("decode_part"),
+            FramePart::NeedMore
+        );
+        let err = dec
+            .decode_part(b"<?xml version=\"1.0\"?>")
+            .expect_err("the completed prefix is a framing mismatch");
+        assert!(
+            matches!(err, crate::error::FramingError::Mismatch { .. }),
+            "expected Mismatch, got: {err:?}"
+        );
     }
 
     #[test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -26,7 +26,7 @@ use crate::error::{FramingError, NetconfError, ProtocolError, TransportError};
 use crate::facts::Facts;
 use crate::framing::chunked::ChunkedFramer;
 use crate::framing::eom::EomFramer;
-use crate::framing::Framer;
+use crate::framing::{FramePart, Framer};
 use crate::notification::{self, MessageKind, Notification};
 use crate::rpc;
 use crate::rpc::filter::XPathFilter;
@@ -103,6 +103,8 @@ pub struct Session {
     /// Set before a `<partial-lock>` is written and cleared only once a
     /// `lock-id` has been parsed from the reply. See [`Session::is_alive`].
     partial_lock_uncertain: bool,
+    /// Set while a streamed reply is partially drained. See `stream_rpc`.
+    stream_incomplete: bool,
     /// True if this session may have left uncommitted changes in the shared
     /// candidate datastore. Used to decide whether to send `<discard-changes/>`
     /// on close.
@@ -134,6 +136,7 @@ impl Session {
             rpc_timeout: None,
             max_read_buffer: MAX_READ_BUFFER,
             partial_lock_uncertain: false,
+            stream_incomplete: false,
             candidate_dirty: false,
         }
     }
@@ -384,7 +387,9 @@ impl Session {
     ///
     /// Fast in-memory check — does not send any RPC.
     pub fn is_alive(&self) -> bool {
-        self.state == SessionState::Established && !self.partial_lock_uncertain
+        self.state == SessionState::Established
+            && !self.partial_lock_uncertain
+            && !self.stream_incomplete
     }
 
     /// Probe the session by sending a lightweight RPC.
@@ -624,6 +629,11 @@ impl Session {
 
     /// Ensure the session is established before sending RPCs.
     fn ensure_established(&self) -> Result<(), NetconfError> {
+        // A partially-drained stream leaves a suffix of someone else's reply in
+        // the buffer; the next RPC would parse that as its own response.
+        if self.stream_incomplete {
+            return Err(ProtocolError::SessionExpired.into());
+        }
         match self.state {
             SessionState::Established => Ok(()),
             SessionState::Closed => Err(ProtocolError::SessionClosed.into()),
@@ -958,6 +968,304 @@ impl Session {
         .into())
     }
 
+    /// Stream a `<get-config>` reply into `sink` instead of buffering it.
+    ///
+    /// Peak memory becomes one transport read plus one frame chunk, rather than
+    /// the whole reply. That is the point: [`get_config`](Self::get_config)
+    /// accumulates the entire response before returning it, so fetching a large
+    /// configuration costs its size in resident memory even if the caller only
+    /// writes it to a file.
+    ///
+    /// # What the caller receives
+    ///
+    /// The raw `<rpc-reply>` document, verbatim. Deliberately *not* the unwrapped
+    /// `<data>` contents that `get_config` returns, because neither of the two
+    /// transformations that produce those can run on a stream:
+    ///
+    /// - `VendorProfile::unwrap_config` locates the wrapper with
+    ///   `rfind("</configuration>")`, which needs the whole string
+    /// - the reply-repair layer decides on a *closed* payload — the SRX345
+    ///   `<ok/>`-after-`<commit-results>` tolerance is a judgement about a
+    ///   complete document, and cannot be made retroactively
+    ///
+    /// So a caller streaming a reply parses the envelope themselves. That is the
+    /// honest trade for constant memory, and it is why this is a separate method
+    /// rather than a flag on the existing one.
+    ///
+    /// `<rpc-error>` replies are streamed too, not turned into `Err` — detecting
+    /// one requires parsing the envelope, which is exactly what this method does
+    /// not do. Check the document you receive.
+    pub async fn get_config_streaming<W>(
+        &mut self,
+        source: Datastore,
+        filter: Option<&str>,
+        sink: &mut W,
+    ) -> Result<usize, NetconfError>
+    where
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        if let Some(filter_xml) = filter {
+            rpc::validate_xml_fragment(filter_xml)?;
+        }
+        let msg_id = self.next_message_id();
+        let xml = operations::get_config_xml(&msg_id, source, filter);
+        self.stream_rpc(&xml, &msg_id, sink).await
+    }
+
+    /// Stream a `<get>` reply into `sink`. See
+    /// [`get_config_streaming`](Self::get_config_streaming) for what the caller
+    /// receives and why.
+    pub async fn get_streaming<W>(
+        &mut self,
+        filter: Option<&str>,
+        sink: &mut W,
+    ) -> Result<usize, NetconfError>
+    where
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        if let Some(filter_xml) = filter {
+            rpc::validate_xml_fragment(filter_xml)?;
+        }
+        let msg_id = self.next_message_id();
+        let xml = operations::get_xml(&msg_id, filter);
+        self.stream_rpc(&xml, &msg_id, sink).await
+    }
+
+    /// Send `xml` and write the framed reply to `sink` as it arrives.
+    ///
+    /// Returns the number of payload bytes written.
+    async fn stream_rpc<W>(
+        &mut self,
+        xml: &str,
+        message_id: &str,
+        sink: &mut W,
+    ) -> Result<usize, NetconfError>
+    where
+        W: tokio::io::AsyncWrite + Unpin,
+    {
+        use tokio::io::AsyncWriteExt;
+
+        // Checked before the keepalive probe. A device that does not answer RPCs
+        // on a subscribed session would otherwise hang on the probe, or have the
+        // session marked closed, instead of getting this immediate rejection.
+        //
+        // Streaming reads one frame off the wire and hands it straight to the
+        // caller — it cannot demultiplex. With a subscription active, an RFC
+        // 5277 notification can arrive before the reply, and this would return
+        // the notification as the result while the real reply stayed queued.
+        // `send_rpc_raw` classifies frames and buffers notifications; there is
+        // no way to do that while streaming, so refuse instead of racing.
+        if self.has_subscription {
+            return Err(ProtocolError::Xml(
+                "streaming replies is not supported while a notification subscription \
+                 is active: notifications and replies cannot be told apart without \
+                 buffering the frame"
+                    .to_string(),
+            )
+            .into());
+        }
+
+        // Refused while the candidate holds uncommitted edits.
+        //
+        // An interrupted stream poisons the session, and a poisoned session
+        // rejects `discard_changes` — while `close_session` swallows that
+        // failure and drops the transport. On a shared Junos candidate that
+        // leaves another operator's next lock staring at edits nobody owns.
+        // Streaming is a read; requiring a clean candidate for it costs callers
+        // nothing and keeps the cleanup path that #71 and #74 spent four
+        // revisions getting right.
+        if self.candidate_dirty {
+            return Err(ProtocolError::Xml(
+                "cannot stream a reply while the candidate is dirty: an interrupted \
+                 stream would block the discard that cleans it up"
+                    .to_string(),
+            )
+            .into());
+        }
+
+        self.keepalive_check().await?;
+        self.ensure_established()?;
+
+        let framed = self.framer.encode(xml);
+        self.transport.write_all(&framed).await?;
+
+        // Set before the first read and cleared only on a complete frame.
+        //
+        // Once any part has been drained, the buffer holds a *suffix* of this
+        // reply. If the future is cancelled or the sink errors there, the next
+        // RPC on this session parses that suffix as its own response and fails —
+        // and a pooled connection would be handed to someone else in that state.
+        // Nothing after an await runs when a future is dropped, so this has to
+        // be set first, exactly as the partial-lock path does.
+        self.stream_incomplete = true;
+
+        // One deadline for the whole reply, not one per read. A peer that drips
+        // a byte before each individual timeout expires would otherwise reset it
+        // forever and stream indefinitely under a configured `rpc_timeout`; the
+        // buffered path bounds the entire loop, so this does too.
+        let deadline = self.rpc_timeout.map(|t| tokio::time::Instant::now() + t);
+
+        let mut written = 0usize;
+        let mut temp = vec![0u8; READ_BUF_SIZE];
+        // Held back until the reply's message-id has been checked. A prior RPC
+        // that was cancelled or timed out can leave its reply queued, and
+        // emitting that to the sink would hand the caller stale XML while the
+        // requested reply stayed unread. `send_rpc_raw` discards mismatched
+        // frames; this does the same, it just has to peek first.
+        //
+        // Bounded: `message-id` is an attribute on the opening `<rpc-reply>`, so
+        // it is within the first few hundred bytes of any real reply. If it has
+        // not appeared by then the frame is not one we can verify, and is
+        // discarded rather than trusted.
+        const ID_PEEK_LIMIT: usize = 8192;
+        let mut prefix: Vec<u8> = Vec::new();
+        let mut verified = false;
+        let mut discarding = false;
+
+        loop {
+            loop {
+                match self.framer.decode_part(&self.read_buffer)? {
+                    FramePart::Data { payload, consumed } => {
+                        self.read_buffer.drain(..consumed);
+                        if discarding {
+                            continue;
+                        }
+                        if verified {
+                            sink.write_all(&payload).await.map_err(TransportError::Io)?;
+                            written += payload.len();
+                            continue;
+                        }
+                        prefix.extend_from_slice(&payload);
+                        match Self::reply_message_id(&prefix) {
+                            Some(found) if found == message_id => {
+                                verified = true;
+                                sink.write_all(&prefix).await.map_err(TransportError::Io)?;
+                                written += prefix.len();
+                                prefix.clear();
+                            }
+                            Some(_) => {
+                                // A stale reply. Swallow the rest of this frame
+                                // and keep waiting for ours.
+                                discarding = true;
+                                prefix.clear();
+                            }
+                            None if prefix.len() > ID_PEEK_LIMIT => {
+                                discarding = true;
+                                prefix.clear();
+                            }
+                            None => {}
+                        }
+                    }
+                    FramePart::End { consumed } => {
+                        self.read_buffer.drain(..consumed);
+                        if discarding || !verified {
+                            // That frame was not ours. Reset and wait for the
+                            // next one; the buffer is back at a boundary.
+                            discarding = false;
+                            verified = false;
+                            prefix.clear();
+                            continue;
+                        }
+                        // Cleared before the flush: the terminator is consumed,
+                        // so the session is at a valid message boundary and a
+                        // failing sink must not condemn an otherwise healthy
+                        // pooled connection.
+                        self.stream_incomplete = false;
+                        self.last_activity = Some(Instant::now());
+                        sink.flush().await.map_err(TransportError::Io)?;
+                        return Ok(written);
+                    }
+                    FramePart::NeedMore => break,
+                }
+            }
+
+            if self.read_buffer.len() > self.max_read_buffer {
+                return Err(TransportError::Io(std::io::Error::new(
+                    std::io::ErrorKind::OutOfMemory,
+                    format!(
+                        "{} bytes held without completing a frame (ceiling {})",
+                        self.read_buffer.len(),
+                        self.max_read_buffer
+                    ),
+                ))
+                .into());
+            }
+
+            let n = match deadline {
+                Some(at) => tokio::time::timeout_at(at, self.transport.read(&mut temp))
+                    .await
+                    .map_err(|_| {
+                        crate::error::RpcError::Timeout(self.rpc_timeout.unwrap_or_default())
+                    })??,
+                None => self.transport.read(&mut temp).await?,
+            };
+            if n == 0 {
+                return Err(TransportError::Io(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "connection closed mid-reply while streaming",
+                ))
+                .into());
+            }
+            self.read_buffer.extend_from_slice(&temp[..n]);
+        }
+    }
+
+    /// Extract `message-id` from the first element's opening tag, if it has
+    /// arrived yet.
+    ///
+    /// Byte-wise and bounded to that tag on purpose. Decoding the whole prefix
+    /// as UTF-8 fails whenever a read or chunk boundary lands mid-codepoint,
+    /// which would discard a perfectly valid reply for a reason that has nothing
+    /// to do with its contents. Restricting the search to the opening tag also
+    /// stops `message-id` being matched inside a leading comment or processing
+    /// instruction.
+    fn reply_message_id(prefix: &[u8]) -> Option<String> {
+        // First real element start: skip `<?...?>` and `<!--...-->`.
+        let mut i = 0;
+        loop {
+            let lt = prefix[i..].iter().position(|&b| b == b'<')? + i;
+            match prefix.get(lt + 1) {
+                Some(b'?') | Some(b'!') => {
+                    let gt = prefix[lt..].iter().position(|&b| b == b'>')? + lt;
+                    i = gt + 1;
+                }
+                Some(_) => {
+                    let gt = prefix[lt..].iter().position(|&b| b == b'>')? + lt;
+                    return Self::message_id_in_tag(&prefix[lt..=gt]);
+                }
+                // Tag has not arrived in full yet.
+                None => return None,
+            }
+        }
+    }
+
+    /// `message-id="..."` within one opening tag's bytes.
+    fn message_id_in_tag(tag: &[u8]) -> Option<String> {
+        let at = tag
+            .windows(b"message-id".len())
+            .position(|w| w == b"message-id")?;
+        let mut j = at + b"message-id".len();
+        while j < tag.len() && tag[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        if tag.get(j)? != &b'=' {
+            return None;
+        }
+        j += 1;
+        while j < tag.len() && tag[j].is_ascii_whitespace() {
+            j += 1;
+        }
+        let quote = *tag.get(j)?;
+        if quote != b'"' && quote != b'\'' {
+            return None;
+        }
+        j += 1;
+        let close = tag[j..].iter().position(|&b| b == quote)? + j;
+        // The id itself is ASCII in practice, but decode defensively rather
+        // than assuming.
+        std::str::from_utf8(&tag[j..close]).ok().map(str::to_string)
+    }
+
     /// Fetch configuration using an XPath filter (RFC 6241 §6.4).
     ///
     /// Returns [`ProtocolError::CapabilityMissing`] when the device did not
@@ -1188,6 +1496,9 @@ impl Session {
     /// Error when a previous partial lock or unlock left this session's lock
     /// state unknown.
     fn ensure_lock_state_known(&self) -> Result<(), NetconfError> {
+        if self.stream_incomplete {
+            return Err(ProtocolError::SessionExpired.into());
+        }
         if self.partial_lock_uncertain {
             return Err(ProtocolError::SessionExpired.into());
         }
@@ -3411,6 +3722,206 @@ mod tests {
         // so raising it for one fetch must be reversible.
         session.set_max_read_buffer(default);
         assert_eq!(session.max_read_buffer(), default);
+    }
+
+    #[tokio::test]
+    async fn streaming_get_config_writes_the_reply() {
+        let mut data = mock_device_hello();
+        data.extend_from_slice(&mock_data_reply(
+            "1",
+            "<system><host-name>r1</host-name></system>",
+        ));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let mut out: Vec<u8> = Vec::new();
+        let n = session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect("streaming get-config");
+
+        let text = String::from_utf8(out).expect("utf-8");
+        assert_eq!(n, text.len());
+        // The *raw envelope*, not the unwrapped payload — that is the contract.
+        assert!(text.contains("<rpc-reply"), "got {text}");
+        assert!(text.contains("<host-name>r1</host-name>"), "got {text}");
+    }
+
+    #[tokio::test]
+    async fn streaming_survives_a_reply_larger_than_the_ceiling() {
+        // The point of the feature: emitted bytes leave the buffer, so a reply
+        // far bigger than `max_read_buffer` streams fine where `get_config`
+        // would refuse it.
+        let big = "x".repeat(256 * 1024);
+        let mut data = mock_device_hello();
+        data.extend_from_slice(&mock_data_reply("1", &big));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        session.set_max_read_buffer(64 * 1024);
+
+        let mut out: Vec<u8> = Vec::new();
+        let n = session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect("a large reply must stream under a small ceiling");
+        assert!(n > 256 * 1024, "expected the whole payload, got {n}");
+    }
+
+    #[tokio::test]
+    async fn streaming_reports_eof_mid_reply() {
+        // Hello, then a truncated frame: the stream must fail rather than
+        // silently returning a partial document.
+        let mut data = mock_device_hello();
+        data.extend_from_slice(b"<rpc-reply><data>partial");
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let mut out: Vec<u8> = Vec::new();
+        let err = session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect_err("truncated reply must be an error");
+        assert!(err.to_string().contains("mid-reply"), "got {err}");
+    }
+
+    #[tokio::test]
+    async fn streaming_skips_a_stale_reply_and_returns_ours() {
+        // A cancelled RPC can leave its reply queued. Streaming it would hand
+        // the caller someone else's XML and leave the real reply unread.
+        let mut data = mock_device_hello();
+        data.extend_from_slice(&mock_data_reply("99", "<stale/>")); // not ours
+        data.extend_from_slice(&mock_data_reply("1", "<ours/>")); // message-id 1
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let mut out: Vec<u8> = Vec::new();
+        session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect("streaming get-config");
+
+        let text = String::from_utf8(out).expect("utf-8");
+        assert!(text.contains("<ours/>"), "should return our reply: {text}");
+        assert!(
+            !text.contains("<stale/>"),
+            "must not emit the stale reply: {text}"
+        );
+    }
+
+    #[test]
+    fn reply_message_id_reads_the_attribute() {
+        let f = Session::reply_message_id;
+        assert_eq!(f(br#"<rpc-reply message-id="7">"#).as_deref(), Some("7"));
+        assert_eq!(
+            f(br#"<rpc-reply message-id = '12' >"#).as_deref(),
+            Some("12")
+        );
+        // Not enough bytes yet: keep waiting rather than guessing.
+        assert_eq!(f(br#"<rpc-reply message-"#), None);
+        assert_eq!(f(br#"<rpc-reply "#), None);
+    }
+
+    #[test]
+    fn reply_message_id_survives_a_split_codepoint() {
+        // A read or chunk boundary can land mid-codepoint. Decoding the whole
+        // prefix as UTF-8 would fail and discard a perfectly valid reply.
+        let mut buf = br#"<rpc-reply message-id="7"><data>caf"#.to_vec();
+        buf.push(0xC3); // first byte of a truncated two-byte codepoint
+        assert_eq!(
+            Session::reply_message_id(&buf).as_deref(),
+            Some("7"),
+            "a split codepoint after the opening tag must not hide the id"
+        );
+    }
+
+    #[test]
+    fn reply_message_id_ignores_prologs_and_comments() {
+        let f = Session::reply_message_id;
+        assert_eq!(
+            f(br#"<?xml version="1.0"?><rpc-reply message-id="5">"#).as_deref(),
+            Some("5")
+        );
+        // A decoy inside a comment must not be read as the id.
+        assert_eq!(
+            f(br#"<!-- message-id="99" --><rpc-reply message-id="5">"#).as_deref(),
+            Some("5")
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_is_refused_while_the_candidate_is_dirty() {
+        // An interrupted stream poisons the session, and a poisoned session
+        // cannot discard — which would strand edits on a shared candidate.
+        let transport = MockTransport::new(mock_junos_hello());
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        session.mark_candidate_dirty();
+
+        let mut out: Vec<u8> = Vec::new();
+        let err = session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect_err("must refuse with a dirty candidate");
+        assert!(err.to_string().contains("candidate is dirty"), "got {err}");
+        assert!(
+            session.candidate_dirty(),
+            "and the discard path must still be available"
+        );
+        assert!(session.is_alive(), "refusing must not poison the session");
+    }
+
+    #[tokio::test]
+    async fn streaming_is_refused_while_a_subscription_is_active() {
+        // Streaming cannot demultiplex: a notification arriving before the reply
+        // would be handed to the caller as the result.
+        let mut data = mock_device_hello_with_notification();
+        data.extend_from_slice(&mock_ok_reply("1"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        session
+            .create_subscription(None, None, None, None)
+            .await
+            .expect("subscribe");
+
+        let mut out: Vec<u8> = Vec::new();
+        let err = session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect_err("must refuse while subscribed");
+        assert!(err.to_string().contains("subscription"), "got {err}");
+    }
+
+    #[tokio::test]
+    async fn an_interrupted_stream_poisons_the_session() {
+        // Truncated reply: part of the frame is drained, then EOF. The buffer
+        // now holds a suffix, so the next RPC would misparse it — and a pooled
+        // connection must not be handed on in that state.
+        let mut data = mock_device_hello();
+        data.extend_from_slice(b"<rpc-reply><data>partial");
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert!(session.is_alive());
+
+        let mut out: Vec<u8> = Vec::new();
+        let _ = session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect_err("truncated reply");
+
+        assert!(
+            !session.is_alive(),
+            "a half-drained stream must poison the session"
+        );
+        assert!(
+            session.get(None).await.is_err(),
+            "and further RPCs must be refused rather than misparsing the suffix"
+        );
     }
 
     #[tokio::test]

--- a/src/session.rs
+++ b/src/session.rs
@@ -26,7 +26,7 @@ use crate::error::{FramingError, NetconfError, ProtocolError, TransportError};
 use crate::facts::Facts;
 use crate::framing::chunked::ChunkedFramer;
 use crate::framing::eom::EomFramer;
-use crate::framing::{FramePart, Framer};
+use crate::framing::{FramePart, Framer, StreamDecoder};
 use crate::notification::{self, MessageKind, Notification};
 use crate::rpc;
 use crate::rpc::filter::XPathFilter;
@@ -1105,6 +1105,13 @@ impl Session {
         // buffered path bounds the entire loop, so this does too.
         let deadline = self.rpc_timeout.map(|t| tokio::time::Instant::now() + t);
 
+        // Chunk-granularity streaming needs state the `Framer` trait cannot
+        // hold, and without it the chunked path does not stream at all: this
+        // crate's own encoder emits one chunk per message, so an all-or-nothing
+        // chunk decoder buffers the entire reply and trips the ceiling before a
+        // byte reaches the sink.
+        let mut decoder = StreamDecoder::for_version(self.version == Some(NetconfVersion::V1_1));
+
         let mut written = 0usize;
         let mut temp = vec![0u8; READ_BUF_SIZE];
         // Held back until the reply's message-id has been checked. A prior RPC
@@ -1121,13 +1128,24 @@ impl Session {
         let mut prefix: Vec<u8> = Vec::new();
         let mut verified = false;
         let mut discarding = false;
+        // Same bound `send_rpc_raw` applies. Without it a peer that keeps
+        // sending frames for other message-ids holds this call open forever
+        // whenever no `rpc_timeout` is configured.
+        let mut stale_frames = 0usize;
+        let mut last_stale = String::new();
+        // Bytes at the front of `read_buffer` already handed to the decoder.
+        // Draining per part memmoves everything behind it each time, so a reply
+        // delivered as many small chunks would be quadratic; advance an offset
+        // and compact once per read instead.
+        let mut offset = 0usize;
 
         loop {
             loop {
-                match self.framer.decode_part(&self.read_buffer)? {
+                match decoder.decode_part(&self.read_buffer[offset..])? {
                     FramePart::Data { payload, consumed } => {
-                        self.read_buffer.drain(..consumed);
-                        if discarding {
+                        offset += consumed;
+                        // A chunk header carries no payload of its own.
+                        if discarding || payload.is_empty() {
                             continue;
                         }
                         if verified {
@@ -1143,9 +1161,10 @@ impl Session {
                                 written += prefix.len();
                                 prefix.clear();
                             }
-                            Some(_) => {
+                            Some(other) => {
                                 // A stale reply. Swallow the rest of this frame
                                 // and keep waiting for ours.
+                                last_stale = other;
                                 discarding = true;
                                 prefix.clear();
                             }
@@ -1157,8 +1176,21 @@ impl Session {
                         }
                     }
                     FramePart::End { consumed } => {
-                        self.read_buffer.drain(..consumed);
+                        offset += consumed;
                         if discarding || !verified {
+                            stale_frames += 1;
+                            if stale_frames > MAX_STALE_DRAIN {
+                                tracing::error!(
+                                    expected = %message_id,
+                                    actual = %last_stale,
+                                    "streaming: exceeded max drain attempts ({MAX_STALE_DRAIN})"
+                                );
+                                return Err(crate::error::RpcError::MessageIdMismatch {
+                                    expected: message_id.to_string(),
+                                    actual: last_stale,
+                                }
+                                .into());
+                            }
                             // That frame was not ours. Reset and wait for the
                             // next one; the buffer is back at a boundary.
                             discarding = false;
@@ -1166,6 +1198,7 @@ impl Session {
                             prefix.clear();
                             continue;
                         }
+                        self.read_buffer.drain(..offset);
                         // Cleared before the flush: the terminator is consumed,
                         // so the session is at a valid message boundary and a
                         // failing sink must not condemn an otherwise healthy
@@ -1178,6 +1211,9 @@ impl Session {
                     FramePart::NeedMore => break,
                 }
             }
+
+            self.read_buffer.drain(..offset);
+            offset = 0;
 
             if self.read_buffer.len() > self.max_read_buffer {
                 return Err(TransportError::Io(std::io::Error::new(
@@ -1220,17 +1256,28 @@ impl Session {
     /// stops `message-id` being matched inside a leading comment or processing
     /// instruction.
     fn reply_message_id(prefix: &[u8]) -> Option<String> {
-        // First real element start: skip `<?...?>` and `<!--...-->`.
+        fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+            haystack.windows(needle.len()).position(|w| w == needle)
+        }
+        // First real element start, skipping any prolog. Each construct is
+        // skipped to its own terminator, not to the next `>`: a comment may
+        // legally contain one, and `<!-- > <rpc-reply message-id="1"> -->`
+        // would otherwise be mistaken for the root element.
         let mut i = 0;
         loop {
             let lt = prefix[i..].iter().position(|&b| b == b'<')? + i;
             match prefix.get(lt + 1) {
-                Some(b'?') | Some(b'!') => {
-                    let gt = prefix[lt..].iter().position(|&b| b == b'>')? + lt;
-                    i = gt + 1;
+                Some(b'!') if prefix[lt..].starts_with(b"<!--") => {
+                    i = find(&prefix[lt + 4..], b"-->")? + lt + 4 + 3;
+                }
+                Some(b'!') => {
+                    i = prefix[lt..].iter().position(|&b| b == b'>')? + lt + 1;
+                }
+                Some(b'?') => {
+                    i = find(&prefix[lt + 2..], b"?>")? + lt + 2 + 2;
                 }
                 Some(_) => {
-                    let gt = prefix[lt..].iter().position(|&b| b == b'>')? + lt;
+                    let gt = Self::tag_end(&prefix[lt..])? + lt;
                     return Self::message_id_in_tag(&prefix[lt..=gt]);
                 }
                 // Tag has not arrived in full yet.
@@ -1239,31 +1286,71 @@ impl Session {
         }
     }
 
-    /// `message-id="..."` within one opening tag's bytes.
+    /// Offset of the `>` that closes an opening tag, ignoring any inside a
+    /// quoted attribute value.
+    fn tag_end(tag: &[u8]) -> Option<usize> {
+        let mut quote: Option<u8> = None;
+        for (i, &b) in tag.iter().enumerate() {
+            match quote {
+                Some(q) if b == q => quote = None,
+                Some(_) => {}
+                None if b == b'"' || b == b'\'' => quote = Some(b),
+                None if b == b'>' => return Some(i),
+                None => {}
+            }
+        }
+        None
+    }
+
+    /// Value of the unqualified `message-id` attribute within one opening tag.
+    ///
+    /// Attribute names are parsed and compared whole. A substring search would
+    /// let a stale reply carrying a qualified extension attribute such as
+    /// `evil:message-id="1"` ahead of its real `message-id="99"` masquerade as
+    /// message 1 — the caller would be handed the stale reply while its own
+    /// stayed queued.
     fn message_id_in_tag(tag: &[u8]) -> Option<String> {
-        let at = tag
-            .windows(b"message-id".len())
-            .position(|w| w == b"message-id")?;
-        let mut j = at + b"message-id".len();
-        while j < tag.len() && tag[j].is_ascii_whitespace() {
-            j += 1;
+        // Past `<` and the element name.
+        let mut i = 1;
+        while i < tag.len() && !tag[i].is_ascii_whitespace() && tag[i] != b'>' && tag[i] != b'/' {
+            i += 1;
         }
-        if tag.get(j)? != &b'=' {
-            return None;
+        loop {
+            while i < tag.len() && tag[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            if i >= tag.len() || tag[i] == b'>' || tag[i] == b'/' {
+                return None;
+            }
+            let name_start = i;
+            while i < tag.len() && !tag[i].is_ascii_whitespace() && tag[i] != b'=' && tag[i] != b'>'
+            {
+                i += 1;
+            }
+            let name = &tag[name_start..i];
+            while i < tag.len() && tag[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            if tag.get(i) != Some(&b'=') {
+                return None;
+            }
+            i += 1;
+            while i < tag.len() && tag[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            let quote = *tag.get(i)?;
+            if quote != b'"' && quote != b'\'' {
+                return None;
+            }
+            i += 1;
+            let close = tag[i..].iter().position(|&b| b == quote)? + i;
+            if name == b"message-id" {
+                // The id itself is ASCII in practice, but decode defensively
+                // rather than assuming.
+                return std::str::from_utf8(&tag[i..close]).ok().map(str::to_string);
+            }
+            i = close + 1;
         }
-        j += 1;
-        while j < tag.len() && tag[j].is_ascii_whitespace() {
-            j += 1;
-        }
-        let quote = *tag.get(j)?;
-        if quote != b'"' && quote != b'\'' {
-            return None;
-        }
-        j += 1;
-        let close = tag[j..].iter().position(|&b| b == quote)? + j;
-        // The id itself is ASCII in practice, but decode defensively rather
-        // than assuming.
-        std::str::from_utf8(&tag[j..close]).ok().map(str::to_string)
     }
 
     /// Fetch configuration using an XPath filter (RFC 6241 §6.4).
@@ -3767,6 +3854,137 @@ mod tests {
             .await
             .expect("a large reply must stream under a small ceiling");
         assert!(n > 256 * 1024, "expected the whole payload, got {n}");
+    }
+
+    fn mock_device_hello_11() -> Vec<u8> {
+        let hello = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hello xmlns="urn:ietf:params:xml:ns:netconf:base:1.0">
+  <capabilities>
+    <capability>urn:ietf:params:netconf:base:1.0</capability>
+    <capability>urn:ietf:params:netconf:base:1.1</capability>
+  </capabilities>
+  <session-id>1</session-id>
+</hello>"#;
+        let mut buf = hello.as_bytes().to_vec();
+        buf.extend_from_slice(b"]]>]]>");
+        buf
+    }
+
+    /// One chunk for the whole message — exactly what this crate's own encoder
+    /// emits, and the shape that must still stream.
+    fn single_chunk_reply(id: &str, payload: &str) -> Vec<u8> {
+        let msg = format!(
+            "<rpc-reply message-id=\"{id}\" xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\"><data>{payload}</data></rpc-reply>"
+        );
+        let mut buf = format!("\n#{}\n", msg.len()).into_bytes();
+        buf.extend_from_slice(msg.as_bytes());
+        buf.extend_from_slice(b"\n##\n");
+        buf
+    }
+
+    #[tokio::test]
+    async fn streaming_survives_a_large_reply_over_chunked_framing() {
+        // The 1.1 half of the ceiling test above, and the one that actually
+        // matters: NETCONF 1.1 peers — including this crate — send one chunk
+        // per message, so a decoder that only emits whole chunks buffers the
+        // entire reply and trips the ceiling before writing a byte.
+        let big = "x".repeat(256 * 1024);
+        let mut data = mock_device_hello_11();
+        data.extend_from_slice(&single_chunk_reply("1", &big));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+        assert_eq!(session.version(), Some(NetconfVersion::V1_1));
+        session.set_max_read_buffer(64 * 1024);
+
+        let mut out: Vec<u8> = Vec::new();
+        let n = session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect("a large single chunk must stream under a small ceiling");
+        assert!(n > 256 * 1024, "expected the whole payload, got {n}");
+        let text = String::from_utf8(out).expect("utf-8");
+        assert!(text.starts_with("<rpc-reply"), "envelope must be preserved");
+        assert!(
+            text.ends_with("</rpc-reply>"),
+            "got tail {:?}",
+            &text[text.len() - 32..]
+        );
+    }
+
+    #[tokio::test]
+    async fn streaming_ignores_a_qualified_message_id_attribute() {
+        // A stale reply carrying `evil:message-id="1"` ahead of its real
+        // `message-id="99"`. A substring search finds the decoy first and
+        // streams the wrong document while ours stays queued.
+        let mut data = mock_device_hello();
+        data.extend_from_slice(
+            b"<rpc-reply xmlns:evil=\"urn:x\" evil:message-id=\"1\" message-id=\"99\" \
+              xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\"><data><stale/></data></rpc-reply>",
+        );
+        data.extend_from_slice(b"]]>]]>");
+        data.extend_from_slice(&mock_data_reply("1", "<real/>"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let mut out: Vec<u8> = Vec::new();
+        session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect("streaming get-config");
+        let text = String::from_utf8(out).expect("utf-8");
+        assert!(text.contains("<real/>"), "got {text}");
+        assert!(!text.contains("stale"), "streamed the decoy reply: {text}");
+    }
+
+    #[tokio::test]
+    async fn streaming_is_not_fooled_by_a_message_id_in_a_comment() {
+        // `<!-- > ... -->` contains a `>`, so skipping the prolog to the next
+        // `>` leaves the scan inside the comment and reads the decoy id.
+        let mut data = mock_device_hello();
+        data.extend_from_slice(
+            b"<!-- > <rpc-reply message-id=\"1\"> --><rpc-reply message-id=\"99\" \
+              xmlns=\"urn:ietf:params:xml:ns:netconf:base:1.0\"><data><stale/></data></rpc-reply>",
+        );
+        data.extend_from_slice(b"]]>]]>");
+        data.extend_from_slice(&mock_data_reply("1", "<real/>"));
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let mut out: Vec<u8> = Vec::new();
+        session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect("streaming get-config");
+        let text = String::from_utf8(out).expect("utf-8");
+        assert!(text.contains("<real/>"), "got {text}");
+        assert!(!text.contains("stale"), "streamed the decoy reply: {text}");
+    }
+
+    #[tokio::test]
+    async fn streaming_stops_draining_stale_frames_eventually() {
+        // No `rpc_timeout` here on purpose: without a drain bound, a peer that
+        // keeps answering some other message-id holds the call open forever.
+        let mut data = mock_device_hello();
+        for stale_id in 50..=50 + MAX_STALE_DRAIN {
+            data.extend_from_slice(&mock_data_reply(&stale_id.to_string(), "<stale/>"));
+        }
+        let transport = MockTransport::new(data);
+        let mut session = Session::new(Box::new(transport));
+        session.establish().await.expect("establish failed");
+
+        let mut out: Vec<u8> = Vec::new();
+        let err = session
+            .get_config_streaming(Datastore::Running, None, &mut out)
+            .await
+            .expect_err("must give up rather than drain forever");
+        let err_str = format!("{err:?}");
+        assert!(
+            err_str.contains("MessageIdMismatch"),
+            "expected MessageIdMismatch, got: {err_str}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #76.

`get_config` and friends hold the whole reply in memory and refuse
anything past `max_read_buffer`. This adds a streaming path —
`get_config_streaming`, `get_streaming`, `stream_rpc` — that writes the
raw reply envelope to an `AsyncWrite` as frames arrive, so peak memory is
one frame's worth rather than the whole document.

## What the review passes turned up

Five rounds of `codex exec review`. Two findings were substantive enough
to change the design:

**Streaming did not stream over chunked framing.** `Framer`'s methods take
`&self`, so a chunk-granularity decoder cannot report "half of this chunk
is here". This crate's own encoder emits one chunk per message, so against
any NETCONF 1.1 peer the path buffered the entire reply and tripped the
ceiling before writing a byte — precisely the property it advertises. The
first ceiling test only passed because the mock hello negotiates base:1.0.

The fix replaces the public `Framer::decode_part` addition with a private
stateful `StreamDecoder`. **This PR therefore makes no public trait change
at all.**

**A stale reply could be streamed in place of the real one.** The
message-id check was a substring search, so a queued reply carrying
`evil:message-id="1"` ahead of its real `message-id="99"` matched a
request for message 1. Attribute names are now parsed and compared whole,
and the prolog scan honours `-->` and `?>` rather than stopping at the
first `>` — `<!-- > <rpc-reply message-id="1"> -->` was being read as the
root element.

Also fixed: stale frames are bounded by `MAX_STALE_DRAIN` as `send_rpc_raw`
does; the read buffer is compacted once per read instead of drained per
part (quadratic in the number of chunks); and the typed
`FramingError::Mismatch` for base:1.1-advertising, EOM-sending firmware is
preserved on the streaming path, including when a transport read splits the
marker mid-way.

Two defects were found by tests written for this PR rather than by review:
a panic when exactly `\n#` was buffered (input a peer controls), and a
whitespace-flood DoS I introduced and then removed.

## Safety

`stream_rpc` sets `stream_incomplete` **before** its first await, so a
cancelled future or a failing sink poisons the session rather than leaving
a partial reply in the buffer for the next RPC — or for whoever the pool
hands the connection to next. It is cleared only after the frame
terminator is consumed, so a sink error on an otherwise healthy connection
does not condemn it.

Streaming is refused while the candidate is dirty or a subscription is
active.

## Testing

650 tests pass; clippy `-D warnings` and `cargo fmt --check` clean. New
coverage: chunked and EOM ceiling tests, the qualified-attribute spoof, the
comment decoy, the stale-drain bound, partial-chunk emission, and split
marker reads.

## Review note

~1100 lines, over the "reviewable in one sitting" bar. It did not need to
be — each of the six commits was gated separately and the gate ran on every
one. The commits are readable in order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)