### PR TITLE
chore(release): 0.16.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,9 +300,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "clap",
  "colored",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-yang"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "quick-xml",
  "rustnetconf",
@@ -2235,7 +2235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ unsafe_code = "forbid"
 
 [package]
 name = "rustnetconf"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Consumers that need those should use a dedicated SSH crate alongside this one. A
 
 ## What's New in v0.16.0
 
-Feature release. Nothing was removed and no existing item changed shape; 39 public items were added. `rustnetconf-yang` takes a minor bump to 0.2.0 because #81 gave it a real feature flag; `rustnetconf-cli` (0.3.7) has no source changes and bumps only to carry the new `rustnetconf = "0.16"` requirement.
+Feature release. Nothing was removed from the public API and no existing item changed shape. `rustnetconf-yang` takes a minor bump to 0.2.0 because #81 gave it a real feature flag; `rustnetconf-cli` (0.3.7) has no source changes and bumps only to carry the new `rustnetconf = "0.16"` requirement.
 
 **One source-level break.** `ProtocolError` gains an `InvalidValue` variant, and the enum is not `#[non_exhaustive]`, so downstream code matching it exhaustively needs a new arm or a wildcard:
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.15.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.15.0)** (smaller error types — one breaking change).
-> On crates.io: `rustnetconf` 0.15.0 · `rustnetconf-cli` 0.3.6 · `rustnetconf-yang` 0.1.6.
-> See [What's New in v0.15.0](#whats-new-in-v0150) below.
+> **Latest release — [v0.16.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.16.0)** (four new RFCs, streaming reads, XML hardening — no breaking changes).
+> On crates.io: `rustnetconf` 0.16.0 · `rustnetconf-cli` 0.3.7 · `rustnetconf-yang` 0.2.0.
+> See [What's New in v0.16.0](#whats-new-in-v0160) below.
 
 ## Workspace
 
@@ -47,6 +47,44 @@ SSH is present as a *transport for NETCONF*, not as a general-purpose capability
 - Remote shell or command execution
 
 Consumers that need those should use a dedicated SSH crate alongside this one. A native SCP1 client was briefly added and then reverted before it was ever released (#52, reverted by #53) for exactly this reason; issues #47 and #51 were closed as not planned on the same grounds. The round trip is visible in `git log` between v0.13.2 and the next release — it was a deliberate reversal, not an accident.
+
+## What's New in v0.16.0
+
+Feature release, and a **drop-in upgrade from 0.15.0** — nothing in the public API was removed or changed shape, 36 items were added. `rustnetconf-yang` takes a minor bump to 0.2.0 because #82 gave it a real feature flag; `rustnetconf-cli` (0.3.7) has no source changes and bumps only to carry the new `rustnetconf = "0.16"` requirement.
+
+### Protocol coverage
+
+Four gaps closed, each one an operation the module docs already implied existed.
+
+- **`copy-config`, `delete-config`, `cancel-commit`** (#71). RFC 6241 §7.3, §7.4 and §8.4. `delete_config` takes a `DeleteTarget`, not a `Datastore`, because the `ietf-netconf` YANG module's `config-target` choice contains only `startup` and `url` — neither `running` nor `candidate` is a legal target, and a type that cannot express them is better than a runtime rejection.
+
+- **XPath filters** (#72). `XPathFilter` with namespace bindings, for `get` and `get-config`. The module documentation had promised this for several releases; it now exists.
+
+- **`with-defaults`** (#74), RFC 6243. `get_config_with_defaults`, `get_with_defaults`, `copy_config_with_defaults`, covering all four retrieval modes.
+
+- **Partial lock** (#73), RFC 5717. `partial_lock` / `partial_unlock`. If a partial-lock reply is lost, the session is marked unhealthy rather than assumed unlocked — a lock whose state is unknown is not a lock you may act on, and a pooled connection must not carry that ambiguity to the next caller.
+
+### Reading large replies
+
+- **Streaming reads** (#76). `get_config_streaming`, `get_streaming` and `stream_rpc` write the raw reply envelope to an `AsyncWrite` as frames arrive, so peak memory is one frame rather than the whole document. A cancelled future or a failing sink poisons the session instead of leaving a partial reply in the buffer for the next RPC — or for whoever the pool hands the connection to next.
+
+- **The read-buffer ceiling is adjustable** (#92). `set_max_read_buffer` on `Client` and `Session`, and on `TlsClientBuilder`. It survives `reconnect()` and is restored when a pooled connection is returned, so a raised ceiling is a property of the client rather than of one connection that happens to still be open.
+
+### XML correctness
+
+- **Fuzzing found fourteen escapes from the outbound validator** (#80). `validate_xml_fragment` is a hand-written conformance layer over quick-xml, which is deliberately permissive. Differential fuzzing against a conforming parser found fourteen fragments it accepted that are not well-formed XML — including one where the validation mechanism was itself the escape: `</_>x<_>` balanced against the synthetic root the validator wraps the fragment in. All fourteen are fixed, and the fuzz targets ship in `fuzz/`.
+
+- **Strict validation is available, opt-in** (#89, #93). The `strict-validation` feature validates by attempting a conforming parse instead of by enumerating rules. Off by default: it costs one small pure-Rust dependency (142 → 143 crates), and that is the caller's trade to make. Three residual cases the rule list still accepts are documented on #89.
+
+### Supply chain and build
+
+- **The stale `RUSTSEC-2023-0071` suppression is gone** (#78). `rsa` had already left the dependency graph — russh 0.62 gates it behind a non-default feature — so the suppression was a loaded gun: it would have silently covered a genuine future `rsa` advisory.
+
+- **`chacha20` moved off a yanked version.** The lockfile pinned 0.10.0, which the registry has since yanked; it now resolves to 0.10.2. Transitive via russh (`rand`, `ssh-cipher`), and not a published advisory — `cargo audit` reports it as a warning, not a vulnerability — but a release should not ship a lockfile pinning a yanked crypto crate.
+
+- **`libyang2` bundling is now opt-out** (#81). `rustnetconf-yang` built libyang2 from source unconditionally, costing ~44 MB of build artifacts and making `cmake` a hard prerequisite. `default = ["bundled"]` keeps that behaviour; `--no-default-features` links a system libyang2 via pkg-config instead.
+
+- **`unsafe_code = "forbid"` is enforced workspace-wide** (#79). The README claimed no unsafe code; a crate-root `#![forbid(unsafe_code)]` does not reach build scripts, examples or integration tests, which are separate crates. It is now a `[workspace.lints]` entry, so the claim is enforced everywhere it was being made.
 
 ## What's New in v0.15.0
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,19 @@ Consumers that need those should use a dedicated SSH crate alongside this one. A
 
 ## What's New in v0.16.0
 
-Feature release, and a **drop-in upgrade from 0.15.0** — nothing in the public API was removed or changed shape, 36 items were added. `rustnetconf-yang` takes a minor bump to 0.2.0 because #82 gave it a real feature flag; `rustnetconf-cli` (0.3.7) has no source changes and bumps only to carry the new `rustnetconf = "0.16"` requirement.
+Feature release. Nothing was removed and no existing item changed shape; 36 were added. `rustnetconf-yang` takes a minor bump to 0.2.0 because #81 gave it a real feature flag; `rustnetconf-cli` (0.3.7) has no source changes and bumps only to carry the new `rustnetconf = "0.16"` requirement.
+
+**One source-level break.** `ProtocolError` gains an `InvalidValue` variant, and the enum is not `#[non_exhaustive]`, so downstream code matching it exhaustively needs a new arm or a wildcard:
+
+```rust
+match err {
+    ProtocolError::CapabilityMissing { .. } => ...,
+    // ...
+    _ => ...,  // add this, or an explicit InvalidValue arm
+}
+```
+
+Nothing else in the crate is affected — every other new enum (`WithDefaults`, `DeleteTarget`, `CopySource`, `ConfigLocation`) is new, not an addition to an existing one. No public error enum is `#[non_exhaustive]` today, so variant additions will keep landing as breaks until that changes.
 
 ### Protocol coverage
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.16.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.16.0)** (four new RFCs, streaming reads, XML hardening — no breaking changes).
+> **Latest release — [v0.16.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.16.0)** (four new RFCs, streaming reads, XML hardening; one source break — a new `ProtocolError` variant).
 > On crates.io: `rustnetconf` 0.16.0 · `rustnetconf-cli` 0.3.7 · `rustnetconf-yang` 0.2.0.
 > See [What's New in v0.16.0](#whats-new-in-v0160) below.
 
@@ -50,7 +50,7 @@ Consumers that need those should use a dedicated SSH crate alongside this one. A
 
 ## What's New in v0.16.0
 
-Feature release. Nothing was removed and no existing item changed shape; 36 were added. `rustnetconf-yang` takes a minor bump to 0.2.0 because #81 gave it a real feature flag; `rustnetconf-cli` (0.3.7) has no source changes and bumps only to carry the new `rustnetconf = "0.16"` requirement.
+Feature release. Nothing was removed and no existing item changed shape; 39 public items were added. `rustnetconf-yang` takes a minor bump to 0.2.0 because #81 gave it a real feature flag; `rustnetconf-cli` (0.3.7) has no source changes and bumps only to carry the new `rustnetconf = "0.16"` requirement.
 
 **One source-level break.** `ProtocolError` gains an `InvalidValue` variant, and the enum is not `#[non_exhaustive]`, so downstream code matching it exhaustively needs a new arm or a wildcard:
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/rustnetconf-cli/Cargo.toml
+++ b/rustnetconf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-cli"
-version = "0.3.6"
+version = "0.3.7"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "Terraform-like CLI for declarative NETCONF network config management"
@@ -13,7 +13,7 @@ name = "netconf"
 path = "src/main.rs"
 
 [dependencies]
-rustnetconf = { version = "0.15", path = ".." }
+rustnetconf = { version = "0.16", path = ".." }
 clap = { version = "4", features = ["derive"] }
 colored = "3"
 toml = "0.8"

--- a/rustnetconf-yang/Cargo.toml
+++ b/rustnetconf-yang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-yang"
-version = "0.1.6"
+version = "0.2.0"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "YANG model code generation for rustnetconf — compile-time config validation"
@@ -18,7 +18,7 @@ generated = []
 bundled = ["yang2/bundled"]
 
 [dependencies]
-rustnetconf = { version = "0.15", path = ".." }
+rustnetconf = { version = "0.16", path = ".." }
 serde = { version = "1", features = ["derive"] }
 quick-xml = "0.41"
 thiserror = "2"

--- a/rustnetconf-yang/src/lib.rs
+++ b/rustnetconf-yang/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rustnetconf-yang = { version = "0.1", features = ["generated"] }
+//! rustnetconf-yang = { version = "0.2", features = ["generated"] }
 //! ```
 //!
 //! Then use a bundled model:

--- a/src/framing/mod.rs
+++ b/src/framing/mod.rs
@@ -184,7 +184,7 @@ impl StreamDecoder {
 /// entire message is buffered, so peak memory is the reply size regardless of
 /// what the caller does with it.
 #[derive(Debug, PartialEq, Eq)]
-pub enum FramePart {
+pub(crate) enum FramePart {
     /// Payload ready to emit now, plus the input bytes consumed producing it.
     ///
     /// `consumed` may exceed `payload.len()` — framing overhead (chunk headers)


### PR DESCRIPTION
`rustnetconf` 0.15.0 → **0.16.0**, `rustnetconf-yang` 0.1.6 → **0.2.0**, `rustnetconf-cli` 0.3.6 → **0.3.7**. All three publish together, as at 0.14 and 0.15.

Twelve commits since v0.15.0: copy/delete-config and cancel-commit (#71), XPath filters (#72), partial lock (#73), with-defaults (#74), streaming reads (#76), an adjustable and durable read-buffer ceiling (#92), fourteen validator escapes found by fuzzing and fixed (#80), opt-in strict XML validation (#89), the stale RUSTSEC-2023-0071 suppression dropped (#78), libyang2 bundling made opt-out (#81), and `unsafe_code = "forbid"` enforced workspace-wide (#79).

## Compatibility

**One source-level break**, which the first draft of this PR got wrong and called a drop-in upgrade. `ProtocolError` gains `InvalidValue` and is not `#[non_exhaustive]`, so downstream exhaustive matches stop compiling. An audit of every public enum confirmed it is the only variant added to an existing one — `WithDefaults`, `DeleteTarget`, `CopySource` and `ConfigLocation` are all new types. Nothing was removed and nothing changed shape.

No public error enum is `#[non_exhaustive]`, so variant additions will keep landing as breaks. Worth a follow-up issue rather than a change inside a release PR.

## What review caught

- `fuzz/` is an independent workspace, so the bump left its lockfile on 0.15.0 and `--locked` builds failed.
- `rustnetconf-yang`'s crate-level quick start still said `version = "0.1"`, which Cargo treats as incompatible with 0.2 — copying the published docs would install the superseded release.
- The banner said "no breaking changes" while the section below it documented one.
- I stated a public-API item count twice and got it wrong both times. Removed rather than fixed: it was decoration, and the compatibility contract is the part that carries weight.

## Also

`FramePart` was `pub` in a `pub mod`, making it public API, but nothing public uses it since the `Framer::decode_part` addition was reverted during #94. Publishing would have committed us permanently to a type with no public purpose, so it is now `pub(crate)`.

`chacha20` 0.10.0 → 0.10.2 in the lockfile. 0.10.0 is yanked in the registry — a `cargo audit` warning rather than an advisory, but not something a release should pin.

## Verification

650 tests, clippy `-D warnings`, `cargo fmt --check`, and `cargo check --manifest-path fuzz/Cargo.toml --locked` all clean. `cargo publish --dry-run -p rustnetconf` packages 63 files successfully.

**Not yet published to crates.io** — that step is held for explicit go-ahead, since it cannot be undone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)