### PR TITLE
fix(rpc): close two documented validator residuals

### DIFF
--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -64,19 +64,15 @@ clean run means "no new class within that budget", not "the validator conforms".
 Known cases, all reachable in minutes:
 
 ```
-<i n = '... & ...' />                 # attribute values are not entity-checked:
-<a b="&cmp;"/>  <a b="&#4;"/>         # a bare `&`, an undefined entity, and an
-                                      # out-of-range character reference all pass,
-                                      # because quick-xml keeps them raw in the
-                                      # attribute and emits no GeneralRef event
-
 <a xmlns:p="urn:x" xmlns:q="urn:x"    # duplicate *expanded* attribute names.
    p:x="1" q:x="2"/>                  # `with_checks(true)` compares lexical keys
                                       # only, so tracking declarations is needed
-
-<xmlns:a/>                            # `xmlns` is forbidden as an element prefix;
-                                      # the QName check sees two valid NCNames
 ```
+
+Two classes previously listed here — unchecked attribute references, and `xmlns`
+as an element prefix — are now rules 16 and 17 below. They were closed after the
+fuzzer surfaced them again during the quick-xml 0.42 migration. That is the third
+time this table has shrunk by enumeration and not reached zero.
 
 This is structural, not a backlog item. `validate_xml_fragment` is a
 hand-written conformance layer over quick-xml, which is *deliberately*
@@ -100,6 +96,8 @@ below had to be added by hand after the fuzzer pointed at it:
 | 13 | PI target is a `Name` | `<?<a?>`. Colons **are** legal here — two revisions wrongly rejected `<?a:b?>` and then `<?a:b:c?>` by reusing the element-name (QName) check |
 | 14 | `Char` in PI bodies | control characters |
 | 15 | no literal `<` in attribute values | `<a b="x<y"/>` |
+| 16 | reserved `xmlns` prefix on elements | `<xmlns:a/>` — a well-formed QName of two valid NCNames, which no conforming parser accepts. Attributes are the opposite case: `xmlns:p="…"` **is** the declaration syntax, so the rule cannot live in the shared name check |
+| 17 | references in attribute values | `<i n='&'/>`, `<a b="&cmp;"/>`, `<a b="&#4;"/>` — quick-xml keeps attribute values raw and emits no `GeneralRef` event, so a bare `&`, an undefined entity and an out-of-range char ref all passed. Resolution now goes through the same helper the text path uses, so the two cannot disagree |
 
 Enumerating rules terminates only when the list is complete, and nothing here
 proves it is. #10 and #13 were found *after* the first twelve were fixed and the

--- a/rustnetconf-cli/src/diff/tree.rs
+++ b/rustnetconf-cli/src/diff/tree.rs
@@ -55,7 +55,13 @@ fn resolve_entity_ref(entity: &quick_xml::events::BytesRef<'_>) -> Option<String
         return Some(ch.to_string());
     }
     let name = entity.decode().ok()?;
-    quick_xml::escape::resolve_predefined_entity(&name).map(|s| s.to_string())
+    // `resolve_xml_entity`, not `resolve_predefined_entity` — the same hazard
+    // the library crate's copy of this helper documents, missed here when that
+    // one was fixed. `resolve_predefined_entity` is dispatched on quick-xml's
+    // `escape-html` feature, and Cargo unifies features across the whole
+    // graph, so any unrelated dependency enabling it would make `netconf diff`
+    // resolve HTML5 entities the device never sent.
+    quick_xml::escape::resolve_xml_entity(&name).map(|s| s.to_string())
 }
 
 /// Parse an XML string into a simplified tree.

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -107,16 +107,16 @@ pub fn validate_xml_fragment(xml: &str) -> Result<(), ProtocolError> {
                 break;
             }
             Ok(Event::Start(ref e)) => {
-                validate_name(e.name().as_ref())?;
+                validate_element_name(e.name().as_ref())?;
                 validate_attributes(e)?;
                 depth += 1;
             }
             Ok(Event::Empty(ref e)) => {
-                validate_name(e.name().as_ref())?;
+                validate_element_name(e.name().as_ref())?;
                 validate_attributes(e)?;
             }
             Ok(Event::End(ref e)) => {
-                validate_name(e.name().as_ref())?;
+                validate_element_name(e.name().as_ref())?;
                 depth -= 1;
                 // Reaching zero before EOF means the fragment closed the
                 // synthetic root itself. `</_>x<_>` is balanced overall, so a
@@ -504,6 +504,7 @@ fn validate_attributes(tag: &quick_xml::events::BytesStart<'_>) -> Result<(), Pr
                     .to_string(),
             ));
         }
+        validate_attribute_references(value)?;
     }
     Ok(())
 }
