### PR TITLE
chore(release): 0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "aws-lc-rs",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-cli"
-version = "0.3.8"
+version = "0.3.9"
 dependencies = [
  "clap",
  "colored",
@@ -1883,7 +1883,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf-yang"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "quick-xml",
  "rustnetconf",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ unsafe_code = "forbid"
 
 [package]
 name = "rustnetconf"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "An async-first NETCONF 1.0/1.1 client library for Rust"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ Async NETCONF client library, YANG code generation, vendor profiles, connection 
 
 Built on [tokio](https://tokio.rs), [russh](https://crates.io/crates/russh), and [rustls](https://crates.io/crates/rustls) — pure Rust, no OpenSSL, no libssh2.
 
-> **Latest release — [v0.16.1](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.16.1)** (two XML validator escapes closed, and an entity-resolution bug in `netconf diff`; no API change).
-> On crates.io: `rustnetconf` 0.16.1 · `rustnetconf-cli` 0.3.8 · `rustnetconf-yang` 0.2.0.
-> See [What's New in v0.16.1](#whats-new-in-v0161) below.
+> **Latest release — [v0.16.2](https://github.com/fastrevmd-lab/rustnetconf/releases/tag/v0.16.2)** (quick-xml 0.42; no API change to `rustnetconf`, but a breaking one to `rustnetconf-yang`, which re-exports quick-xml's `Writer`).
+> On crates.io: `rustnetconf` 0.16.2 · `rustnetconf-cli` 0.3.9 · `rustnetconf-yang` 0.3.0.
+> See [What's New in v0.16.2](#whats-new-in-v0162) below.
 
 ## Workspace
 
@@ -47,6 +47,44 @@ SSH is present as a *transport for NETCONF*, not as a general-purpose capability
 - Remote shell or command execution
 
 Consumers that need those should use a dedicated SSH crate alongside this one. A native SCP1 client was briefly added and then reverted before it was ever released (#52, reverted by #53) for exactly this reason; issues #47 and #51 were closed as not planned on the same grounds. The round trip is visible in `git log` between v0.13.2 and the next release — it was a deliberate reversal, not an accident.
+
+## What's New in v0.16.2
+
+The quick-xml 0.42 migration (#70). 0.42 decodes at the reader, so events hand back `str` rather than `[u8]`, which removes most of the decode / `from_utf8_lossy` layer this crate carried. The change is mostly deletion: 239 insertions against 277 deletions.
+
+**`rustnetconf` 0.16.2 is a patch — quick-xml is fully internal there.** No public signature, error variant, or trait exposes it, verified by reading every public item.
+
+**`rustnetconf-yang` 0.3.0 is a breaking change, and this is the one to read.** Unlike the library crate, yang puts quick-xml in its *public* API:
+
+```rust
+pub use quick_xml::Writer;
+
+pub trait WriteXmlFields {
+    fn write_xml_fields(&self, writer: &mut Writer<Cursor<Vec<u8>>>) -> Result<(), XmlError>;
+}
+```
+
+`new_writer`, `finish_writer`, `write_text_element`, `write_start_with_ns`, `write_end` and `write_element_with_fields` all take or return that type. A `Writer` from quick-xml 0.41 and one from 0.42 are distinct types from distinct crate versions, so any code that implements `WriteXmlFields` by hand, or that holds a `Writer` it obtained elsewhere, needs to move to 0.42 at the same time. Code that only uses generated types and calls `to_xml()` is unaffected.
+
+`rustnetconf-cli` 0.3.9 is a patch: its `diff/tree.rs` moved to the 0.42 event API, and its entity resolution still uses `resolve_xml_entity` — the `escape-html` feature-unification hazard fixed in 0.16.1 is unchanged by the version bump.
+
+Both `rustnetconf-cli` and `rustnetconf-yang` now require `rustnetconf = "0.16.2"` rather than a looser range. quick-xml 0.41 and 0.42 are semver-incompatible, so a graph that paired the new CLI or yang with `rustnetconf` 0.16.1 would build **both** copies of quick-xml.
+
+### What the migration decided, where a choice existed
+
+- **Kept as byte scans** — the attribute-separator check and the PI-target split. Both use `is_ascii_whitespace`, never `char::is_whitespace`, which is Unicode-aware and would split on characters XML does not treat as whitespace.
+- **Moved to `str`** — splitting on `:` in `expanded_name`/`resolve_ns`, where no char boundary can fall inside a single-byte codepoint, and the whitespace-outside-root test, written as the four XML whitespace characters explicitly.
+- **`OpenElement` moved `Vec<u8>` → `String`** — the last byte holdout. Its helpers had already moved, so every comparison was crossing a boundary for nothing.
+- **Five UTF-8 branches deleted, not retyped** — the reader guarantees UTF-8 now, and three of the five silently skipped or discarded input on failure.
+
+### Verification
+
+A parser that compiles, passes, and then mis-parses is the failure mode this change is exposed to, so the unit suite alone was not the argument.
+
+- 654 tests, clippy and fmt clean, `cargo build --locked` in `fuzz/`
+- `reply_parser_is_total` — 6.06M fuzz executions on the migrated parser, no crashes
+- `fragment_embeds_cleanly` — 8.1M on the pre-migration parser, 5.5M on the migrated one
+- **Live vSRX (Junos 24.4R1.9), against a baseline**: 23 + 9 tests passed on both, under `RUSTNETCONF_TEST_VSRX_REQUIRED=1` so a run that never reached the device would have failed rather than reported a pass it did not earn
 
 ## What's New in v0.16.1
 

--- a/fuzz/Cargo.lock
+++ b/fuzz/Cargo.lock
@@ -1375,7 +1375,7 @@ dependencies = [
 
 [[package]]
 name = "rustnetconf"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "async-trait",
  "aws-lc-rs",

--- a/rustnetconf-cli/Cargo.toml
+++ b/rustnetconf-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-cli"
-version = "0.3.8"
+version = "0.3.9"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "Terraform-like CLI for declarative NETCONF network config management"
@@ -13,7 +13,7 @@ name = "netconf"
 path = "src/main.rs"
 
 [dependencies]
-rustnetconf = { version = "0.16.1", path = ".." }
+rustnetconf = { version = "0.16.2", path = ".." }
 clap = { version = "4", features = ["derive"] }
 colored = "3"
 toml = "0.8"

--- a/rustnetconf-yang/Cargo.toml
+++ b/rustnetconf-yang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustnetconf-yang"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["fastrevmd-lab"]
 description = "YANG model code generation for rustnetconf — compile-time config validation"
@@ -18,7 +18,7 @@ generated = []
 bundled = ["yang2/bundled"]
 
 [dependencies]
-rustnetconf = { version = "0.16", path = ".." }
+rustnetconf = { version = "0.16.2", path = ".." }
 serde = { version = "1", features = ["derive"] }
 quick-xml = "0.42"
 thiserror = "2"

--- a/rustnetconf-yang/src/lib.rs
+++ b/rustnetconf-yang/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rustnetconf-yang = { version = "0.2", features = ["generated"] }
+//! rustnetconf-yang = { version = "0.3", features = ["generated"] }
 //! ```
 //!
 //! Then use a bundled model:


### PR DESCRIPTION
`rustnetconf` 0.16.1 → 0.16.2, `rustnetconf-cli` 0.3.8 → 0.3.9, `rustnetconf-yang` 0.2.0 → **0.3.0**. One commit since v0.16.1: the quick-xml 0.42 migration (#70).

## `rustnetconf-yang` takes a breaking bump — read this part

The migration PR verified that quick-xml is **fully internal to `rustnetconf`** — no public signature, error variant, or trait exposes it. That is true, and it is why the library crate is honestly a patch. It is **not** true of `rustnetconf-yang`, which that check did not cover:

```rust
pub use quick_xml::Writer;

pub trait WriteXmlFields {
    fn write_xml_fields(&self, writer: &mut Writer<Cursor<Vec<u8>>>) -> Result<(), XmlError>;
}
```

`new_writer`, `finish_writer`, `write_text_element`, `write_start_with_ns`, `write_end` and `write_element_with_fields` all take or return that type. A `Writer` from quick-xml 0.41 and one from 0.42 are distinct types from distinct crate versions, so hand-written `WriteXmlFields` impls, and any `Writer` obtained elsewhere and passed in, stop compiling.

Users who only touch generated types and call `to_xml()` are unaffected. For a 0.x crate the minor position is the breaking position, hence **0.3.0**, not 0.2.1.

## Dependency floors

Both `rustnetconf-cli` and `rustnetconf-yang` now require `rustnetconf = "0.16.2"` rather than a looser range. quick-xml 0.41 and 0.42 are semver-incompatible, so a graph pairing the new CLI or yang with `rustnetconf` 0.16.1 would build **both** copies of quick-xml. For the CLI this is the same lesson as 0.16.1: it is a binary, so `cargo publish` ships its lockfile and `cargo install --locked` honours it.

## A repeat defect, caught again

`rustnetconf-yang`'s crate-level quick start told users to depend on `version = "0.2"`, which Cargo treats as incompatible with 0.3 — copying the published docs would install the superseded release. This is the identical defect caught during the 0.16.0 release, when it still said `0.1`. Updated to `0.3`.

## Verification

- `cargo fmt --all -- --check` clean
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- 654 tests pass
- `cargo audit` clean over 302 dependencies
- `cargo publish --dry-run` for `rustnetconf`
- `cargo build --locked` in `fuzz/` — its independent lockfile regenerated
- `codex exec review --commit 7f99d40` — no findings

The migration's own device evidence is on #70: live vSRX 24.4R1.9, 23 + 9 tests against a baseline, every run under `RUSTNETCONF_TEST_VSRX_REQUIRED=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)