### PR TITLE
chore(release): 0.16.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ unsafe_code = "forbid"
 
 [package]
 name = "rustnetconf"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.16.0](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.16.0)** (four new RFCs, streaming reads, XML hardening; one source break — a new `ProtocolError` variant).
-> On crates.io: `rustnetconf` 0.16.0 · `rustnetconf-cli` 0.3.7 · `rustnetconf-yang` 0.2.0.
-> See [What's New in v0.16.0](#whats-new-in-v0160) below.
+> **Latest release — [v0.16.1](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.16.1)** (two XML validator escapes closed, and an entity-resolution bug in `netconf diff`; no API change).
+> On crates.io: `rustnetconf` 0.16.1 · `rustnetconf-cli` 0.3.8 · `rustnetconf-yang` 0.2.0.
+> See [What's New in v0.16.1](#whats-new-in-v0161) below.
 
 ## Workspace
 
@@ -47,6 +47,26 @@ SSH is present as a *transport for NETCONF*, not as a general-purpose capability
 - Remote shell or command execution
 
 Consumers that need those should use a dedicated SSH crate alongside this one. A native SCP1 client was briefly added and then reverted before it was ever released (#52, reverted by #53) for exactly this reason; issues #47 and #51 were closed as not planned on the same grounds. The round trip is visible in `git log` between v0.13.2 and the next release — it was a deliberate reversal, not an accident.
+
+## What's New in v0.16.1
+
+Patch release, no API change. Two escapes from the outbound XML validator and one entity-resolution bug in the CLI (#96).
+
+`rustnetconf-yang` does **not** bump. It has no source change, and its `rustnetconf = "0.16"` requirement already resolves to 0.16.1 — publishing it would ship a version whose only content is a version number. The 0.15 and 0.16 releases moved all three crates because the requirement itself changed incompatibly; a patch does not do that.
+
+- **The `netconf diff` entity bug** — this is the one that reached users. `rustnetconf-cli`'s copy of `resolve_entity_ref` still called quick-xml's `resolve_predefined_entity`. Under Cargo feature unification, any crate in the graph enabling quick-xml's `escape-html` turns that into a resolver for the full HTML5 entity set, so `netconf diff` could resolve entities the device never sent. The library crate's copy was fixed for exactly this; the duplicate in the CLI was missed. Anyone on `rustnetconf-cli` 0.3.7 should upgrade.
+
+  The CLI's requirement on the library is raised from `0.16` to `0.16.1` at the same time. `rustnetconf-cli` calls `validate_xml_fragment` directly, and `^0.16` permits 0.16.0 — which is what a `cargo install --locked` would have selected from the packaged lockfile, shipping the new CLI against the pre-fix validator.
+
+- **Reserved `xmlns` prefix on an element** (rule 16). `<xmlns:a/>` is two valid NCNames, so the QName check accepted it and no conforming parser does (Namespaces in XML §3). It cannot live in `validate_name` because the rule is asymmetric — `xmlns:p="…"` on an *attribute* is the declaration syntax. Only the prefix is reserved; `<xmlns/>` stays legal.
+
+- **References in attribute values** (rule 17). XML 1.0 §2.3 gives `AttValue ::= '"' ([^<&"] | Reference)* '"'`, so a bare `&` is as illegal as a bare `<`, which was already checked. quick-xml keeps attribute values raw and emits no `GeneralRef` event, so `<i n='&'/>`, `&cmp;` and `&#4;` all passed. Resolution now routes through the same helper as the text path, so attribute values and character data cannot disagree about which entities exist.
+
+Both validator rules were already written down in `fuzz/README.md` as known escapes of the rule list, tracked under #89. One class remains — duplicate *expanded* attribute names — and the README's warning that the rule list is not a conformance check still stands. For a conforming parse, use the opt-in `strict-validation` feature.
+
+### Live-device tests fail loudly now
+
+`tests/integration_vsrx.rs` early-returns when `RUSTNETCONF_TEST_VSRX_HOST` is unset, and libtest has no "skipped" outcome for a test that returns normally — so a run that never contacted a device printed the same `23 passed` as one that did. Set `RUSTNETCONF_TEST_VSRX_REQUIRED=1` when a run is meant to be device coverage: every skip becomes a failure that names its reason, so a misspelled variable or an unreadable key file fails the run instead of passing it. A `~/` in `RUSTNETCONF_TEST_VSRX_KEY` is also expanded now — Rust does not do it, and neither does every shell in that position, and the resulting failure looked like an authentication fault.
 
 ## What's New in v0.16.0
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/rustnetconf-cli/Cargo.toml
+++ b/rustnetconf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-cli"
-version = "0.3.7"
+version = "0.3.8"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "Terraform-like CLI for declarative NETCONF network config management"
@@ -13,7 +13,7 @@ name = "netconf"
 path = "src/main.rs"
 
 [dependencies]
-rustnetconf = { version = "0.16", path = ".." }
+rustnetconf = { version = "0.16.1", path = ".." }
 clap = { version = "4", features = ["derive"] }
 colored = "3"
 toml = "0.8"

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -5,6 +5,18 @@
 //! each test calls [`skip_unless_vsrx_configured`] which returns `None`
 //! and the test early-returns as a no-op.
 //!
+//! ## A no-op run reports as `ok`, not as skipped
+//!
+//! libtest has no "skipped" outcome for a test that returns normally, so a
+//! suite that never contacted a device is indistinguishable from one that
+//! did — both print `test result: ok`. That makes a green line worthless as
+//! evidence for anything that depends on the device having been reached.
+//!
+//! Set `RUSTNETCONF_TEST_VSRX_REQUIRED=1` whenever the run is meant to be
+//! device coverage. Every skip then panics instead of returning `None`, so a
+//! misspelled variable, an env that did not survive into the cargo process,
+//! or an unreadable key file fails the run rather than passing it.
+//!
 //! ## Configuration
 //!
 //! | Env var | Required | Default | Notes |
@@ -12,6 +24,7 @@
 //! | `RUSTNETCONF_TEST_VSRX_HOST` | yes | — | e.g. `192.168.1.227:830` |
 //! | `RUSTNETCONF_TEST_VSRX_USER` | no | `netconf` | Junos username |
 //! | `RUSTNETCONF_TEST_VSRX_KEY` | no | `$HOME/.ssh/id_ed25519` | SSH private key path |
+//! | `RUSTNETCONF_TEST_VSRX_REQUIRED` | no | unset | `1`/`true`/`yes` — turn every skip into a failure |
 //!
 //! ## Examples
 //!
@@ -42,17 +55,82 @@ impl VsrxTarget {
     }
 }
 
-/// Returns `Some(VsrxTarget)` when `RUSTNETCONF_TEST_VSRX_HOST` is set,
-/// otherwise `None`. Tests should early-return on `None` so the suite is a
-/// no-op for contributors without a lab device.
+/// True when `RUSTNETCONF_TEST_VSRX_REQUIRED` asks for device coverage.
+///
+/// The point of the flag is that a skipped live test is reported as a pass.
+/// When it is set, every reason to skip becomes a panic instead, so a run
+/// that never reached the device fails rather than printing `ok`.
+fn device_required() -> bool {
+    match std::env::var("RUSTNETCONF_TEST_VSRX_REQUIRED") {
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
+        Err(_) => false,
+    }
+}
+
+/// Skip, or fail loudly if the run was asked to be device coverage.
+fn skip_or_fail(reason: &str) -> Option<VsrxTarget> {
+    assert!(
+        !device_required(),
+        "RUSTNETCONF_TEST_VSRX_REQUIRED is set, but this test cannot reach a \
+         device: {reason}. The suite is refusing to report a pass it did not earn."
+    );
+    None
+}
+
+/// Expand a leading `~/` against `$HOME`.
+///
+/// Rust does no tilde expansion, and neither does every shell in the position
+/// `VAR=~/path cmd`. Without this, `RUSTNETCONF_TEST_VSRX_KEY=~/.ssh/k` hands
+/// russh a literal `~/.ssh/k`, which fails as an authentication error — the
+/// same misleading shape as the `srxoutpost` username bug documented above.
+fn expand_tilde(path: &str) -> String {
+    let Some(rest) = path.strip_prefix("~/") else {
+        return path.to_string();
+    };
+    match std::env::var("HOME") {
+        Ok(home) => format!("{}/{rest}", home.trim_end_matches('/')),
+        Err(_) => path.to_string(),
+    }
+}
+
+/// Returns `Some(VsrxTarget)` when `RUSTNETCONF_TEST_VSRX_HOST` is set and the
+/// configured key file is readable, otherwise `None`.
+///
+/// Tests should early-return on `None` so the suite is a no-op for
+/// contributors without a lab device. Under
+/// `RUSTNETCONF_TEST_VSRX_REQUIRED=1` there is no `None` — each of those
+/// cases panics with the specific reason instead.
 pub fn vsrx_target() -> Option<VsrxTarget> {
-    let host = std::env::var("RUSTNETCONF_TEST_VSRX_HOST").ok()?;
+    let Ok(host) = std::env::var("RUSTNETCONF_TEST_VSRX_HOST") else {
+        return skip_or_fail("RUSTNETCONF_TEST_VSRX_HOST is unset");
+    };
+    if host.trim().is_empty() {
+        return skip_or_fail("RUSTNETCONF_TEST_VSRX_HOST is set but empty");
+    }
     let username =
         std::env::var("RUSTNETCONF_TEST_VSRX_USER").unwrap_or_else(|_| "netconf".to_string());
-    let key_path = std::env::var("RUSTNETCONF_TEST_VSRX_KEY").unwrap_or_else(|_| {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/home/mharman".to_string());
-        format!("{home}/.ssh/id_ed25519")
-    });
+    let key_path = expand_tilde(
+        &std::env::var("RUSTNETCONF_TEST_VSRX_KEY").unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/home/mharman".to_string());
+            format!("{home}/.ssh/id_ed25519")
+        }),
+    );
+
+    // Checked here rather than at connect time: an unusable key surfaces from
+    // russh as `authentication failed`, which reads as a device or account
+    // fault. Naming the file is the difference between a five-minute fix and
+    // an afternoon on the wrong device.
+    //
+    // Opened rather than stat'd. `Path::is_file` answers a question about the
+    // directory entry, not about access — a key at mode 000 is `is_file() ==
+    // true` and unreadable, which is precisely the case this check exists for.
+    if let Err(e) = std::fs::File::open(&key_path) {
+        return skip_or_fail(&format!("SSH key {key_path} cannot be opened: {e}"));
+    }
+
     Some(VsrxTarget {
         host,
         username,
@@ -69,6 +147,9 @@ pub fn vsrx_target() -> Option<VsrxTarget> {
 ///     None => return,
 /// };
 /// ```
+///
+/// Returns `None` only when the run is not required to be device coverage —
+/// see [`vsrx_target`].
 pub fn skip_unless_vsrx_configured() -> Option<VsrxTarget> {
     vsrx_target()
 }


### PR DESCRIPTION
Patch release. `rustnetconf` 0.16.0 → 0.16.1, `rustnetconf-cli` 0.3.7 → 0.3.8. One commit since v0.16.0 (#96), all of it fixes, no API change.

`rustnetconf-yang` deliberately does not move: no source change, and its `rustnetconf = "0.16"` requirement already resolves to 0.16.1 for a library consumer. 0.15 and 0.16 moved all three crates because the *requirement* changed incompatibly; a patch does not do that.

## Contents

- **The CLI entity bug** — the one that actually reached users. `rustnetconf-cli`'s copy of `resolve_entity_ref` still called `resolve_predefined_entity`, the quick-xml `escape-html` feature-unification hazard the library copy was already fixed for.
- **Validator rule 16** — reserved `xmlns` prefix on an element.
- **Validator rule 17** — references in attribute values.

## The CLI dependency floor is raised to `0.16.1`

Found by the review gate and confirmed against `target/package/`. Unlike yang, the CLI is a **binary**: `cargo publish` ships its lockfile and `cargo install --locked` honours it. `^0.16` permits 0.16.0, and the lock packaged before this change did select it. Since `rustnetconf-cli/src/desired.rs` calls `rustnetconf::rpc::validate_xml_fragment` directly, that would have shipped the new CLI against the pre-fix validator.

Consequence worth knowing: `cargo publish -p rustnetconf-cli --dry-run` cannot resolve until the library is on the index, so the two-step publish order is now enforced rather than merely documented.

## The live-device suite fails loudly now

`tests/integration_vsrx.rs` early-returns when `RUSTNETCONF_TEST_VSRX_HOST` is unset, and libtest has no *skipped* outcome for a test that returns normally — so a run that never contacted a device printed the same `23 passed` as one that did. A green line was therefore useless as evidence for anything gated on the device having been reached.

`RUSTNETCONF_TEST_VSRX_REQUIRED=1` turns every skip into a failure naming its reason. Two reasons are checked up front rather than at connect time: no host, and a key file that cannot be opened. An unusable key surfaces from russh as `authentication failed`, which reads as a device or account fault — the same misleading shape as the `srxoutpost` username bug already documented in that file's header.

The key check **opens** the file rather than stat'ing it. `Path::is_file` answers a question about the directory entry, not about access: a key at mode 000 is `is_file() == true` and unreadable, confirmed with a probe binary. That was the second review finding.

`~/` in `RUSTNETCONF_TEST_VSRX_KEY` is expanded too — Rust does not do it, and not every shell does it in the position `VAR=~/path cmd`, so the documented invocation could hand russh a literal `~`.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- 654 tests pass
- `cargo audit` clean
- `cargo publish --dry-run` for `rustnetconf`
- `cargo build --locked` in `fuzz/` — its independent lockfile was regenerated, the defect that broke `--locked` at the 0.16.0 release
- Both fail-loud paths exercised directly, not just compiled
- `codex exec review --commit f53671d`: two findings, both confirmed against the code and fixed; re-review of the amended commit returned no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)