@@ -515,6 +516,81 @@ fn validate_attributes(tag: &quick_xml::events::BytesStart<'_>) -> Result<(), Pr
 /// device to choke on. Found by the `fragment_embeds_cleanly` fuzz target, twice:
 /// first with control characters, then with a legal character in an illegal
 /// position, which is what prompted encoding the real production.
+/// Every `&` in an attribute value must open a `Reference`.
+///
+/// XML 1.0 §2.3 gives `AttValue ::= '"' ([^<&"] | Reference)* '"'`, so a bare
+/// `&` is as illegal there as a bare `<` — but quick-xml passes `<i n='&'/>`
+/// through even with `with_checks(true)`. Found by the `fragment_embeds_cleanly`
+/// fuzz target.
+///
+/// Resolution goes through the same helper the `GeneralRef` text path uses, so
+/// attribute values and character data cannot disagree about which entities
+/// exist — including the `escape-html` feature-unification hazard that helper
+/// already guards against.
+fn validate_attribute_references(value: &str) -> Result<(), ProtocolError> {
+    let mut rest = value;
+    while let Some(amp) = rest.find('&') {
+        let after = &rest[amp + 1..];
+        let Some(semi) = after.find(';') else {
+            return Err(ProtocolError::Xml(
+                "XML fragment has an attribute value containing a bare `&`; write \
+                 `&amp;`, or complete the reference"
+                    .to_string(),
+            ));
+        };
+        let name = &after[..semi];
+        match crate::xml_entity::resolve_entity_ref(&quick_xml::events::BytesRef::new(name)) {
+            Some(resolved)
+                if resolved
+                    .chars()
+                    .all(crate::rpc::reply::lexical::is_valid_xml_char) => {}
+            Some(_) => {
+                return Err(ProtocolError::Xml(
+                    "XML fragment has an attribute value with a character reference \
+                     outside the range XML 1.0 permits"
+                        .to_string(),
+                ));
+            }
+            None => {
+                let preview: String = name.chars().take(32).collect();
+                return Err(ProtocolError::Xml(format!(
+                    "XML fragment has an attribute value referencing an undefined \
+                     entity `&{preview};`; only the five predefined entities and \
+                     numeric character references can be embedded"
+                )));
+            }
+        }
+        rest = &after[semi + 1..];
+    }
+    Ok(())
+}
+
+/// An element name: a `QName` that additionally may not carry the reserved
+/// `xmlns` prefix.
+///
+/// Split out from [`validate_name`] because the rule is asymmetric.
+/// Namespaces in XML §3 reserves `xmlns` for declarations, so `<xmlns:a/>` is
+/// a perfectly well-formed QName that no conforming parser accepts — while
+/// `xmlns:p="…"` on an *attribute* is the declaration syntax itself and must
+/// stay legal. Applying this inside `validate_name` would reject every
+/// namespace declaration in the crate.
+///
+/// Only the prefix is reserved: `<xmlns/>` is a valid element name, and
+/// roxmltree accepts it.
+fn validate_element_name(raw: &[u8]) -> Result<(), ProtocolError> {
+    validate_name(raw)?;
+    let mut parts = raw.split(|byte| *byte == b':');
+    if let (Some(prefix), Some(_)) = (parts.next(), parts.next()) {
+        if prefix == b"xmlns" {
+            return Err(ProtocolError::Xml(
+                "XML fragment has an element using the reserved `xmlns` prefix;                  it may only introduce namespace declarations"
+                    .to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
 fn validate_name(raw: &[u8]) -> Result<(), ProtocolError> {
     let name = std::str::from_utf8(raw)
         .map_err(|_| ProtocolError::Xml("XML fragment has a non-UTF-8 element name".to_string()))?;
@@ -540,6 +616,78 @@ fn validate_name(raw: &[u8]) -> Result<(), ProtocolError> {
 #[cfg(test)]
 mod xml_validate_tests {
     use super::*;
+
+    #[test]
+    fn rejects_a_bare_ampersand_in_an_attribute_value() {
+        // XML 1.0 §2.3. quick-xml passes these through even with checks on.
+        for fragment in [
+            "<i n='&'/>",
+            "<i n=\"a & b\"/>",
+            "<i n='&nosuch;'/>",
+            "<i n='&;'/>",
+            // Unterminated: the `;` never arrives.
+            "<i n='&amp'/>",
+        ] {
+            assert!(
+                validate_xml_fragment(fragment).is_err(),
+                "expected rejection of {fragment:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_well_formed_references_in_attribute_values() {
+        for fragment in [
+            "<i n='a &amp; b'/>",
+            "<i n='&lt;&gt;&quot;&apos;'/>",
+            "<i n='&#38;'/>",
+            "<i n='&#x26;'/>",
+            "<i n='plain'/>",
+        ] {
+            assert!(
+                validate_xml_fragment(fragment).is_ok(),
+                "expected acceptance of {fragment:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_the_reserved_xmlns_prefix_on_an_element() {
+        // Namespaces in XML §3. `<xmlns:a/>` is a well-formed QName, so the
+        // QName check accepts it and a conforming parser does not — found by
+        // the `fragment_embeds_cleanly` fuzz target, which minimised a much
+        // larger input down to exactly this.
+        for fragment in [
+            "<xmlns:snt/>",
+            "<xmlns:a></xmlns:a>",
+            "<a><xmlns:b/></a>",
+            // Declaring the prefix does not rescue it.
+            "<xmlns:a xmlns:xmlns=\"urn:x\"/>",
+        ] {
+            assert!(
+                validate_xml_fragment(fragment).is_err(),
+                "expected rejection of {fragment:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_xmlns_where_it_is_legal() {
+        // Only the *prefix* is reserved. These must keep working, and the
+        // middle two are how every namespaced RPC this crate emits is built.
+        for fragment in [
+            // `xmlns` as a local name is a valid element name.
+            "<xmlns/>",
+            "<a xmlns=\"urn:x\"/>",
+            "<a xmlns:p=\"urn:x\"/>",
+            "<p:a xmlns:p=\"urn:x\"><p:b/></p:a>",
+        ] {
+            assert!(
+                validate_xml_fragment(fragment).is_ok(),
+                "expected acceptance of {fragment:?}"
+            );
+        }
+    }
 
     #[test]
     fn test_valid_xml_fragment() {
@@ -739,11 +887,18 @@ mod fragment_validation_tests {
         // Every one of these is in fuzz/README.md's residual table: the rule
         // list accepts them, a conforming parser does not. This is the whole
         // argument of #89, as an assertion.
-        for frag in [
-            r#"<a b="&cmp;"/>"#, // undefined entity in an attribute
-            r#"<a b="&#4;"/>"#,  // out-of-range char ref in an attribute
+        // Rules 16 and 17 closed the other two classes this list used to hold
+        // (see fuzz/README.md). Duplicate *expanded* attribute names remain:
+        // `with_checks(true)` compares lexical keys, so catching it means
+        // tracking namespace declarations through the fragment.
+        //
+        // A named slice rather than an inline array: this list is expected to
+        // shrink again, and it should read as a set that happens to hold one
+        // member rather than as a one-off assertion.
+        const RESIDUAL: &[&str] = &[
             r#"<a xmlns:p="urn:x" xmlns:q="urn:x" p:x="1" q:x="2"/>"#, // duplicate expanded names
-        ] {
+        ];
+        for frag in RESIDUAL {
             assert!(
                 validate_xml_fragment(frag).is_ok(),
                 "rule list is expected to accept {frag:?} — if this fails the residual shrank"


### PR DESCRIPTION
Both of these were already written down in `fuzz/README.md` as known escapes of the rule list, tracked under #89 — not new discoveries. The fuzzer resurfaced them while I was verifying the quick-xml 0.42 migration, so they are closed here rather than left standing.

## Rule 16 — the reserved `xmlns` prefix on an element

`<xmlns:a/>` is a well-formed QName of two valid NCNames, so the QName check accepts it and no conforming parser does (Namespaces in XML §3).

It needs its own function rather than a line in `validate_name`, because the rule is **asymmetric**: `xmlns:p="…"` on an *attribute* is the namespace-declaration syntax itself. Folding it into the shared check would reject every namespaced RPC this crate emits.

Only the prefix is reserved. Verified against roxmltree before implementing:

```
<xmlns:a/>                    -> REJECT: the 'xmlns' prefix is used, but it must not be
<xmlns/>                      -> ACCEPT      # `xmlns` as a local name is fine
<a xmlns:p="urn:x"/>          -> ACCEPT      # the declaration syntax
<p:a xmlns:p="urn:x"/>        -> ACCEPT
<xmlns:a xmlns:xmlns="urn:x"/> -> REJECT     # declaring it does not rescue it
```

## Rule 17 — references in attribute values

XML 1.0 §2.3 gives `AttValue ::= '"' ([^<&"] | Reference)* '"'`, so a bare `&` is as illegal as a bare `<` — which was already checked. quick-xml keeps attribute values raw and emits no `GeneralRef` event, so `<i n='&'/>`, `&cmp;` and `&#4;` all passed.

Resolution routes through the same helper the text path uses, so attribute values and character data cannot disagree about which entities exist — and it inherits that helper's guard against the `escape-html` feature-unification hazard.

## Also: the CLI had an unfixed copy of the entity resolver

`rustnetconf-cli/src/diff/tree.rs` still called `resolve_predefined_entity`. That is precisely the hazard the library crate's copy of `resolve_entity_ref` documents and was fixed for — the duplicate in the CLI was missed at the time. If any crate in the graph enables quick-xml's `escape-html`, Cargo's feature unification would make `netconf diff` resolve HTML5 entities the device never sent.

This one is a genuine undocumented bug, and it shipped in 0.16.0.

## The residual test did its job

`strict_catches_what_the_rule_list_documents_as_residual` **failed** when I added rule 17, because it asserts the rule list *accepts* each residual case. That is exactly what it was written for in #93 — the residual shrinking is caught loudly instead of drifting silently. Its list and the README table are updated.

One class remains: duplicate *expanded* attribute names. `with_checks(true)` compares lexical keys, so catching it means tracking namespace declarations through the fragment.

## Verification

654 tests, clippy `-D warnings`, `cargo fmt --check` clean.

`fragment_embeds_cleanly` ran **8.1M executions with no crashes** — the first clean run at that scale. That is a signal, not conformance: the remaining residual is real, and the README's warning that a clean run means "no new class within that budget" still stands. This is the third time the table has shrunk by enumeration without reaching zero, which remains the argument in #89.

🤖 Generated with [Claude Code](https://claude.com/claude-code)